### PR TITLE
Correct version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to VectorCore will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2026-04-11
+## [0.2.1] - 2026-04-11
 
 ### Added
 

--- a/Sources/VectorCore/Version.swift
+++ b/Sources/VectorCore/Version.swift
@@ -28,7 +28,7 @@ public struct VectorCoreVersion {
     /// Current version string of VectorCore.
     ///
     /// This matches the version in Package.swift.
-    public static let version = "0.3.0"
+    public static let version = "0.2.1"
 
     /// Major version number.
     ///
@@ -38,12 +38,12 @@ public struct VectorCoreVersion {
     /// Minor version number.
     ///
     /// Incremented when adding functionality in a backwards-compatible manner.
-    public static let minor = 3
+    public static let minor = 2
 
     /// Patch version number.
     ///
     /// Incremented when making backwards-compatible bug fixes.
-    public static let patch = 0
+    public static let patch = 1
 
     /// Pre-release version identifier.
     ///


### PR DESCRIPTION
## Summary
- Corrects version from 0.3.0 to 0.2.1 — additive conformance on an existing type is patch-level, not minor

## Test plan
- [x] No code changes, version metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)