### PR TITLE
BE3 loose ends: seed source-side benchmark data + commit audit docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ fastlane/test_output
 *.swp
 *.swo
 *~
+
+# Test result artifacts (xunit / swift-testing outputs from `swift test --xunit-output`)
+*-swift-testing.xml
+test-results*.xml
+test-results*.txt

--- a/Docs/beta-evolution-3/DOCUMENT-1.md
+++ b/Docs/beta-evolution-3/DOCUMENT-1.md
@@ -1,0 +1,38 @@
+Low-Level Swift & SIMD Optimization
+Issue 1.1: Strict Aliasing (TBAA) Violations
+Target Files:
+Sources/VectorCore/Vectors/Vector1536Optimized.swift
+Sources/VectorCore/Vectors/Vector768Optimized.swift
+Sources/VectorCore/Vectors/Vector512Optimized.swift
+Target Methods: toArray(), withUnsafeBufferPointer, withUnsafeMutableBufferPointer
+The Defect: The codebase extracts a base pointer from ContiguousArray<SIMD4<Float>> and permanently rebinds it to Float.self using UnsafeRawPointer(...).bindMemory(to: Float.self, capacity: ...). This permanently changes the memory's dynamic type, violating Type-Based Alias Analysis (TBAA). The optimizer assumes mismatched pointer types do not alias, leading to silent register corruption or trap instructions in Release builds.
+Agent Action:
+Remove all usages of .bindMemory(to:capacity:).
+Replace them with the scoped, safe alternative: .withMemoryRebound(to:capacity: { ... }).
+Example Fix:
+Swift
+// BEFORE
+let floatBuffer = UnsafeRawPointer(buffer.baseAddress!).bindMemory(to: Float.self, capacity: 512)
+return try body(UnsafeBufferPointer(start: floatBuffer, count: 512))
+
+// AFTER
+return try buffer.baseAddress!.withMemoryRebound(to: Float.self, capacity: 512) { floatPtr in
+    try body(UnsafeBufferPointer(start: floatPtr, count: 512))
+}
+Issue 1.2: Cache Thrashing in Structure-of-Arrays (SoA) Traversal
+Target File: Sources/VectorCore/Operations/Kernels/BatchKernels_SoA.swift
+Target Methods: euclid2_blocked, dot_blocked_2way, cosine_fused_blocked_2way, etc.
+The Defect: The nested loops traverse candidates (j) in the outer loop and SIMD lanes (i) in the inner loop. Inside the inner loop, the code accesses: let c0 = soa.lanePointer(i)[j] (which resolves to buffer + i * N). Because i increments in the inner loop, every single memory read jumps by N * 16 bytes. This obliterates spatial locality, causing an L1/L2 cache miss on nearly every instruction.
+Agent Action:
+Implement Loop Tiling (Block-Structured Traversal).
+Chunk the candidates into blocks (e.g., BLOCK_SIZE = 64 or 128).
+Inside the block loop, allocate a temporary stack-local array of accumulators (e.g., var acc = [SIMD4<Float>](repeating: .zero, count: BLOCK_SIZE)).
+Invert the inner loop nesting: The outer loop iterates over lanes (i), and the inner loop iterates over candidates (j within the chunk).
+This ensures soa.lanePointer(i)[j] is accessed sequentially in memory [j, j+1, j+2...], achieving stride-1 memory access. After processing all lanes, flush the accumulators to the out buffer.
+Issue 1.3: Existential Boxing Destroying Compiler Specialization
+Target File: Sources/VectorCore/Operations/Operations.swift
+Target Area: @TaskLocal public static var simdProvider: any ArraySIMDProvider
+The Defect: Storing and accessing math providers as existentials (any ArraySIMDProvider) forces dynamic dispatch via the Protocol Witness Table (PWT). This entirely disables LLVM's ability to inline functions, unroll loops, and auto-vectorize standard array operations inside hot mathematical loops.
+Agent Action:
+Refactor the Operations methods to use generic constraints (e.g., <Provider: ArraySIMDProvider>) instead of existential any variables.
+Alternatively, bypass the existential completely by routing static calls directly to concrete implementations (e.g., SIMDOperations.FloatProvider) inside the hot loops.

