### PR TITLE
NormalizationHint conforms to IndexableVector + fix test infra crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to VectorCore will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-11
+
+### Added
+
+#### `NormalizationHint<V>` conforms to `IndexableVector`
+- `NormalizationHint<V: IndexableVector>` now conforms to `VectorProtocol`, `IndexableVector`, `Codable`, `Hashable`, and `Collection`
+- Enables passing hinted vectors directly to `<V: IndexableVector>` typed insert APIs in VectorAccelerate 0.4.3+ and VectorIndex 0.1.4+
+- Downstream cosine distance fast paths (dot product when `isNormalized == true`) are now reachable from consumer code
+- All `VectorProtocol` operations forward transparently to the wrapped vector
+- Mutation through any `VectorProtocol` API automatically invalidates hints (`isNormalized` resets to `false`, `cachedMagnitude` clears to `nil`)
+- Codable round-trip preserves vector data and hint metadata via keyed container
+- `Equatable`/`Hashable` include hint state: same vector with different hints are distinct values
+- Double-wrapping prevention: `hint.withNormalizationHint()` returns `self` instead of nesting
+
+### Tests
+- 13 new tests for `NormalizationHint` conformance: type conformance, storage forwarding, mutation invalidation, required initializers, equality, hashing, Codable round-trip (Vector512Optimized + DynamicVector), insert simulation, arithmetic, double-wrapping prevention, collection iteration
+
 ## [0.2.0] - 2026-03-28
 
 ### Added

--- a/Sources/VectorCore/Integration/IndexableVector.swift
+++ b/Sources/VectorCore/Integration/IndexableVector.swift
@@ -87,44 +87,210 @@ extension Vector: IndexableVector where D: StaticDimension {}
 
 // MARK: - Normalized Vector Hint
 
-/// Struct to track normalization status alongside a vector.
+/// Wrapper that carries normalization metadata alongside a vector.
 ///
-/// Use this when you want to track whether vectors have been pre-normalized
-/// without modifying the vector type itself.
+/// `NormalizationHint` conforms to `IndexableVector`, so it can be passed
+/// directly to any `<V: IndexableVector>` typed API. Downstream packages
+/// (e.g. VectorIndex) read `isNormalized` and `cachedMagnitude` to skip
+/// redundant normalization during cosine distance computation.
+///
+/// Mutation through any `VectorProtocol` API automatically invalidates
+/// the hint (resets `isNormalized` to `false` and clears `cachedMagnitude`).
 ///
 /// ```swift
-/// let hint = NormalizationHint(vector: myVector, isNormalized: true)
-/// if hint.isNormalized {
-///     // Use dot product for cosine similarity
-/// }
+/// let normalized = myVector.normalizedUnchecked()
+/// let hint = NormalizationHint(vector: normalized, isNormalized: true)
+/// index.insert(id: "doc1", vector: hint)  // fast-path cosine distance
 /// ```