--- a/Docs/beta-evolution-3/DOCUMENT-2.md
+++ b/Docs/beta-evolution-3/DOCUMENT-2.md
@@ -1,0 +1,60 @@
+Issue 1.1: Strict Aliasing (TBAA) Violations via Permanent Memory Rebinding
+File Name & Line Context: Vector1536Optimized.swift, Vector768Optimized.swift, Vector512Optimized.swift (inside toArray(), withUnsafeBufferPointer, and withUnsafeMutableBufferPointer).
+Technical Vulnerability / Bottleneck: The code retrieves an UnsafeRawPointer from ContiguousArray<SIMD4<Float>> and permanently rebinds the memory using .bindMemory(to: Float.self, capacity: ...).
+The Hardware/Compiler Mechanic: Swift relies on Type-Based Alias Analysis (TBAA) for aggressive memory optimizations. bindMemory(to:capacity:) permanently changes the dynamic type of the memory location. Because the ContiguousArray still assumes it owns memory bound to SIMD4<Float>.self, altering this binding mid-flight and leaving it that way when the closure returns triggers undefined behavior (UB). The LLVM optimizer will assume pointers of mismatched types do not alias, resulting in silent memory corruption or trap instruction generation in release builds. Temporary punning must use withMemoryRebound(to:capacity:).
+Impact Severity: Critical
+Issue 1.2: Massive Cache Thrashing via Incorrect SoA Loop Traversal
+File Name & Line Context: BatchKernels_SoA.swift (e.g., euclid2_blocked, cosine_prenorm_blocked).
+Technical Vulnerability / Bottleneck: The nested loops traverse candidates (j) in the outer loop and vector lanes (i) in the inner loop. Inside the inner loop, it accesses: let c0 = soa.lanePointer(i)[j].
+The Hardware/Compiler Mechanic: Structure-of-Arrays (SoA) layout is explicitly designed to provide spatial locality across candidates. Because lanePointer(i) resolves to buffer + i * N, iterating i in the inner loop means each subsequent memory read jumps by N * 16 bytes (the total number of candidates). For a batch of 10,000 vectors, every single inner-loop read jumps 160KB, guaranteeing an L1/L2 cache miss every instruction and severely starving the CPU's memory bandwidth. The loops must be tiled: the inner loop must traverse contiguous candidates (j).
+Impact Severity: Critical
+Issue 1.3: Existential Boxing Destroying Compiler Specialization
+File Name & Line Context: Operations.swift (Lines 21-24: @TaskLocal public static var simdProvider: any ArraySIMDProvider) and VectorTypeFactory.swift.
+Technical Vulnerability / Bottleneck: The core architecture stores and passes math providers and vectors as existentials (any Protocol).
+The Hardware/Compiler Mechanic: Returning or storing any Protocol forces the compiler to wrap the instance in an Existential Container. Method invocations (like .dot()) must traverse a Protocol Witness Table (PWT) at runtime. This prevents the LLVM mid-level optimizer from monomorphizing the generics, completely disabling function inlining, unrolling, and auto-vectorization on the hottest execution paths in the library.
+Impact Severity: High Performance Cost
+2. Accelerate Framework Integration
+Issue 2.1: Severe Heap Allocation Churn in Math Providers
+File Name & Line Context: ArraySIMDProvider.swift (e.g., add, subtract, elementWiseMultiply).
+Technical Vulnerability / Bottleneck: Core arithmetic operations allocate a new dynamic array (var result = [Float](repeating: 0, count: a.count)) on every single invocation before executing the SIMD operation.
+The Hardware/Compiler Mechanic: SIMD's primary advantage is executing math at memory-bus speeds. By allocating dynamic heap arrays inside math primitives, the operation triggers global allocator locks (swift_allocObject), memory zero-filling, and ARC traffic. This completely saturates the CPU, turning an O(1) memory operation into massive heap churn and neutralizing Accelerate's throughput.
+Impact Severity: High Performance Cost
+Issue 2.2: Missed vForce Vectorization for Transcendentals
+File Name & Line Context: ArraySIMDProvider.swift (sqrt, log, abs) and VectorMath.swift (softmax).
+Technical Vulnerability / Bottleneck: Transcendental operations are implemented by mapping Foundation math functions over arrays sequentially (e.g., a.map { Foundation.sqrt($0) }).
+The Hardware/Compiler Mechanic: Transcendental functions take dozens of clock cycles per element. Accelerate's vForce library (e.g., vvsqrtf, vvlogf) vectors these operations across AMX/NEON registers. Mapping over standard scalar functions forces a purely serial execution path.
+Impact Severity: High Performance Cost
+3. Metal Compute Pipeline & Bridging Integrity
+Issue 3.1: GPU Architecture Stub & Zero-Copy Alignment Violation
+File Name & Line Context: ComputeDevice.swift and AlignedMemory.swift (optimalAlignment = 64).
+Technical Vulnerability / Bottleneck: The library advertises .gpu routing but lacks .metal kernels and MSL bridging headers. Furthermore, CPU memory alignment is hardcoded to 64 bytes (posix_memalign).
+The Hardware/Compiler Mechanic: For Apple Silicon unified memory to achieve zero-copy GPU execution, CPU data structures must possess strict physical page alignment (16KB or 4KB, depending on OS version) to be mapped securely via makeBuffer(bytesNoCopy:). Passing a 64-byte aligned ContiguousArray pointer to Metal in the future will force the driver to synchronously malloc and memcpy the entire candidate database over the memory bus, destroying batch performance.
+Impact Severity: Informational (Architectural Risk)
+4. Numerical Rigor & Edge Cases
+Issue 4.1: Int16 Arithmetic Overflow in Quantized Euclidean Kernel
+File Name & Line Context: QuantizedKernels.swift (accumulateEuclidDiffSq, Line ~167).
+Technical Vulnerability / Bottleneck: The INT8 kernel squares the difference of two Int8 components by promoting to Int16 and using wrapping arithmetic: Int32(diff.x &* diff.x).
+The Hardware/Compiler Mechanic: The maximum difference between signed 8-bit bounds is 255. Squaring it yields 65025. Because Int16.max is 32767, the value 65025 overflows the Int16 multiplication and wraps in two's complement to -511. This negative scalar is then cast to Int32 and accumulated, massively corrupting distance computations for highly dissimilar quantized vectors (a higher true distance will result in a smaller computed distance).
+Impact Severity: Critical
+Issue 4.2: Infinity Overflow in Cosine Similarity Denominator
+File Name & Line Context: CosineKernels.swift (calculateCosineDistance, Lines 16-20).
+Technical Vulnerability / Bottleneck: The similarity denominator is calculated as let denomSq = sumAA * sumBB followed by let denom = sqrt(denomSq).
+The Hardware/Compiler Mechanic: The maximum finite value for an IEEE-754 32-bit Float is ~3.4×10³⁸. If sumAA and sumBB belong to unnormalized vectors and evaluate to 1.0×10²⁰, their product becomes 1.0×10⁴⁰. This overflows the FP32 register to +Infinity. The subsequent division dot / +Infinity yields 0.0, triggering the clamping logic to return an invalid cosine distance of 1.0. The denominator must be computed as sqrt(sumAA) * sqrt(sumBB).
+Impact Severity: Critical
+Issue 4.3: Memory Leak on Asynchronous Pool Return
+File Name & Line Context: MemoryPool.swift (returnBuffer, Lines 224-228).
+Technical Vulnerability / Bottleneck: The raw buffer pointer is cast to an Int and passed into an async closure with a [weak self] capture. If self is nil, the closure simply returns.
+The Hardware/Compiler Mechanic: If the MemoryPool is deallocated before the GCD async task executes, the rawPointer is dropped and never passed to AlignedMemory.deallocate(). Because the memory was allocated via posix_memalign, it is invisible to ARC and permanently leaks into the OS.
+Impact Severity: Critical
+Issue 4.4: Subnormal Reciprocal Overflow (NaN Poisoning)
+File Name & Line Context: NormalizeKernels.swift (magnitude and magnitudeSquared, Lines 42-43, 103-104).
+Technical Vulnerability / Bottleneck: The "stable" Kahan algorithm calculates an inverse scale: let scale = 1.0 / maxAbs.
+The Hardware/Compiler Mechanic: If a vector consists entirely of subnormal (denormalized) floating-point numbers near zero (e.g., 1e-40), the division 1.0 / 1e-40 overflows the 32-bit Float upper bound, becoming +Infinity. The subsequent vector scaling loop (storage[i] * simdScale) multiplies subnormals by +Infinity, yielding NaN or +Infinity. This silently poisons the entire vector with NaNs during normalization.
+Impact Severity: Critical
+Issue 4.5: Flawed Epsilon Truncation Rejecting Valid Micro-Vectors
+File Name & Line Context: DistanceMetrics.swift (CosineDistance, Line 84).
+Technical Vulnerability / Bottleneck: Zero-vector detection guards the denominator using guard magnitudeProduct > Float.ulpOfOne else { return 1.0 }.
+The Hardware/Compiler Mechanic: Float.ulpOfOne (approx. 1.19e-7) denotes precision granularity around 1.0, not absolute scale limits. If two valid dense micro-vectors share magnitudes of 1e-4, their magnitudeProduct evaluates to 1e-8. Because 1e-8 < 1.19e-7, the function skips computation and falsely reports a distance of 1.0. The epsilon must be gated by Float.leastNormalMagnitude.
+Impact Severity: Critical
+Which of these index numbers would you like me to refactor and deep-dive into first?
+(I recommend starting with 1.1 and 1.2 to patch the strict-aliasing traps and cache thrashing, followed by 4.1, 4.2, and 4.4 to restore IEEE-754 mathematical integrity).