-public struct NormalizationHint<V: IndexableVector>: Sendable {
-    /// The vector
-    public let vector: V
+public struct NormalizationHint<V: IndexableVector> {
+    /// The wrapped vector
+    public var vector: V
 
-    /// Whether the vector is pre-normalized
-    public let isNormalized: Bool
+    /// Whether the vector is pre-normalized (magnitude ≈ 1).
+    ///
+    /// Automatically reset to `false` on any mutation.
+    public private(set) var isNormalized: Bool
 
-    /// Cached magnitude (1.0 if normalized)
+    /// Internal cache for magnitude value
+    private var _cachedMagnitude: Float?
+
+    /// Magnitude of the vector, using cached value when available.
+    ///
+    /// Returns `1.0` when `isNormalized` is true, the cached value if
+    /// available, or computes from the underlying vector.
     public var magnitude: Float {
-        isNormalized ? 1.0 : vector.magnitude
+        if isNormalized { return 1.0 }
+        if let cached = _cachedMagnitude { return cached }
+        return vector.magnitude
     }
 
-    /// Initialize with explicit normalization status
+    /// Reset hint metadata after mutation.
+    private mutating func invalidateHints() {
+        isNormalized = false
+        _cachedMagnitude = nil
+    }
+
+    // MARK: - Initializers
+
+    /// Initialize with explicit normalization status.
     public init(vector: V, isNormalized: Bool) {
         self.vector = vector
         self.isNormalized = isNormalized
+        self._cachedMagnitude = isNormalized ? 1.0 : nil
     }
 
-    /// Initialize with auto-detection of normalization
+    /// Initialize with auto-detection of normalization.
+    ///
+    /// Computes the vector's magnitude and caches it. If the magnitude
+    /// is within 0.001 of 1.0, marks the vector as normalized.
     public init(vector: V) {
         self.vector = vector
-        self.isNormalized = abs(vector.magnitude - 1.0) < 0.001
+        let mag = vector.magnitude
+        self.isNormalized = abs(mag - 1.0) < 0.001
+        self._cachedMagnitude = mag
     }
 
-    /// Create from a normalized vector
+    /// Create from a vector known to be normalized.
     public static func normalized(_ vector: V) -> NormalizationHint<V> {
         NormalizationHint(vector: vector, isNormalized: true)
+    }
+}
+
+// MARK: - VectorProtocol Conformance
+
+extension NormalizationHint: VectorProtocol {
+    public typealias Scalar = Float
+    public typealias Storage = V.Storage
+
+    public var storage: Storage {
+        @inlinable get { vector.storage }
+        set { vector.storage = newValue; invalidateHints() }
+    }
+
+    @inlinable
+    public var scalarCount: Int { vector.scalarCount }
+
+    public init() {
+        self.vector = V()
+        self.isNormalized = false
+        self._cachedMagnitude = nil
+    }
+
+    public init(_ array: [Scalar]) throws {
+        self.vector = try V(array)
+        self.isNormalized = false
+        self._cachedMagnitude = nil
+    }
+
+    public init(repeating value: Scalar) {
+        self.vector = V(repeating: value)
+        self.isNormalized = false
+        self._cachedMagnitude = nil
+    }
+
+    @inlinable
+    public func toArray() -> [Scalar] {
+        vector.toArray()
+    }
+
+    @inlinable
+    public func withUnsafeBufferPointer<R>(
+        _ body: (UnsafeBufferPointer<Scalar>) throws -> R
+    ) rethrows -> R {
+        try vector.withUnsafeBufferPointer(body)
+    }
+
+    public mutating func withUnsafeMutableBufferPointer<R>(
+        _ body: (UnsafeMutableBufferPointer<Scalar>) throws -> R
+    ) rethrows -> R {
+        let result = try vector.withUnsafeMutableBufferPointer(body)
+        invalidateHints()
+        return result
+    }
+
+    @inlinable
+    public var isFinite: Bool { vector.isFinite }
+
+    @inlinable
+    public var isZero: Bool { vector.isZero }
+}
+
+// MARK: - Collection Conformance
+
+extension NormalizationHint {
+    @inlinable
+    public subscript(index: Int) -> Scalar {
+        precondition(index >= 0 && index < scalarCount, "Index \(index) out of bounds")
+        return vector[index]
+    }
+}
+
+// MARK: - Equatable & Hashable
+
+extension NormalizationHint: Equatable {
+    public static func == (lhs: NormalizationHint, rhs: NormalizationHint) -> Bool {
+        lhs.vector == rhs.vector && lhs.isNormalized == rhs.isNormalized
+    }
+}
+
+extension NormalizationHint: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        vector.hash(into: &hasher)
+        hasher.combine(isNormalized)
+    }
+}
+
+// MARK: - Codable
+
+extension NormalizationHint: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case vector
+        case isNormalized
+        case cachedMagnitude
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.vector = try container.decode(V.self, forKey: .vector)
+        self.isNormalized = try container.decode(Bool.self, forKey: .isNormalized)
+        self._cachedMagnitude = try container.decodeIfPresent(Float.self, forKey: .cachedMagnitude)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(vector, forKey: .vector)
+        try container.encode(isNormalized, forKey: .isNormalized)
+        try container.encodeIfPresent(_cachedMagnitude, forKey: .cachedMagnitude)
+    }
+}
+
+// MARK: - IndexableVector Conformance
+
+extension NormalizationHint: IndexableVector {
+    /// Cached magnitude: returns 1.0 if normalized, stored cache otherwise.
+    public var cachedMagnitude: Float? {
+        if isNormalized { return 1.0 }
+        return _cachedMagnitude
+    }
+}
+
+// MARK: - Double-Wrapping Prevention
+
+extension NormalizationHint {
+    /// Returns self instead of wrapping in another NormalizationHint layer.
+    public func withNormalizationHint() -> NormalizationHint<V> {
+        self
+    }
+
+    /// Returns a re-hinted copy with normalized status.
+    public func normalizedWithHint() -> NormalizationHint<V>? {
+        guard let norm = try? vector.normalized().get() else { return nil }
+        return NormalizationHint(vector: norm, isNormalized: true)
+    }
+
+    /// Returns a re-hinted copy with normalized status (unchecked).
+    public func normalizedUncheckedWithHint() -> NormalizationHint<V> {
+        NormalizationHint(vector: vector.normalizedUnchecked(), isNormalized: true)
     }
 }
 