--- a/Docs/beta-evolution-3/DOCUMENT-3.md
+++ b/Docs/beta-evolution-3/DOCUMENT-3.md
@@ -1,0 +1,9 @@
+Metal Compute Pipeline & Bridging Integrity
+Issue 3.1: GPU Zero-Copy Page Alignment Violation
+Target Files: Sources/VectorCore/Storage/AlignedMemory.swift, Sources/VectorCore/Platform/PlatformConfiguration.swift
+Target Variable: optimalAlignment
+The Defect: The framework advertises .gpu routing but hardcodes CPU memory alignment to 64 bytes (a standard CPU cache line). For Apple Silicon's Unified Memory Architecture (UMA) to achieve zero-copy GPU execution (via MTLDevice.makeBuffer(bytesNoCopy:)), CPU allocations must be strictly aligned to the OS memory page size. If they aren't, the GPU driver silently initiates a blocking memcpy across the PCIe bus, destroying batch performance.
+Agent Action:
+Modify PlatformConfiguration.optimalAlignment and AlignedMemory.optimalAlignment.
+Use a dynamic query Int(getpagesize()) for Apple platforms (or hardcode 16384 for Apple Silicon arch(arm64)), which satisfies the bytesNoCopy alignment restrictions.
+Add documentation noting that this page-alignment is strictly required for zero-copy MTLBuffer bridging.

--- a/Docs/beta-evolution-3/DOCUMENT-4.md
+++ b/Docs/beta-evolution-3/DOCUMENT-4.md
@@ -1,0 +1,46 @@
+Numerical Rigor & Edge Cases
+Issue 4.1: Int16 Arithmetic Overflow in Quantized Euclidean
+Target File: Sources/VectorCore/Operations/Kernels/QuantizedKernels.swift
+Target Method: accumulateEuclidDiffSq (Around line 167)
+The Defect: The kernel calculates Int32(diff.x &* diff.x) where diff.x is an Int16. The maximum difference between two Int8 components is 255. Squaring it yields 65025. Because Int16.max is 32767, this operation overflows the 16-bit multiplication before it is cast to Int32, wrapping to -511 in two's complement. This mathematically corrupts distance calculations.
+Agent Action:
+Cast the Int16 components to Int32 before performing the multiplication.
+Correct Logic:
+Swift
+let dx = Int32(diff.x)
+let dy = Int32(diff.y)
+// ...
+acc &+= (dx &* dx) &+ (dy &* dy) // ...
+Issue 4.2: Infinity Overflow in Cosine Similarity Denominator
+Target File: Sources/VectorCore/Operations/Kernels/CosineKernels.swift
+Target Method: calculateCosineDistance(dot:sumAA:sumBB:)
+The Defect: The code evaluates let denomSq = sumAA * sumBB followed by let denom = sqrt(denomSq). If sumAA and sumBB belong to large unnormalized vectors (e.g., 1.0e20), their product becomes 1.0e40. This exceeds the upper bound of an IEEE-754 32-bit Float (~3.4e38), overflowing to +Infinity. The subsequent division results in 0.0.
+Agent Action:
+Compute the square roots independently before multiplication to keep intermediate values safely inside the FP32 domain.
+Correct Logic: let denom = sqrt(sumAA) * sqrt(sumBB)
+Issue 4.3: Memory Leak on Asynchronous Pool Return
+Target File: Sources/VectorCore/Utilities/MemoryPool.swift
+Target Method: returnBuffer (Around line 224)
+The Defect: The method casts a raw pointer to an Int and dispatches it to an async queue with a [weak self] capture. If the pool has been deallocated, guard let self = self else { return } silently returns. Because the pointer was allocated with posix_memalign (which ignores ARC), the memory is permanently leaked into the OS.
+Agent Action:
+In the else block of the guard statement, explicitly free the memory.
+Correct Logic:
+Swift
+let rawPointerToFree = UnsafeMutableRawPointer(bitPattern: pointerAddress)!
+guard let self = self else { 
+    AlignedMemory.deallocate(rawPointerToFree)
+    return 
+}
+Issue 4.4: Subnormal Reciprocal Overflow (NaN Poisoning)
+Target File: Sources/VectorCore/Operations/Kernels/NormalizeKernels.swift
+Target Methods: magnitude, magnitudeSquared, normalizeUnchecked
+The Defect: Kahan's stabilization algorithm calculates an inverse scale: let scale = 1.0 / maxAbs. If the vector consists entirely of subnormal (denormalized) floats near zero (e.g., 1e-40), the division 1.0 / 1e-40 overflows and becomes +Infinity. Multiplying the array elements by +Infinity poisons the entire vector with NaNs.
+Agent Action:
+Clamp maxAbs to a safe minimum threshold before calculating the reciprocal.
+Add Check: let safeMaxAbs = Swift.max(maxAbs, Float.leastNormalMagnitude) before calculating the scale.
+Issue 4.5: Flawed Epsilon Truncation Rejecting Valid Micro-Vectors
+Target Files: Sources/VectorCore/Operations/DistanceMetrics.swift (CosineDistance), Sources/VectorCore/Operations/Kernels/CosineKernels.swift
+Target Area: Zero-vector detection guards (e.g., guard magnitudeProduct > Float.ulpOfOne else { return 1.0 })
+The Defect: Float.ulpOfOne (approx. 1.19e-7) denotes precision steps at 1.0, not the absolute limit of float representation near zero. If two valid dense micro-vectors have magnitudes of 1e-4, their magnitudeProduct is 1e-8. Because 1e-8 < 1.19e-7, valid vectors are wrongly rejected and returned with maximum distance.
+Agent Action:
+Change all absolute magnitude product checks from Float.ulpOfOne (and any hardcoded 1e-9 checks) to Float.leastNormalMagnitude (or a strict absolute domain epsilon like 1e-15) to properly distinguish mathematical zero spaces from valid micro-vector spaces.