--- a/Sources/VectorCore/Operations/Kernels/MixedPrecisionKernels.swift
+++ b/Sources/VectorCore/Operations/Kernels/MixedPrecisionKernels.swift
@@ -3643,23 +3643,8 @@ internal struct MixedPrecisionBenchmark {
         warmupIterations: Int = 100
     ) -> (fp32: BenchmarkResult, fp16: BenchmarkResult, speedup: Double) {
         // Create random test vectors
-        var vec1 = Vector512Optimized()
-        var vec2 = Vector512Optimized()
-
-        for _ in 0..<128 {
-            vec1.storage.append(SIMD4<Float>(
-                Float.random(in: -1...1),
-                Float.random(in: -1...1),
-                Float.random(in: -1...1),
-                Float.random(in: -1...1)
-            ))
-            vec2.storage.append(SIMD4<Float>(
-                Float.random(in: -1...1),
-                Float.random(in: -1...1),
-                Float.random(in: -1...1),
-                Float.random(in: -1...1)
-            ))
-        }
+        let vec1 = try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
+        let vec2 = try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
 
         let vec1_fp16 = MixedPrecisionKernels.Vector512FP16(from: vec1)
         let vec2_fp16 = MixedPrecisionKernels.Vector512FP16(from: vec2)
@@ -3703,23 +3688,8 @@ internal struct MixedPrecisionBenchmark {
         var fp16Results: [Float] = []
 
         for _ in 0..<testVectors {
-            var vec1 = Vector512Optimized()
-            var vec2 = Vector512Optimized()
-
-            for _ in 0..<128 {
-                vec1.storage.append(SIMD4<Float>(
-                    Float.random(in: -1...1),
-                    Float.random(in: -1...1),
-                    Float.random(in: -1...1),
-                    Float.random(in: -1...1)
-                ))
-                vec2.storage.append(SIMD4<Float>(
-                    Float.random(in: -1...1),
-                    Float.random(in: -1...1),
-                    Float.random(in: -1...1),
-                    Float.random(in: -1...1)
-                ))
-            }
+            let vec1 = try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
+            let vec2 = try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
 
             let vec1_fp16 = MixedPrecisionKernels.Vector512FP16(from: vec1)
             let vec2_fp16 = MixedPrecisionKernels.Vector512FP16(from: vec2)
@@ -3758,29 +3728,9 @@ internal struct MixedPrecisionBenchmark {
         iterations: Int = 100
     ) -> (mixed: BenchmarkResult, fp16: BenchmarkResult) {
         // Create test data
-        var query = Vector512Optimized()
-        var candidates: [Vector512Optimized] = []
-
-        for _ in 0..<128 {
-            query.storage.append(SIMD4<Float>(
-                Float.random(in: -1...1),
-                Float.random(in: -1...1),
-                Float.random(in: -1...1),
-                Float.random(in: -1...1)
-            ))
-        }
-
-        for _ in 0..<candidateCount {
-            var vec = Vector512Optimized()
-            for _ in 0..<128 {
-                vec.storage.append(SIMD4<Float>(
-                    Float.random(in: -1...1),
-                    Float.random(in: -1...1),
-                    Float.random(in: -1...1),
-                    Float.random(in: -1...1)
-                ))
-            }
-            candidates.append(vec)
+        let query = try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
+        let candidates: [Vector512Optimized] = (0..<candidateCount).map { _ in
+            try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
         }
 
         let candidatesFP16 = candidates.map { MixedPrecisionKernels.Vector512FP16(from: $0) }

--- a/Sources/VectorCore/Version.swift
+++ b/Sources/VectorCore/Version.swift
@@ -28,7 +28,7 @@ public struct VectorCoreVersion {
     /// Current version string of VectorCore.
     ///
     /// This matches the version in Package.swift.
-    public static let version = "0.2.0"
+    public static let version = "0.3.0"
 
     /// Major version number.
     ///
@@ -38,7 +38,7 @@ public struct VectorCoreVersion {
     /// Minor version number.
     ///
     /// Incremented when adding functionality in a backwards-compatible manner.
-    public static let minor = 2
+    public static let minor = 3
 
     /// Patch version number.
     ///

--- a/Tests/ComprehensiveTests/BatchKernels_SoATests.swift
+++ b/Tests/ComprehensiveTests/BatchKernels_SoATests.swift
@@ -526,8 +526,12 @@ struct BatchKernels_SoATests {
             }
 
             // Test lane processing with different query patterns
-            let alternatingStorage = (0..<128).map { i in
-                SIMD4<Float>(Float(i % 2), Float((i + 1) % 2), Float(i % 3), Float((i + 2) % 3))
+            let alternatingStorage: [SIMD4<Float>] = (0..<128).map { (i: Int) -> SIMD4<Float> in
+                let a = Float(i % 2)
+                let b = Float((i + 1) % 2)
+                let c = Float(i % 3)
+                let d = Float((i + 2) % 3)
+                return SIMD4<Float>(a, b, c, d)
             }
             let alternatingArray = alternatingStorage.flatMap { simd4 in [simd4.x, simd4.y, simd4.z, simd4.w] }
             let alternatingQuery = try! Vector512Optimized(alternatingArray)
@@ -1513,13 +1517,12 @@ struct BatchKernels_SoATests {
             }
 
             // Test 2: Subnormal numbers
-            let subnormalStorage = (0..<128).map { i in
-                SIMD4<Float>(
-                    subnormal * Float(i + 1),
-                    subnormal * Float(i + 2),
-                    subnormal * Float(i + 3),
-                    subnormal * Float(i + 4)
-                )
+            let subnormalStorage: [SIMD4<Float>] = (0..<128).map { (i: Int) -> SIMD4<Float> in
+                let a = subnormal * Float(i + 1)
+                let b = subnormal * Float(i + 2)
+                let c = subnormal * Float(i + 3)
+                let d = subnormal * Float(i + 4)
+                return SIMD4<Float>(a, b, c, d)
             }
             let subnormalArray = subnormalStorage.flatMap { simd4 in [simd4.x, simd4.y, simd4.z, simd4.w] }
             let subnormalQuery = try! Vector512Optimized(subnormalArray)
@@ -1528,7 +1531,8 @@ struct BatchKernels_SoATests {
             let subnormalResult = BatchKernels_SoA.batchEuclideanSquared512(query: subnormalQuery, candidates: subnormalCandidates)
 
             #expect(subnormalResult.count == 1)
-            #expect(abs(subnormalResult[0]) < epsilon, "Identical subnormal vectors should have ~zero distance: \(subnormalResult[0])")
+            let subnormalDist = subnormalResult[0]
+            #expect(abs(subnormalDist) < epsilon, "Identical subnormal vectors should have ~zero distance: \(String(describing: subnormalDist))")
 
             // Test 3: Mixed normal and denormalized values
             let mixedStorage = (0..<128).map { i in

--- a/Tests/ComprehensiveTests/ErrorHandlingMocksTests.swift
+++ b/Tests/ComprehensiveTests/ErrorHandlingMocksTests.swift
@@ -261,7 +261,7 @@ struct ErrorHandlingMocksTests {
 
     // MARK: - Error Injection Framework Tests
 
-    @Suite("Error Injection Framework")
+    @Suite("Error Injection Framework", .serialized)
     struct ErrorInjectionTests {
 
         @Test("Deterministic error injection")

--- a/Tests/ComprehensiveTests/IntegrationProtocolsTests.swift
+++ b/Tests/ComprehensiveTests/IntegrationProtocolsTests.swift
@@ -230,6 +230,218 @@ struct IntegrationProtocolsSuite {
         #expect(hint.isNormalized)
     }
 
+    // MARK: - NormalizationHint IndexableVector Conformance Tests
+
+    @Test
+    func testNormalizationHint_ConformsToIndexableVector() {
+        let v = try! Vector512Optimized(Array(repeating: Float(0.5), count: 512))
+        let hint = NormalizationHint(vector: v, isNormalized: true)
+
+        // Must compile: NormalizationHint is an IndexableVector
+        let _: any IndexableVector = hint
+        #expect(hint.isNormalized == true)
+        #expect(hint.cachedMagnitude == 1.0)
+    }
+
+    @Test
+    func testNormalizationHint_StorageForwarding() {
+        let v = try! Vector512Optimized(Array(repeating: Float(1.0), count: 512))
+        let hint = NormalizationHint(vector: v, isNormalized: false)
+
+        #expect(hint.scalarCount == 512)
+        #expect(hint.startIndex == 0)
+        #expect(hint.endIndex == 512)
+
+        let arr = hint.toArray()
+        #expect(arr.count == 512)
+        #expect(arr[0] == 1.0)
+        #expect(arr[511] == 1.0)
+
+        // Read via subscript
+        #expect(hint[0] == 1.0)
+        #expect(hint[255] == 1.0)
+    }
+
+    @Test
+    func testNormalizationHint_MutationInvalidatesHint_StorageSetter() {
+        let normalized = try! Vector512Optimized(
+            Array(repeating: Float(0.5), count: 512)
+        ).normalizedUnchecked()
+        var hint = NormalizationHint(vector: normalized, isNormalized: true)
+
+        #expect(hint.isNormalized == true)
+        #expect(hint.cachedMagnitude == 1.0)
+
+        // Mutate via storage setter
+        let other = try! Vector512Optimized(Array(repeating: Float(2.0), count: 512))
+        hint.storage = other.storage
+        #expect(hint.isNormalized == false)
+        #expect(hint.cachedMagnitude == nil)
+    }
+
+    @Test
+    func testNormalizationHint_MutationInvalidatesHint_MutableBuffer() {
+        let normalized = try! Vector512Optimized(
+            Array(repeating: Float(0.5), count: 512)
+        ).normalizedUnchecked()
+        var hint = NormalizationHint(vector: normalized, isNormalized: true)
+
+        #expect(hint.isNormalized == true)
+
+        hint.withUnsafeMutableBufferPointer { buffer in
+            buffer[0] = 42.0
+        }
+
+        #expect(hint.isNormalized == false)
+        #expect(hint.cachedMagnitude == nil)
+    }
+
+    @Test
+    func testNormalizationHint_RequiredInitializers() throws {
+        // init()
+        let zero = NormalizationHint<Vector512Optimized>()
+        #expect(zero.scalarCount == 512)
+        #expect(zero.isNormalized == false)
+        #expect(zero.isZero == true)
+
+        // init(_ array:)
+        let values = Array(repeating: Float(0.5), count: 512)
+        let fromArray = try NormalizationHint<Vector512Optimized>(values)
+        #expect(fromArray.scalarCount == 512)
+        #expect(fromArray[0] == 0.5)
+        #expect(fromArray.isNormalized == false)
+
+        // init(repeating:)
+        let repeated = NormalizationHint<Vector512Optimized>(repeating: 3.0)
+        #expect(repeated[0] == 3.0)
+        #expect(repeated[511] == 3.0)
+        #expect(repeated.isNormalized == false)
+    }
+
+    @Test
+    func testNormalizationHint_EqualityIncludesHint() {
+        let v = try! Vector512Optimized(Array(repeating: Float(0.5), count: 512))
+        let hint1 = NormalizationHint(vector: v, isNormalized: true)
+        let hint2 = NormalizationHint(vector: v, isNormalized: false)
+        let hint3 = NormalizationHint(vector: v, isNormalized: true)
+
+        #expect(hint1 != hint2)  // Same vector, different hint
+        #expect(hint1 == hint3)  // Same vector, same hint
+    }
+
+    @Test
+    func testNormalizationHint_HashableConsistency() {
+        let v = try! Vector512Optimized(Array(repeating: Float(0.5), count: 512))
+        let hint1 = NormalizationHint(vector: v, isNormalized: true)
+        let hint2 = NormalizationHint(vector: v, isNormalized: true)
+
+        #expect(hint1.hashValue == hint2.hashValue)
+
+        var set = Set<NormalizationHint<Vector512Optimized>>()
+        set.insert(hint1)
+        #expect(set.contains(hint2))
+    }
+
+    @Test
+    func testNormalizationHint_CodableRoundTrip() throws {
+        let v = try! Vector512Optimized(Array(repeating: Float(0.5), count: 512))
+        let original = NormalizationHint(vector: v, isNormalized: true)
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            NormalizationHint<Vector512Optimized>.self, from: data
+        )
+
+        #expect(decoded == original)
+        #expect(decoded.isNormalized == true)
+        #expect(decoded.cachedMagnitude == 1.0)
+        #expect(decoded.toArray() == original.toArray())
+    }
+
+    @Test
+    func testNormalizationHint_CodableRoundTrip_DynamicVector() throws {
+        let v = DynamicVector([3, 4])
+        let original = NormalizationHint(vector: v, isNormalized: false)
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            NormalizationHint<DynamicVector>.self, from: data
+        )
+
+        #expect(decoded.vector.toArray() == [3, 4])
+        #expect(decoded.isNormalized == false)
+    }
+
+    @Test
+    func testNormalizationHint_InsertSimulation() {
+        // Simulates what VectorIndex.insert<V: IndexableVector>(id:vector:) does
+        func simulateInsert<V: IndexableVector>(id: Int, vector: V) -> (
+            skippedNormalization: Bool,
+            usedCachedMagnitude: Bool
+        ) {
+            let skipNorm = vector.isNormalized
+            let usedCache = vector.cachedMagnitude != nil
+            return (skipNorm, usedCache)
+        }
+
+        // Without hint — bare vector always returns defaults
+        let v = try! Vector512Optimized(Array(repeating: Float(0.5), count: 512))
+        let result1 = simulateInsert(id: 0, vector: v)
+        #expect(result1.skippedNormalization == false)
+        #expect(result1.usedCachedMagnitude == false)
+
+        // With hint — fast path activates
+        let normalized = v.normalizedUnchecked()
+        let hint = NormalizationHint(vector: normalized, isNormalized: true)
+        let result2 = simulateInsert(id: 1, vector: hint)
+        #expect(result2.skippedNormalization == true)
+        #expect(result2.usedCachedMagnitude == true)
+    }
+
+    @Test
+    func testNormalizationHint_Arithmetic() throws {
+        let v1 = try NormalizationHint<Vector512Optimized>(
+            Array(repeating: Float(1.0), count: 512)
+        )
+        let v2 = try NormalizationHint<Vector512Optimized>(
+            Array(repeating: Float(2.0), count: 512)
+        )
+
+        // Arithmetic produces results with isNormalized == false
+        let sum = v1 + v2
+        #expect(sum[0] == 3.0)
+        #expect(sum.isNormalized == false)
+
+        let dot = v1.dotProduct(v2)
+        #expect(approxEqual(dot, 1024.0))  // 512 * 1 * 2
+    }
+
+    @Test
+    func testNormalizationHint_NoDoubleWrapping() {
+        let v = DynamicVector([3, 4])
+        let hint = NormalizationHint(vector: v, isNormalized: true)
+        let rewrapped = hint.withNormalizationHint()
+
+        // Should return NormalizationHint<DynamicVector>, not nested
+        #expect(type(of: rewrapped) == type(of: hint))
+        #expect(rewrapped.isNormalized == hint.isNormalized)
+    }
+
+    @Test
+    func testNormalizationHint_CollectionIteration() {
+        let hint = NormalizationHint(
+            vector: DynamicVector([0.5, 0.5, 0.5, 0.5]),
+            isNormalized: false
+        )
+
+        var count = 0
+        for element in hint {
+            #expect(element == 0.5)
+            count += 1
+        }
+        #expect(count == 4)
+    }
+
     // MARK: - SimpleVectorCollection Tests
 
     @Test

--- a/Tests/ComprehensiveTests/MixedPrecisionPerformanceBenchmark.swift
+++ b/Tests/ComprehensiveTests/MixedPrecisionPerformanceBenchmark.swift
@@ -140,7 +140,7 @@ struct MixedPrecisionPerformanceBenchmark {
         let batchSizes = [10, 100, 1000]
 
         print("\n=== Euclidean Batch Throughput (512-dim) ===")
-        print(String(format: "%-10s | %-15s | %-15s | %-10s | %-15s", "Batch Size", "FP32 (M/sec)", "FP16 (M/sec)", "Speedup", "Memory Saved"))
+        print("Batch Size | FP32 (M/sec)    | FP16 (M/sec)    | Speedup    | Memory Saved   ")
         print(String(repeating: "-", count: 80))
 
         for n in batchSizes {
@@ -167,8 +167,8 @@ struct MixedPrecisionPerformanceBenchmark {
             let speedup = fp16Throughput / fp32Throughput
             let memorySaved = n * 1024  // bytes
 
-            print(String(format: "%-10d | %-15.2f | %-15.2f | %-10.2fx | %-15s",
-                n, fp32Throughput, fp16Throughput, speedup, "\(memorySaved / 1024) KB"))
+            let memStr = "\(memorySaved / 1024) KB"
+            print(String(format: "%-10d | %-15.2f | %-15.2f | %-10.2fx | ", n, fp32Throughput, fp16Throughput, speedup) + memStr.padding(toLength: 15, withPad: " ", startingAt: 0))
         }
     }
 
@@ -177,7 +177,7 @@ struct MixedPrecisionPerformanceBenchmark {
     @Test("Dimension scaling: Euclidean performance across dimensions")
     func benchmarkDimensionScaling() throws {
         print("\n=== Dimension Scaling (Euclidean FP16×FP16) ===")
-        print(String(format: "%-10s | %-15s | %-15s | %-10s", "Dimension", "FP32 (ns)", "FP16 (ns)", "Speedup"))
+        print("Dimension  | FP32 (ns)       | FP16 (ns)       | Speedup   ")
         print(String(repeating: "-", count: 60))
 
         // 512-dim
@@ -231,7 +231,7 @@ struct MixedPrecisionPerformanceBenchmark {
     @Test("Accuracy: Relative error measurements across operations")
     func measureAccuracyLoss() throws {
         print("\n=== Accuracy Measurements ===")
-        print(String(format: "%-15s | %-20s | %-20s", "Operation", "FP16×FP16 Error %", "FP32×FP16 Error %"))
+        print("Operation       | FP16×FP16 Error %    | FP32×FP16 Error %   ")
         print(String(repeating: "-", count: 60))
 
         let trials = 100
@@ -269,9 +269,9 @@ struct MixedPrecisionPerformanceBenchmark {
         let avgCosError16x16 = cosineErrors16x16.reduce(0, +) / Float(trials)
         let avgCosError32x16 = cosineErrors32x16.reduce(0, +) / Float(trials)
 
-        print(String(format: "%-15s | %-20.4f | %-20.4f", "Euclidean",
+        print("Euclidean       | " + String(format: "%-20.4f | %-20.4f",
             avgEucError16x16 * 100, avgEucError32x16 * 100))
-        print(String(format: "%-15s | %-20.4f | %-20.4f", "Cosine",
+        print("Cosine          | " + String(format: "%-20.4f | %-20.4f",
             avgCosError16x16 * 100, avgCosError32x16 * 100))
 
         // Validate errors are acceptable
@@ -288,7 +288,7 @@ struct MixedPrecisionPerformanceBenchmark {
         print("\n=== Memory Footprint Analysis ===")
 
         let dimensions = [512, 768, 1536]
-        print(String(format: "%-10s | %-15s | %-15s | %-15s", "Dimension", "FP32 (bytes)", "FP16 (bytes)", "Savings %"))
+        print("Dimension  | FP32 (bytes)    | FP16 (bytes)    | Savings %      ")
         print(String(repeating: "-", count: 60))
 
         for dim in dimensions {
@@ -331,7 +331,7 @@ struct MixedPrecisionPerformanceBenchmark {
     @Test("Validate shouldUseMixedPrecision heuristic")
     func validateHeuristic() throws {
         print("\n=== Heuristic Validation ===")
-        print(String(format: "%-15s | %-10s | %-20s", "Batch Size", "Dimension", "Recommendation"))
+        print("Batch Size      | Dimension  | Recommendation      ")
         print(String(repeating: "-", count: 50))
 
         let testCases: [(Int, Int)] = [
@@ -349,8 +349,8 @@ struct MixedPrecisionPerformanceBenchmark {
                 dimension: dimension
             )
 
-            print(String(format: "%-15d | %-10d | %-20s",
-                batchSize, dimension, shouldUse ? "✅ Use FP16" : "❌ Use FP32"))
+            let rec = shouldUse ? "Use FP16" : "Use FP32"
+            print(String(format: "%-15d | %-10d | ", batchSize, dimension) + rec.padding(toLength: 20, withPad: " ", startingAt: 0))
         }
 
         // Validate heuristic logic


### PR DESCRIPTION
## Summary
- **`NormalizationHint<V>` now conforms to `IndexableVector`**, enabling downstream cosine distance fast paths in VectorAccelerate 0.4.3+ and VectorIndex 0.1.4+. Consumers wrapping pre-normalized vectors in `NormalizationHint` can now pass them directly to `<V: IndexableVector>` typed insert APIs, where `isNormalized == true` triggers dot-product cosine instead of full normalization.
- **Fixes four pre-existing test infrastructure bugs** that prevented the full test suite from running: double-init crash (signal 5), `String(format: "%s")` UB crash (signal 11), ErrorInjection parallelism failures, and type-checker timeouts.

## Changes

### NormalizationHint Conformance (v0.3.0)
- `NormalizationHint<V>` conforms to `VectorProtocol`, `IndexableVector`, `Codable`, `Hashable`, `Collection`
- All operations forward transparently to the wrapped vector
- Mutation through any VectorProtocol API auto-invalidates hints (`isNormalized` → false, `cachedMagnitude` → nil)
- Double-wrapping prevention: `hint.withNormalizationHint()` returns `self`
- 13 new tests covering conformance, round-trip, mutation invalidation, and insert simulation

### Test Infrastructure Fixes
- **MixedPrecisionKernels.swift**: `Vector512Optimized()` + `.storage.append` produced 256 SIMD4 lanes instead of 128 → precondition crash. Fixed 6 instances.
- **MixedPrecisionPerformanceBenchmark.swift**: `String(format: "%s", swiftString)` is UB — `%s` reads the `NSString` bridge pointer as `const char *`. Fixed 8 instances.
- **ErrorHandlingMocksTests.swift**: Added `.serialized` to `ErrorInjectionTests` — shared singleton caused cross-test interference under parallel execution.
- **BatchKernels_SoATests.swift**: Added type annotations to complex closures that exceeded the type-checker's time limit.

## Test plan
- [x] `swift build` — clean compilation
- [x] `swift test --filter IntegrationProtocolsSuite` — 43/43 tests pass (13 new)
- [x] `swift test --filter ErrorHandlingMocks` — 29/29 pass with default parallelism
- [x] `swift test --filter benchmarkEuclideanBatchThroughput` — no crash, passes
- [x] `swift test` — full suite (970 tests, 136 suites) completes with zero process crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)