--- a/Docs/beta-evolution-3/be3-master.md
+++ b/Docs/beta-evolution-3/be3-master.md
@@ -1,0 +1,17 @@
+Project: VectorCore Refactoring (High-Performance Vector Mathematics)
+Goal: Resolve critical memory semantics, numerical instability, and performance bottlenecks identified during a principal-level architectural audit.
+Global Constraints & Mechanics
+Zero-Regression Mandate: VectorCore is a foundational compute library. Do not alter public API signatures or break downstream consumers.
+Type-Based Alias Analysis (TBAA): Never permanently rebind memory owned by Swift standard library collections (e.g., ContiguousArray).
+IEEE-754 Semantics: Subnormals, Infinities, and NaNs must be explicitly accounted for in all math kernels. Do not ignore mathematical overflows.
+Minimal Invasiveness: Apply surgical fixes to the exact files and lines specified. Do not initiate sweeping rewrites of unrelated components.
+🚨 REQUIRED EXECUTION ORDER
+The agent MUST implement the changes in the following strict chronological sequence. Proceeding out of order risks masking crashes, introducing noisy performance profiling, or causing tests to infinitely hang.
+PHASE 1: Numerical Rigor & Edge Cases (See Document 4)
+Why first? Fixing mathematical overflows, NaN poisoning, and memory leaks ensures the test harness will not randomly trap, crash, or leak memory during subsequent phases. This establishes mathematical ground truth.
+PHASE 2: Low-Level Swift & SIMD Optimization (See Document 1)
+Why second? Resolves Undefined Behavior (UB) caused by strict-aliasing violations and fixes the algorithmic cache-thrashing that is currently starving the CPU memory bus.
+PHASE 3: Accelerate Framework Integration (See Document 2)
+Why third? Once memory is stable and caches are behaving sequentially, removing heap churn and leveraging vForce will unlock raw hardware throughput.
+PHASE 4: Metal Compute Pipeline Prep (See Document 3)
+Why last? Foundational memory alignment adjustments for zero-copy GPU bridging rely on the stability established in Phases 1–3.

--- a/Sources/VectorCore/Operations/Kernels/KernelAutoTuner.swift
+++ b/Sources/VectorCore/Operations/Kernels/KernelAutoTuner.swift
@@ -614,9 +614,14 @@ public actor KernelAutoTuner {
     private func generateTestData(for workload: WorkloadCharacteristics) -> TestData? {
         switch workload.dimension {
         case 512:
-            let query = Vector512Optimized(generator: { _ in Float.random(in: -1.0...1.0) })
+            // Deterministic data: reproducible benchmarks + stable accuracy
+            // measurement (unseeded Float.random previously made the accuracy
+            // tests flaky). next() ∈ [0,1] → [-1,1]. The generator closure is
+            // non-escaping and called in order, so threading one rng is safe.
+            var rng = SeededRNG(seed: 0x5EED_0512)
+            let query = Vector512Optimized(generator: { _ in rng.next() * 2 - 1 })
             let candidates = (0..<workload.batchSize).map { _ in
-                Vector512Optimized(generator: { _ in Float.random(in: -1.0...1.0) })
+                Vector512Optimized(generator: { _ in rng.next() * 2 - 1 })
             }
 
             let queryINT8 = Vector512INT8(from: query, params: nil)
@@ -632,9 +637,10 @@ public actor KernelAutoTuner {
             ))
 
         case 768:
-            let query = Vector768Optimized(generator: { _ in Float.random(in: -1.0...1.0) })
+            var rng = SeededRNG(seed: 0x5EED_0768)
+            let query = Vector768Optimized(generator: { _ in rng.next() * 2 - 1 })
             let candidates = (0..<workload.batchSize).map { _ in
-                Vector768Optimized(generator: { _ in Float.random(in: -1.0...1.0) })
+                Vector768Optimized(generator: { _ in rng.next() * 2 - 1 })
             }
 
             let queryINT8 = Vector768INT8(from: query, params: nil)
@@ -650,9 +656,10 @@ public actor KernelAutoTuner {
             ))
 
         case 1536:
-            let query = Vector1536Optimized(generator: { _ in Float.random(in: -1.0...1.0) })
+            var rng = SeededRNG(seed: 0x5EED_1536)
+            let query = Vector1536Optimized(generator: { _ in rng.next() * 2 - 1 })
             let candidates = (0..<workload.batchSize).map { _ in
-                Vector1536Optimized(generator: { _ in Float.random(in: -1.0...1.0) })
+                Vector1536Optimized(generator: { _ in rng.next() * 2 - 1 })
             }
 
             let queryINT8 = Vector1536INT8(from: query, params: nil)

--- a/Sources/VectorCore/Operations/Kernels/MixedPrecisionAutoTuner.swift
+++ b/Sources/VectorCore/Operations/Kernels/MixedPrecisionAutoTuner.swift
@@ -916,8 +916,13 @@ public actor MixedPrecisionAutoTuner {
 
 // MARK: - Seeded Random Number Generator
 
-/// Simple seeded RNG for reproducible test data generation
-private struct SeededRNG {
+/// Simple seeded RNG for reproducible test data generation.
+///
+/// Shared by the kernel auto-tuners so their synthetic benchmark data is
+/// reproducible — stable timing *and* stable accuracy measurement across runs.
+/// (An unseeded generator in `KernelAutoTuner` made the accuracy-threshold tests
+/// intermittently flaky on unlucky draws.)
+struct SeededRNG {
     private var state: UInt64
 
     init(seed: UInt32) {

--- a/Sources/VectorCore/Operations/Kernels/MixedPrecisionKernels.swift
+++ b/Sources/VectorCore/Operations/Kernels/MixedPrecisionKernels.swift
@@ -3697,9 +3697,10 @@ internal struct MixedPrecisionBenchmark {
         iterations: Int = 1000,
         warmupIterations: Int = 100
     ) -> (fp32: BenchmarkResult, fp16: BenchmarkResult, speedup: Double) {
-        // Create random test vectors
-        let vec1 = try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
-        let vec2 = try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
+        // Deterministic test vectors (seeded) for reproducible benchmarks.
+        var rng = SeededRNG(seed: 0xB1A5_0512)
+        let vec1 = try! Vector512Optimized((0..<512).map { _ in rng.next() * 2 - 1 })
+        let vec2 = try! Vector512Optimized((0..<512).map { _ in rng.next() * 2 - 1 })
 
         let vec1_fp16 = MixedPrecisionKernels.Vector512FP16(from: vec1)
         let vec2_fp16 = MixedPrecisionKernels.Vector512FP16(from: vec2)
@@ -3742,9 +3743,12 @@ internal struct MixedPrecisionBenchmark {
         var fp32Results: [Float] = []
         var fp16Results: [Float] = []
 
+        // Deterministic data so accuracy measurement is reproducible (unseeded
+        // Float.random made maxRelativeError flake on near-orthogonal draws).
+        var rng = SeededRNG(seed: 0xACC0_0512)
         for _ in 0..<testVectors {
-            let vec1 = try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
-            let vec2 = try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
+            let vec1 = try! Vector512Optimized((0..<512).map { _ in rng.next() * 2 - 1 })
+            let vec2 = try! Vector512Optimized((0..<512).map { _ in rng.next() * 2 - 1 })
 
             let vec1_fp16 = MixedPrecisionKernels.Vector512FP16(from: vec1)
             let vec2_fp16 = MixedPrecisionKernels.Vector512FP16(from: vec2)
@@ -3782,10 +3786,11 @@ internal struct MixedPrecisionBenchmark {
         candidateCount: Int = 1000,
         iterations: Int = 100
     ) -> (mixed: BenchmarkResult, fp16: BenchmarkResult) {
-        // Create test data
-        let query = try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
+        // Deterministic test data (seeded) for reproducible benchmarks.
+        var rng = SeededRNG(seed: 0xBA7C_0512)
+        let query = try! Vector512Optimized((0..<512).map { _ in rng.next() * 2 - 1 })
         let candidates: [Vector512Optimized] = (0..<candidateCount).map { _ in
-            try! Vector512Optimized((0..<512).map { _ in Float.random(in: -1...1) })
+            try! Vector512Optimized((0..<512).map { _ in rng.next() * 2 - 1 })
         }
 
         let candidatesFP16 = candidates.map { MixedPrecisionKernels.Vector512FP16(from: $0) }


### PR DESCRIPTION
## BE3 loose ends: seed source-side benchmark data + commit audit docs

Two follow-ups from the BE3 work, independent of the perf PR (#30):

1. **Eliminate the last latent flakiness** — unseeded `Float.random` in *source-side* benchmark/auto-tuner data generators (the BE3 audit seeded the *test*-side RNG, but these source generators were missed).
2. **Commit the BE3 architectural audit docs** so the rationale lives with the repo.

All changes are correctness-gated: full suite **996 / 0**.

---

### 1. Seed `KernelAutoTuner.generateTestData` (`527137a`)

`generateTestData` built its synthetic query/candidate vectors with unseeded `Float.random(in:)`, so every profiling run saw different data. The accuracy-threshold tests (`testAccuracyMixedPrecision > 0.99`, `testAccuracyQuantized > 0.95`) measure FP16/INT8 error against that data; an unlucky near-zero draw spikes relative error past the threshold — an intermittent failure unrelated to any code change.

Threads a fixed-seed `SeededRNG` (promoted from `private` → `internal` so both auto-tuners share one implementation) through the non-escaping generator closures. Verified stable across 6 consecutive `KernelAutoTunerTests` runs.

### 2. Seed `MixedPrecisionBenchmark` data (`de42a16`)

`measureAccuracy512` / `benchmarkDotProduct512` / `benchmarkBatchOperations512` had the same unseeded-`Float.random` pattern. The accuracy test bounds `maxRelativeError < 0.1`, but that metric spikes on near-orthogonal FP16 dot products (denominator → 0); an unlucky draw exceeded it (observed 0.16). Seeding the auto-tuner shifted global-RNG consumption and surfaced this pre-existing latent flake under parallel execution — caught by the full-suite gate.

Threads fixed-seed `SeededRNG` through all three generators. The accuracy test now yields a **stable** `maxRelativeError` of 7.48% (< 10%), mean 0.12% (< 0.5%), rank correlation 0.999999 — **assertions unchanged, zero variance**. The meaningful gates (mean relative error, rank correlation) were always well within spec; only the loose max bound was flaking. No test was loosened.

> The remaining `.random` calls in `Sources` are public random-vector factory APIs (`Vector.random`, `DynamicVector.random`, Fisher-Yates shuffle, etc.) — contractually random, feeding nothing accuracy-gated. Left as-is.

### 3. Commit BE3 audit source documents (`678cf15`)

`DOCUMENT-1..4.md` (the consolidated per-issue audit: file, bottleneck, hardware/compiler mechanic, prescribed fix) and `be3-master.md` (phase mapping). The per-test triage (`failing-tests-triage.md`) was already tracked. Scratch/CI artifacts (test-result XML, consolidate scripts) deliberately excluded.

---

### Verification
- Full suite: **996 tests / 0 failures**.
- `KernelAutoTunerTests` stable 6/6 runs; the previously-flaky `measureAccuracy512` accuracy test now deterministic at a fixed 7.48% max relative error.
- Flakiness eliminated **by construction** — every source-side benchmark generator now draws from a fixed seed, independent of global-RNG ordering under parallel test execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
