### PR TITLE
Release 0.3.0: hold the line, sharpen the seams (GEMM, zero-copy GPU bridge, provider seams)

### DIFF
--- a/Benchmarks/VectorCoreBench/AppMain.swift
+++ b/Benchmarks/VectorCoreBench/AppMain.swift
@@ -425,7 +425,8 @@ struct App {
             DistanceBench.name: DistanceBench.self,
             NormalizationBench.name: NormalizationBench.self,
             BatchBench.name: BatchBench.self,
-            MemoryBench.name: MemoryBench.self
+            MemoryBench.name: MemoryBench.self,
+            MatrixDistanceBench.name: MatrixDistanceBench.self
         ]
 
         // Create progress reporter based on CLI flag

--- a/Benchmarks/VectorCoreBench/Suites/MatrixDistanceBench.swift
+++ b/Benchmarks/VectorCoreBench/Suites/MatrixDistanceBench.swift
@@ -1,0 +1,73 @@
+import Foundation
+import VectorCore
+import VectorCoreBenchmarking
+
+/// GEMM batch-distance throughput (beta-evolution-4, DOCUMENT-2).
+///
+/// Measures `MatrixDistance.euclideanSquaredMatrix` (cblas_sgemm / AMX) across
+/// N × dim to calibrate the pairwise routing crossover (`matrixRoutingMinN`).
+/// Reports ns per candidate-pair (`unitCount = N*N`); compare against the per-pair
+/// ns from the `distance`/`batch` suites to locate the breakeven.
+///
+/// Opt-in: `vectorcore-bench --suites matrix`.
+struct MatrixDistanceBench: BenchmarkSuite {
+    static let name = "matrix"
+
+    static func run(options: CLIOptions, progress: ProgressReporter) async -> [BenchResult] {
+        var results: [BenchResult] = []
+        let candidateNs = [64, 256, 1024]   // straddles the default crossover (256)
+        for dim in options.dims {
+            for n in candidateNs {
+                switch dim {
+                case 512:
+                    results.append(bench((0..<n).map { try! Vector512Optimized(gen(dim, $0)) }, dim: dim, n: n, minTime: options.minTimeSeconds))
+                case 768:
+                    results.append(bench((0..<n).map { try! Vector768Optimized(gen(dim, $0)) }, dim: dim, n: n, minTime: options.minTimeSeconds))
+                case 1536:
+                    results.append(bench((0..<n).map { try! Vector1536Optimized(gen(dim, $0)) }, dim: dim, n: n, minTime: options.minTimeSeconds))
+                default:
+                    fputs("[matrix] unsupported dimension: \(dim)\n", stderr)
+                }
+            }
+        }
+        return results
+    }
+
+    /// Deterministic, non-trivial vector contents.
+    private static func gen(_ dim: Int, _ i: Int) -> [Float] {
+        (0..<dim).map { Float((($0 &+ i) % 17) - 8) }
+    }
+
+    private static func bench<V: UnifiedVectorBuffer>(
+        _ vs: [V], dim: Int, n: Int, minTime: Double
+    ) -> BenchResult {
+        var out = [Float](repeating: 0, count: n * n)
+        func once() {
+            MatrixDistance.euclideanSquaredMatrix(queries: vs, candidates: vs, into: &out)
+        }
+
+        // Warm up (pipeline + first-touch the output pages).
+        once(); once()
+
+        let clock = ContinuousClock()
+        let budget = Duration.seconds(max(0.1, minTime))
+        var elapsed = Duration.zero
+        var iters = 0
+        while elapsed < budget {
+            elapsed += clock.measure { once() }
+            iters += 1
+        }
+
+        // Prevent dead-code elimination of the timed work.
+        if out[0].isNaN { fputs("", stderr) }
+
+        let c = elapsed.components
+        let totalNs = UInt64(c.seconds) &* 1_000_000_000 &+ UInt64(c.attoseconds / 1_000_000_000)
+        return BenchResult(
+            name: "matrix/euclid/dim\(dim)/N\(n)",
+            iterations: iters,
+            totalNanoseconds: totalNs,
+            unitCount: n * n
+        )
+    }
+}

--- a/Benchmarks/VectorCoreBench/Suites/MatrixDistanceBench.swift
+++ b/Benchmarks/VectorCoreBench/Suites/MatrixDistanceBench.swift
@@ -20,11 +20,17 @@ struct MatrixDistanceBench: BenchmarkSuite {
             for n in candidateNs {
                 switch dim {
                 case 512:
-                    results.append(bench((0..<n).map { try! Vector512Optimized(gen(dim, $0)) }, dim: dim, n: n, minTime: options.minTimeSeconds))
+                    results.append(bench(
+                        (0..<n).map { try! Vector512Optimized(gen(dim, $0)) },
+                        dim: dim, n: n, minTime: options.minTimeSeconds))
                 case 768:
-                    results.append(bench((0..<n).map { try! Vector768Optimized(gen(dim, $0)) }, dim: dim, n: n, minTime: options.minTimeSeconds))
+                    results.append(bench(
+                        (0..<n).map { try! Vector768Optimized(gen(dim, $0)) },
+                        dim: dim, n: n, minTime: options.minTimeSeconds))
                 case 1536:
-                    results.append(bench((0..<n).map { try! Vector1536Optimized(gen(dim, $0)) }, dim: dim, n: n, minTime: options.minTimeSeconds))
+                    results.append(bench(
+                        (0..<n).map { try! Vector1536Optimized(gen(dim, $0)) },
+                        dim: dim, n: n, minTime: options.minTimeSeconds))
                 default:
                     fputs("[matrix] unsupported dimension: \(dim)\n", stderr)
                 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,74 @@ All notable changes to VectorCore will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-06-07
+
+Outcome of the "beta-evolution-4" (BE4) review: **hold the line, sharpen the
+seams.** Rather than grow VectorCore into a database/index engine, this release
+hardens the CPU-primitive foundation and the integration seams that downstream
+packages (VectorIndex, VectorAccelerate, EmbedKit) were bypassing. Net new
+surface: one CPU math primitive (GEMM batch distance), a zero-copy GPU-bridge
+buffer contract, a transparent GPU-dispatch provider seam, and deterministic
+Top-K — plus the removal of a misleading no-op parameter.
+
+### Added
+
+- **`MatrixDistance` — CPU GEMM batch distance.** `euclideanSquaredMatrix` and
+  `cosineDistanceMatrix` compute a full query×candidate distance matrix via
+  Accelerate `cblas_sgemm` (which routes to the AMX coprocessor on Apple
+  Silicon), using the identity `‖x−Y‖² = ‖x‖² + ‖Y‖² − 2⟨x,Y⟩`. Each metric has
+  an `into:` (zero-allocation), an allocating, and a `prepared:` overload;
+  `prepare(_:normalized:)` packs a candidate set once (`PreparedCandidates`) for
+  reuse across query batches. Generic over `UnifiedVectorBuffer`. Output is
+  row-major (`out[i*n + j]`); the identity can round slightly negative when
+  `q ≈ c`, so results are clamped (Euclidean at 0, cosine to `[0, 2]`) and agree
+  with the per-pair kernels to within ~1e-3 relative, not bit-for-bit.
+- **Zero-copy GPU-bridge buffer contract.** `UnifiedVectorBuffer` protocol
+  (`elementCount`, `alignment`, `withUnsafeContiguousBytes`) + `PageAlignedBuffer`
+  — a page-aligned, page-length-rounded `[Float]` slab valid for
+  `MTLDevice.makeBuffer(bytesNoCopy:)`. The optimized vector types and
+  `DynamicVector` conform. `PageAlignedBuffer.consumeAllocation()` transfers
+  ownership to a Metal deallocator without a double free.
+- **Frozen SoA memory-layout contract.** `SoALayout` descriptor +
+  `SoA.layoutDescriptor` / `SoALayout.forType(_:count:pageAligned:)` publish the
+  SoA layout — `lanes`, `count`, `laneStrideBytes`, `logicalByteCount`,
+  `allocatedByteCount`, and the `lane*count+candidate` index formula — as a
+  stable contract for downstream GPU kernels. Documented at
+  `Docs/SoA_Layout_Contract.md`.
+- **Opt-in page-aligned `SoA`.** `SoA.build(from:pageAligned:)` /
+  `init(vectors:pageAligned:)` allocate a page-aligned, page-rounded buffer;
+  `pageAlignedBytes` exposes the base + length for zero-copy GPU import,
+  `consumeAllocation()` hands ownership to a Metal deallocator, and
+  `withUnsafeRawBuffer` gives scoped read access. Default stays 16-byte aligned.
+- **`BatchKernelProvider` — transparent GPU dispatch.** A `ComputeProvider`
+  sub-protocol (`batchDistance` / `findNearest` / `findNearestBatch`). When an
+  installed `computeProvider` conforms, `Operations.findNearest` and
+  `findNearestBatch` delegate to it (GPU path), taking precedence over the CPU
+  GEMM routing; otherwise the CPU path is used.
+- **Deterministic Top-K tie-breaking.** `TieBreaker` (`.smallerIndex` (default),
+  `.insertionOrder`, `.smallerValue`) makes `TopKSelection` results reproducible
+  when distances tie.
+- **GEMM routing for batch operations.** `BatchOperations.Configuration` gains
+  `enableMatrixRouting` (default `true`) and `matrixRoutingMinN` (default `256`);
+  `pairwiseDistances` and `Operations.findNearestBatch` route large batches
+  through `MatrixDistance`. Tune via `await BatchOperations.updateConfiguration { … }`.
+- **`PlatformConfiguration.roundUpToPage(_:)`** — the single page-rounding helper
+  shared by `SoA` and `PageAlignedBuffer`.
+
+### Removed
+
+- **The no-op `blockSize:` parameter is removed from `SoA.init(vectors:…)` and
+  `SoAFP16.init(vectors:…)`.** It was ignored (neither type pads the candidate
+  axis) and implied a layout guarantee that does not exist. **Source-breaking**
+  only for call sites that passed `blockSize:` explicitly — it had a default, so
+  `SoA(vectors:)` / `SoAFP16(vectors:)` are unaffected.
+
+### Documentation
+
+- New `Docs/SoA_Layout_Contract.md` (the frozen SoA layout). Refreshed the
+  Package Boundaries, Memory Alignment, Performance, API Overview, and roadmap
+  docs for the 0.3.0 surface.
+
 ## [0.2.2] - 2026-06-06
 
 Outcome of the "beta-evolution-3" (BE3) architectural audit: a sweep for

--- a/Docs/API_Overview_Map.md
+++ b/Docs/API_Overview_Map.md
@@ -13,7 +13,7 @@ VectorCore is a CPU‑first, high‑performance vector math core for Swift. Use 
 - Create vectors (fixed/dynamic/optimized),
 - Compute distances/metrics,
 - Run nearest‑neighbor operations via `Operations` (async) or `BatchOperations` (async bulk),
-- Plug in Accelerate or Swift SIMD under the hood — no GPU code here.
+- Plug in Accelerate or Swift SIMD under the hood — **no GPU kernels here** (0.3.0 adds the GPU *seam*: a zero-copy buffer contract + a `BatchKernelProvider` dispatch hook, implemented by VectorAccelerate).
 
 Everything else (ANN/graphs, GPU kernels, durable stores) lives in sibling packages.
 
@@ -36,7 +36,7 @@ flowchart LR
     Dot, Minkowski, Hamming]
     C4[Providers (Public)
     SIMDProvider, ArraySIMDProvider,
-    ComputeProvider]
+    ComputeProvider, BatchKernelProvider]
     C5[Utilities (Internal)
     Kernels, Buffer Pools,
     Aligned Storage, Heuristics]
@@ -164,9 +164,9 @@ Key points
 flowchart LR
   subgraph Public
     A[Vectors: Vector<D>, DynamicVector,
-       Vector512/768/1536Optimized]
+       Vector384/512/768/1536Optimized]
     B[Operations: findNearest,
-       distanceMatrix,
+       distanceMatrix, MatrixDistance (GEMM),
        normalize, statistics]
     C[BatchOperations: auto-parallel bulk]
     D[DistanceMetrics: Euclidean,
@@ -174,16 +174,20 @@ flowchart LR
        Chebyshev, Dot,
        Minkowski, Hamming]
     E[Providers: SIMDProvider,
-       ArraySIMDProvider,
-       ComputeProvider]
+       ArraySIMDProvider, ComputeProvider,
+       BatchKernelProvider]
+    F[Buffers: UnifiedVectorBuffer,
+       PageAlignedBuffer, SoALayout]
   end
 ```
 
 Quick reference
-- Vectors: fixed‑dim (compile‑time safety), dynamic (runtime), optimized (SIMD4 layout for 512/768/1536).
+- Vectors: fixed‑dim (compile‑time safety), dynamic (runtime), optimized (SIMD4 layout for 384/512/768/1536).
 - Operations: async APIs for NN search, pairwise computations, normalization, and stats.
+- MatrixDistance: CPU GEMM batch-distance matrices (`cblas_sgemm` → AMX on Apple Silicon); `euclideanSquaredMatrix` / `cosineDistanceMatrix` with a `prepare(_:normalized:)` reuse path. Generic over `UnifiedVectorBuffer`.
 - DistanceMetrics: portable metric implementations (zero‑alloc); plug into Operations.
-- Providers: protocol surface to bind Accelerate/Swift SIMD and execution strategy.
+- Providers: protocol surface to bind Accelerate/Swift SIMD and execution strategy; `BatchKernelProvider` lets an installed GPU provider transparently service `findNearest`/`findNearestBatch`.
+- Buffers: `UnifiedVectorBuffer` / `PageAlignedBuffer` (zero-copy GPU bridge) and the frozen `SoALayout` descriptor (see `Docs/SoA_Layout_Contract.md`).
 
 ---
 
@@ -236,14 +240,15 @@ let nn = try await Operations.findNearest(to: q, in: xs, k: 10)
 
 - Parallelization kicks in based on a heuristic of dimension × items vs overhead.
 - BatchOperations auto‑parallelizes for large inputs; Operations uses ComputeProvider heuristics.
-- Optimized vectors (512/768/1536) unlock fused kernels and Top‑K fast paths internally.
+- Large batches route through the CPU GEMM path (`MatrixDistance`) above `matrixRoutingMinN` (default 256; `BatchOperations.Configuration`).
+- Optimized vectors (384/512/768/1536) unlock fused kernels and Top‑K fast paths internally.
 
 ---
 
 ## Public vs Internal (Cheat Sheet)
 
-- Public: `Vectors`, `Operations`, `BatchOperations`, `DistanceMetrics`, `SIMDProvider`/`ArraySIMDProvider`/`ComputeProvider`.
-- Internal: `Kernels`, `Top‑K selection`, `Buffer pools`, `Aligned storage`, `Heuristics`, many low‑level helpers.
+- Public: `Vectors`, `Operations`, `BatchOperations`, `MatrixDistance`, `DistanceMetrics`, `SIMDProvider`/`ArraySIMDProvider`/`ComputeProvider`/`BatchKernelProvider`, `UnifiedVectorBuffer`/`PageAlignedBuffer`, `SoALayout`, `TieBreaker`.
+- Internal: `Kernels`, `Buffer pools`, `Aligned storage`, `Heuristics`, many low‑level helpers. (Top‑K selection is internal, but its `TieBreaker` policy is public.)
 - Out of scope (in sibling packages): ANN/graphs/clustering (VectorIndex), GPU providers/kernels (VectorAccelerate), durable formats (VectorStore).
 
 ---

--- a/Docs/HowTo_NearestNeighbor.md
+++ b/Docs/HowTo_NearestNeighbor.md
@@ -142,6 +142,25 @@ Batch sizes and auto‑parallelization
   - Batch operations: arrays ≥ ~1,000 elements tend to parallelize.
   - Pairwise (O(n²)) operations parallelize at smaller thresholds (≈100) due to quadratic work.
 
+GEMM/AMX auto‑routing (0.3.0)
+- For large batches, `BatchOperations.pairwiseDistances` and `Operations.findNearestBatch` automatically route through a CPU GEMM path (`MatrixDistance` via Accelerate `cblas_sgemm` → AMX on Apple Silicon) once the batch clears the crossover.
+- Controlled by `BatchOperations.Configuration.enableMatrixRouting` (default `true`) and `matrixRoutingMinN` (default `256`). The GEMM path agrees with the per‑pair kernels to ~1e‑3 relative (clamped identity), not bit‑identical.
+- Tune or disable it:
+
+```swift
+await BatchOperations.updateConfiguration { config in
+    config.enableMatrixRouting = false
+}
+```
+
+- Reuse recipe: for a fixed candidate database queried by many query batches, pack the database once and reuse it across calls:
+
+```swift
+// normalized: true for cosine geometry
+let prepared = MatrixDistance.prepare(candidates, normalized: false)
+MatrixDistance.euclideanSquaredMatrix(queries: queries, prepared: prepared, into: &out)
+```
+
 Provider overrides (advanced)
 
 ```swift
@@ -153,6 +172,15 @@ await Operations.$simdProvider.withValue(DefaultArraySIMDProvider()) {
 // Hint parallel CPU execution
 await Operations.$computeProvider.withValue(CPUComputeProvider.parallel) {
     let _ = try await Operations.distanceMatrix(between: [query], and: database)
+}
+```
+
+Scaling up to the GPU (0.3.0)
+- Installing a `BatchKernelProvider` (e.g. VectorAccelerate's Metal provider) transparently moves `Operations.findNearest` / `findNearestBatch` to the GPU. `Operations` downcasts the installed `computeProvider` to `BatchKernelProvider` and delegates, taking precedence over the CPU GEMM routing.
+
+```swift
+await Operations.$computeProvider.withValue(yourGPUProvider) {
+    let _ = try await Operations.findNearestBatch(queries: queries, in: database, k: 10)
 }
 ```
 
@@ -171,6 +199,9 @@ Zero vectors and cosine
 Dot product distances
 - `DotProductDistance` reports “distance = −dot”; distances are negative, so the “closest” item has the most negative (largest magnitude) dot.
 - If you need similarity scores, compute the dot directly or negate the distance returned.
+
+Reproducible ties (0.3.0)
+- Top‑K ties now resolve deterministically via `TieBreaker` in `TopKSelection` (default `.smallerIndex`; also `.insertionOrder`, `.smallerValue`), so equal‑distance results are reproducible run‑to‑run.
 
 Mixed vector types in an array
 - Use a single vector type per array (`[Vector<Dim512>]` or `[Vector512Optimized]`), not mixed, to prevent type/dispatch overhead and ensure kernel fast paths are available.

--- a/Docs/Memory_Alignment.md
+++ b/Docs/Memory_Alignment.md
@@ -66,59 +66,88 @@ Result: Two cache line fetches for one SIMD load (2x memory bandwidth)
 
 ## VectorCore's Alignment Policy
 
-### Default Alignment: 64 Bytes
+### Default Alignment: 64 Bytes (arm64 SIMD) — but not universal
 
-VectorCore uses **64-byte alignment** for all SIMD storage:
+VectorCore has **two distinct alignment constants** for two distinct purposes. Do not
+conflate them:
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `AlignedMemory.optimalAlignment` | **64** (arm64 & x86_64); 16 otherwise | Default alignment for `allocateAligned`; cache-line / SIMD storage |
+| `AlignedMemory.minimumAlignment` | **16** | Floor enforced by a `precondition` (SIMD4<Float>) |
+| `PlatformConfiguration.l1CacheLineSize` | **64** (arm64 & x86_64) | L1 cache line size |
+| `PlatformConfiguration.optimalAlignment` | **128** on Apple Silicon (AMX); 64 on x86_64 | AMX / matrix-extension data alignment |
+| `PlatformConfiguration.pageSize` | `getpagesize()` at runtime (16 KB Apple Silicon, 4 KB x86) | Page alignment for `bytesNoCopy` |
+
+So "64 bytes" is the default for `AlignedMemory.allocateAligned` (good for SIMD storage and
+the L1 cache line), but it is **not** a universal alignment for VectorCore. Apple Silicon's
+AMX (Apple Matrix Extensions) path prefers **128-byte** alignment
+(`PlatformConfiguration.optimalAlignment`), and the zero-copy GPU path needs **page**
+alignment (see [The Page-Aligned Path](#the-page-aligned-path)). Always pick the alignment
+that matches the consumer.
+
+The optimized vector types back their storage with `ContiguousArray<SIMD4<Float>>`:
 
 ```swift
 public struct Vector512Optimized {
-    // storage is 64-byte aligned
+    // SIMD4<Float> element region; 16-byte element alignment.
     public var storage: ContiguousArray<SIMD4<Float>>
 }
 ```
 
-**Why 64 bytes?**
-- Matches cache line size on Apple Silicon and modern Intel
+**Why 64 bytes as the `allocateAligned` default?**
+- Matches the L1 cache line size on Apple Silicon and modern Intel (`l1CacheLineSize == 64`)
 - Satisfies SIMD4 alignment (16 bytes) with margin
 - Prevents cache line splits
-- Future-proof for wider SIMD (AVX-512 requires 64-byte alignment)
+- Covers AVX-512 (which requires 64-byte alignment) on x86_64
 
 ### Allocation Methods
 
-VectorCore provides centralized aligned allocation:
+VectorCore provides centralized aligned allocation in
+`Sources/VectorCore/Storage/AlignedMemory.swift`. These are the **real public signatures**
+(the implementation uses `posix_memalign` and validates the alignment with `precondition`s):
 
 ```swift
-// Sources/VectorCore/Storage/AlignedMemory.swift
-
 public enum AlignedMemory {
-    /// Allocate aligned memory using posix_memalign
-    public static func allocateAligned<T>(
-        _ type: T.Type,
+    /// Platform-specific optimal alignment (64 on arm64 / x86_64, 16 otherwise).
+    public static var optimalAlignment: Int { get }
+
+    /// Minimum alignment enforced by allocateAligned (16 bytes; SIMD4<Float>).
+    public static let minimumAlignment: Int
+
+    /// Check whether a pointer is aligned to `alignment`.
+    public static func isAligned<T>(_ pointer: UnsafePointer<T>, to alignment: Int) -> Bool
+    public static func isAligned<T>(_ pointer: UnsafeMutablePointer<T>, to alignment: Int) -> Bool
+
+    /// Allocate aligned memory for `Float` (the common case).
+    /// - Precondition: `alignment` is a power of two and ≥ `minimumAlignment`.
+    /// - Throws: `VectorError.allocationFailed(size:reason:)` if `posix_memalign` fails.
+    public static func allocateAligned(
         count: Int,
-        alignment: Int = 64
-    ) throws -> UnsafeMutablePointer<T> {
-        var ptr: UnsafeMutableRawPointer?
-        let size = MemoryLayout<T>.stride * count
-        let result = posix_memalign(&ptr, alignment, size)
+        alignment: Int = optimalAlignment
+    ) throws -> UnsafeMutablePointer<Float>
 
-        guard result == 0, let allocatedPtr = ptr else {
-            throw VectorError.allocationFailed(size: size)
-        }
+    /// Allocate aligned memory for any type `T`.
+    /// - Precondition: `alignment` is a power of two and ≥ `minimumAlignment`.
+    /// - Throws: `VectorError.allocationFailed(size:reason:)` if `posix_memalign` fails.
+    public static func allocateAligned<T>(
+        type: T.Type,
+        count: Int,
+        alignment: Int = optimalAlignment
+    ) throws -> UnsafeMutablePointer<T>
 
-        return allocatedPtr.bindMemory(to: T.self, capacity: count)
-    }
+    /// Deallocate (typed pointer). Calls `free()` internally — never `.deallocate()`.
+    public static func deallocate<T>(_ ptr: UnsafeMutablePointer<T>)
 
-    /// Deallocate memory allocated with allocateAligned
-    public static func deallocate<T>(_ ptr: UnsafeMutablePointer<T>) {
-        free(UnsafeMutableRawPointer(ptr))
-    }
-
-    /// Deallocate raw pointer
-    public static func deallocate(_ ptr: UnsafeMutableRawPointer) {
-        free(ptr)
-    }
+    /// Deallocate (raw pointer). Calls `free()` internally.
+    public static func deallocate(_ ptr: UnsafeMutableRawPointer)
 }
 ```
+
+> **API note.** There is **no** positional `allocateAligned(_ type:count:alignment:)`. Use
+> either the `Float` overload `allocateAligned(count:)` or the labeled generic
+> `allocateAligned(type:count:)`. The default `alignment` is `optimalAlignment` (64 on
+> arm64), so you rarely pass it explicitly.
 
 ---
 
@@ -136,15 +165,12 @@ let vector = Vector512Optimized(repeating: 1.0)
 
 ### Manual Alignment (Advanced)
 
-For custom data structures:
+For custom data structures, use the `Float` overload (default alignment is
+`optimalAlignment`, 64 on arm64):
 
 ```swift
-// Allocate aligned memory
-let ptr = try AlignedMemory.allocateAligned(
-    Float.self,
-    count: 512,
-    alignment: 64
-)
+// Allocate aligned Float memory (alignment defaults to optimalAlignment == 64 on arm64)
+let ptr = try AlignedMemory.allocateAligned(count: 512)
 
 // Use the memory
 for i in 0..<512 {
@@ -155,6 +181,14 @@ for i in 0..<512 {
 AlignedMemory.deallocate(ptr)
 ```
 
+For a non-`Float` element type, use the labeled generic overload:
+
+```swift
+// Generic overload: pass the type with the `type:` label.
+let simdPtr = try AlignedMemory.allocateAligned(type: SIMD4<Float>.self, count: 128)
+defer { AlignedMemory.deallocate(simdPtr) }
+```
+
 ### Buffer Pool with Alignment
 
 VectorCore's buffer pool maintains alignment:
@@ -162,12 +196,8 @@ VectorCore's buffer pool maintains alignment:
 ```swift
 actor SwiftBufferPool {
     func acquire(count: Int) -> UnsafeMutableBufferPointer<Float> {
-        // Allocates 64-byte aligned buffer
-        let ptr = try! AlignedMemory.allocateAligned(
-            Float.self,
-            count: count,
-            alignment: 64
-        )
+        // Allocates optimalAlignment (64-byte on arm64) aligned buffer
+        let ptr = try! AlignedMemory.allocateAligned(count: count)
         return UnsafeMutableBufferPointer(start: ptr, count: count)
     }
 
@@ -187,7 +217,7 @@ actor SwiftBufferPool {
 **The Bug**:
 ```swift
 // ❌ WRONG: Causes undefined behavior
-let ptr = try AlignedMemory.allocateAligned(Float.self, count: 512)
+let ptr = try AlignedMemory.allocateAligned(count: 512)
 // ... use ptr ...
 ptr.deallocate()  // ❌ WRONG! posix_memalign memory MUST use free()
 ```
@@ -200,7 +230,7 @@ ptr.deallocate()  // ❌ WRONG! posix_memalign memory MUST use free()
 **The Fix**:
 ```swift
 // ✅ CORRECT: Use AlignedMemory.deallocate
-let ptr = try AlignedMemory.allocateAligned(Float.self, count: 512)
+let ptr = try AlignedMemory.allocateAligned(count: 512)
 // ... use ptr ...
 AlignedMemory.deallocate(ptr)  // ✅ Calls free() internally
 ```
@@ -223,10 +253,10 @@ array.withUnsafeMutableBufferPointer { buffer in
 
 **The Fix**:
 ```swift
-// ✅ Use aligned allocation
-let ptr = try AlignedMemory.allocateAligned(Float.self, count: 512, alignment: 64)
+// ✅ Use aligned allocation (defaults to optimalAlignment == 64 on arm64)
+let ptr = try AlignedMemory.allocateAligned(count: 512)
 let buffer = UnsafeMutableBufferPointer(start: ptr, count: 512)
-// buffer.baseAddress is guaranteed 64-byte aligned
+// buffer.baseAddress is guaranteed 64-byte aligned on arm64
 // ... use buffer ...
 AlignedMemory.deallocate(ptr)
 ```
@@ -263,42 +293,44 @@ alignedStorage.append(contentsOf: slice)
 ### Apple Silicon (ARM64)
 
 **Hardware characteristics**:
-- Cache line size: 64 bytes (M1/M2), 128 bytes (M3+)
+- Cache line size: 64 bytes (`PlatformConfiguration.l1CacheLineSize`)
+- Page size: `getpagesize()` — **16 KB** on Apple Silicon
 - SIMD width: 128-bit (NEON)
 - Required alignment: 16 bytes (SIMD4<Float>)
-- Recommended alignment: 64 bytes (cache line)
+- Recommended SIMD/cache alignment: 64 bytes (`AlignedMemory.optimalAlignment`)
+- AMX (matrix-extension) alignment: 128 bytes (`PlatformConfiguration.optimalAlignment`)
 
 **Performance notes**:
 - Unaligned SIMD loads: ~2x slower
 - Cache line split: ~1.5x slower
 - `posix_memalign` overhead: ~50ns per allocation
 
-**Optimal alignment strategy**:
+**Optimal alignment strategy** — use the constant for the consumer, not a hardcoded literal:
 ```swift
-// Use 64-byte alignment for M1/M2
-#if arch(arm64)
-let alignment = 64
-#endif
+// SIMD / cache-line storage: 64 on arm64.
+let simdAlignment = AlignedMemory.optimalAlignment        // 64 (arm64)
+
+// AMX / matrix-extension data: 128 on Apple Silicon.
+let amxAlignment = PlatformConfiguration.optimalAlignment // 128 (Apple Silicon)
 ```
 
 ### Intel (x86_64)
 
 **Hardware characteristics**:
-- Cache line size: 64 bytes
+- Cache line size: 64 bytes (`PlatformConfiguration.l1CacheLineSize`)
+- Page size: `getpagesize()` — **4 KB** on x86_64
 - SIMD width: 128-bit (SSE), 256-bit (AVX2), 512-bit (AVX-512)
 - Required alignment: 16 bytes (SSE), 32 bytes (AVX2), 64 bytes (AVX-512)
-- Recommended alignment: 64 bytes
+- Recommended alignment: 64 bytes (`AlignedMemory.optimalAlignment` == 64 on x86_64)
 
 **Performance notes**:
 - Unaligned AVX loads: ~5x slower than aligned
 - AVX-512 unaligned: May cause #GP fault (crash) on older CPUs
 - `_mm_malloc` overhead: ~100ns per allocation
 
-**Optimal alignment strategy**:
+**Optimal alignment strategy** — use the constant (64 on x86_64), don't hardcode:
 ```swift
-#if arch(x86_64)
-let alignment = 64  // Safe for all Intel SIMD
-#endif
+let alignment = AlignedMemory.optimalAlignment  // 64 — safe for all Intel SIMD
 ```
 
 ---
@@ -376,28 +408,62 @@ xcrun xctrace record --template 'Memory' --launch .build/debug/YourApp
 
 ```swift
 public enum AlignedMemory {
-    /// Allocate aligned memory
-    public static func allocateAligned<T>(
-        _ type: T.Type,
+    /// 64 on arm64 / x86_64, 16 otherwise.
+    public static var optimalAlignment: Int { get }
+
+    /// 16 (SIMD4<Float>); the floor enforced by allocateAligned.
+    public static let minimumAlignment: Int
+
+    public static func isAligned<T>(_ pointer: UnsafePointer<T>, to alignment: Int) -> Bool
+    public static func isAligned<T>(_ pointer: UnsafeMutablePointer<T>, to alignment: Int) -> Bool
+
+    /// Float overload. Default alignment = optimalAlignment.
+    public static func allocateAligned(
         count: Int,
-        alignment: Int = 64
+        alignment: Int = optimalAlignment
+    ) throws -> UnsafeMutablePointer<Float>
+
+    /// Generic overload (note the `type:` label). Default alignment = optimalAlignment.
+    public static func allocateAligned<T>(
+        type: T.Type,
+        count: Int,
+        alignment: Int = optimalAlignment
     ) throws -> UnsafeMutablePointer<T>
 
-    /// Deallocate aligned memory (typed pointer)
+    /// Deallocate aligned memory (typed pointer); calls free().
     public static func deallocate<T>(_ ptr: UnsafeMutablePointer<T>)
 
-    /// Deallocate aligned memory (raw pointer)
+    /// Deallocate aligned memory (raw pointer); calls free().
     public static func deallocate(_ ptr: UnsafeMutableRawPointer)
 }
 ```
 
+> The implementation `precondition`s that `alignment` is a power of two and
+> `≥ minimumAlignment`, then calls `posix_memalign`.
+
 ### VectorError
 
+`AlignedMemory` throws via the `allocationFailed(size:reason:)` factory (the
+`reason` argument carries the `posix_memalign` error code):
+
 ```swift
-public enum VectorError: Error {
-    case allocationFailed(size: Int)
-    // ... other cases
+extension VectorError {
+    static func allocationFailed(
+        size: Int,
+        reason: String? = nil,
+        // … source-location parameters with defaults …
+    ) -> VectorError
 }
+```
+
+### PlatformConfiguration (page / AMX constants)
+
+```swift
+// internal enum PlatformConfiguration
+static var l1CacheLineSize: Int   // 64 (arm64 / x86_64)
+static var optimalAlignment: Int  // 128 on Apple Silicon (AMX); 64 on x86_64
+static var pageSize: Int           // getpagesize() — 16 KB Apple Silicon, 4 KB x86
+static func roundUpToPage(_ byteCount: Int) -> Int  // the single page-rounding helper
 ```
 
 ---
@@ -416,8 +482,12 @@ A: On ARM (Apple Silicon): 2-5x slowdown. On Intel: 5-10x slowdown or crash (AVX
 **Q: Can I use `aligned_alloc` instead of `posix_memalign`?**
 A: Yes, but `posix_memalign` is more portable (C99 vs C11) and has identical performance.
 
-**Q: Why 64 bytes instead of 16 bytes?**
-A: 16 bytes satisfies SIMD4 alignment, but 64 bytes prevents cache line splits and is future-proof for AVX-512.
+**Q: Why is `AlignedMemory.optimalAlignment` 64 bytes instead of 16?**
+A: 16 bytes satisfies SIMD4 alignment, but 64 bytes matches the L1 cache line
+(`PlatformConfiguration.l1CacheLineSize`), prevents cache line splits, and covers AVX-512 on
+x86_64. Note 64 is **not** universal: AMX data prefers 128 bytes
+(`PlatformConfiguration.optimalAlignment` on Apple Silicon) and GPU `bytesNoCopy` import
+needs page alignment (`PlatformConfiguration.pageSize`).
 
 ---
 
@@ -434,40 +504,118 @@ contiguity. The GPU calls live in VectorAccelerate.
 `UnifiedVectorBuffer` (`Sources/VectorCore/Storage/UnifiedVectorBuffer.swift`) is a contiguous,
 alignment-guaranteed *read* view over a vector's `Float32` elements:
 
-- `elementCount` — logical element count
-- `alignment` — guaranteed base alignment (power of two ≥ `MemoryLayout<Float>.alignment`)
-- `withUnsafeContiguousBytes { (UnsafeRawBufferPointer) in … }` — scoped raw access to the logical
-  bytes (`elementCount * 4`)
+```swift
+public protocol UnifiedVectorBuffer {
+    var elementCount: Int { get }
+    var alignment: Int { get }   // power of two ≥ MemoryLayout<Float>.alignment
+    func withUnsafeContiguousBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
+}
+```
 
-The optimized vector types (`Vector384/512/768/1536Optimized`) conform with `alignment == 16`
-(their `ContiguousArray<SIMD4<Float>>` element region); `DynamicVector` conforms with
-`alignment == 4` (its storage may be inline). 16-byte alignment is enough to **read**, but not
-enough for `makeBuffer(bytesNoCopy:)`.
+- `elementCount` — logical element count
+- `alignment` — guaranteed base alignment of the yielded pointer
+- `withUnsafeContiguousBytes { (UnsafeRawBufferPointer) in … }` — scoped raw access to the logical
+  bytes (`elementCount * MemoryLayout<Float>.stride`)
+
+Conformers: `Vector384/512/768/1536Optimized` (alignment == `MemoryLayout<SIMD4<Float>>.alignment`,
+i.e. **16**, their `ContiguousArray<SIMD4<Float>>` element region) and `DynamicVector`
+(alignment == `MemoryLayout<Float>.alignment`, i.e. **4**, since storage may be inline). 16-byte
+alignment is enough to **read**, but not enough for `makeBuffer(bytesNoCopy:)`.
 
 ### The page-aligned path (`makeBuffer(bytesNoCopy:)`)
 
 `makeBuffer(bytesNoCopy:length:options:deallocator:)` requires, on macOS, that **both** the base
-address and the length be page multiples (16 KB on Apple Silicon). `PageAlignedBuffer` satisfies
-both:
+address and the length be multiples of the OS page size. The page size is **not** a fixed literal:
+it is `PlatformConfiguration.pageSize` (`getpagesize()` at runtime — **16 KB** on Apple Silicon,
+**4 KB** on x86_64). The single page-rounding helper is `PlatformConfiguration.roundUpToPage(_:)`,
+the authoritative source of truth used by every page-aligned allocation in the package (so the
+`length:` is computed identically everywhere).
 
-- base allocated via `posix_memalign(pageSize)` → page-aligned
-- `allocatedByteCount` = logical bytes **rounded up to a whole page**, with the padding zero-filled
-  so the GPU never imports uninitialized memory
-- `baseAddress` + `allocatedByteCount` are exactly the `bytesNoCopy:` pointer and `length:`
+There are two page-aligned producers. Both round their byte length up with `roundUpToPage(_:)`,
+zero-fill the padding so the GPU never imports uninitialized memory, and back the allocation with
+`posix_memalign` (freed with `free()` via `AlignedMemory.deallocate(_:)`).
 
-### Ownership handoff
+#### Producer 1 — `PageAlignedBuffer` (single embedding)
 
-For true zero-copy the `MTLBuffer` outlives the Swift object and frees the memory through Metal's
-`bytesNoCopy` deallocator. To avoid a double free, choose one:
+`PageAlignedBuffer` (`public final class : UnifiedVectorBuffer`) is the right producer when you
+have **one** vector to hand to the GPU (the canonical EmbedKit case: write a freshly produced
+embedding into page-aligned memory once, then hand the pointer downstream). Real surface:
 
-- call `consumeAllocation()` → transfers ownership; `deinit` no longer frees; the caller (the Metal
-  deallocator) must `free()` the returned base (via `AlignedMemory.deallocate(_:)`), **or**
-- keep the `PageAlignedBuffer` alive for the buffer's lifetime and pass a no-op Metal deallocator.
+```swift
+public final class PageAlignedBuffer: UnifiedVectorBuffer, @unchecked Sendable {
+    public init(elementCount: Int)                  // zero-initialized, page-aligned
+    public convenience init(copying source: [Float]) // allocate + copy once
+
+    public let pageSize: Int                         // captured PlatformConfiguration.pageSize
+    public let allocatedByteCount: Int               // logical bytes rounded up to a page multiple
+    public private(set) var ownsAllocation: Bool
+
+    public var baseAddress: UnsafeMutableRawPointer  // the bytesNoCopy: pointer (traps if consumed)
+    public var alignment: Int { pageSize }
+    public var elementCount: Int
+
+    public func withUnsafeContiguousBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
+    public func withUnsafeMutableBufferPointer<R>(_ body: (UnsafeMutableBufferPointer<Float>) throws -> R) rethrows -> R
+
+    /// Transfer ownership to a Metal bytesNoCopy deallocator.
+    public func consumeAllocation() -> (baseAddress: UnsafeMutableRawPointer, allocatedByteCount: Int)
+}
+```
+
+`baseAddress` and `allocatedByteCount` are exactly the `bytesNoCopy:` pointer and the `length:`.
+
+#### Producer 2 — SoA page-aligned (the primary 0.3.0 batch source)
+
+For a **batch** of candidates — the primary zero-copy source in 0.3.0 — build the
+Structure-of-Arrays buffer page-aligned. The in-memory layout is **frozen** as of 0.3.0; see
+[`Docs/SoA_Layout_Contract.md`](./SoA_Layout_Contract.md) for the authoritative contract (and
+`SoA.layoutDescriptor` for the machine-readable form). Relevant surface:
+
+```swift
+// Build page-aligned (otherwise the default 16-byte allocation):
+let soa = SoA<Vector768Optimized>.build(from: candidates, pageAligned: true)
+// or:        SoA<Vector768Optimized>(vectors: candidates, pageAligned: true)
+
+/// Page-aligned base + page-ROUNDED byte length (≥ logical), or nil if not page-aligned.
+var pageAlignedBytes: (base: UnsafeRawPointer, byteCount: Int)? { get }
+
+/// Transfer ownership of the page-aligned allocation (nil if not page-aligned).
+func consumeAllocation() -> (base: UnsafeMutableRawPointer, byteCount: Int)?
+
+/// Scoped read access to the logical bytes (count * lanes * 16).
+func withUnsafeRawBuffer<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
+```
+
+`pageAlignedBytes.byteCount` is the **page-rounded** length (the `length:` for `bytesNoCopy`), not
+the logical byte count. When deriving the candidate count `N` downstream, take it from
+`SoALayout.count` (via `layoutDescriptor`) — never reverse-engineer `N` from the page-rounded
+length.
+
+### Free / lifetime contract — borrow vs. transfer
+
+Both producers' page-aligned memory comes from `posix_memalign`, so it **must** be freed with
+`free()` — exactly what `AlignedMemory.deallocate(base)` does, which is thread-safe and therefore
+valid from a Metal `bytesNoCopy` deallocator running on an arbitrary thread. For a true zero-copy
+hand-off the `MTLBuffer` outlives the Swift object; pick **one** of two modes and never mix them
+(mixing double-frees):
+
+- **BORROW** — hold a strong reference to the producer (`PageAlignedBuffer` or `SoA`) and read
+  `baseAddress` / `pageAlignedBytes` **without** consuming. The producer still frees on `deinit`,
+  so pass a **no-op** Metal deallocator. The producer's object lifetime is the **sole** validity
+  guarantee: it MUST outlive the `MTLBuffer`.
+- **TRANSFER** — call `consumeAllocation()`. The producer stops owning the allocation (no free on
+  `deinit`; further access to `baseAddress` / `pageAlignedBytes` traps or returns `nil`), and the
+  caller — typically the Metal `bytesNoCopy` deallocator — becomes responsible for freeing the
+  returned base via `AlignedMemory.deallocate(_:)` (== `free`).
+
+VectorCore performs none of the Metal calls; it only provides the page-aligned memory and the
+ownership primitive.
 
 ---
 
 ## Further Reading
 
+- [SoA Layout Contract](./SoA_Layout_Contract.md) — the frozen 0.3.0 SoA in-memory layout
 - [Intel Intrinsics Guide](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html)
 - [ARM NEON Programming Guide](https://developer.arm.com/architectures/instruction-sets/simd-isas/neon)
 - [POSIX memalign documentation](https://man7.org/linux/man-pages/man3/posix_memalign.3.html)
@@ -475,6 +623,6 @@ For true zero-copy the `MTLBuffer` outlives the Swift object and frees the memor
 
 ---
 
-**Document Version**: 1.1
-**Last Updated**: June 2026
-**Applies to**: VectorCore v0.1.0+ (Zero-Copy Buffer Contract: v0.3.0+)
+**Document Version**: 0.3.0
+**Last Updated**: 2026-06-07
+**Applies to**: VectorCore v0.1.0+ (Zero-Copy Buffer Contract & page-aligned producers: v0.3.0+)

--- a/Docs/Memory_Alignment.md
+++ b/Docs/Memory_Alignment.md
@@ -421,6 +421,51 @@ A: 16 bytes satisfies SIMD4 alignment, but 64 bytes prevents cache line splits a
 
 ---
 
+## Zero-Copy Buffer Contract (`UnifiedVectorBuffer`)
+
+*(VectorCore v0.3.0+ — beta-evolution-4, DOCUMENT-4 S5)*
+
+For cross-package, zero-copy hand-off (EmbedKit → VectorAccelerate → GPU), VectorCore exposes a
+**CPU-only** memory contract. It imports no Metal or IOSurface; it only guarantees alignment and
+contiguity. The GPU calls live in VectorAccelerate.
+
+### The read contract
+
+`UnifiedVectorBuffer` (`Sources/VectorCore/Storage/UnifiedVectorBuffer.swift`) is a contiguous,
+alignment-guaranteed *read* view over a vector's `Float32` elements:
+
+- `elementCount` — logical element count
+- `alignment` — guaranteed base alignment (power of two ≥ `MemoryLayout<Float>.alignment`)
+- `withUnsafeContiguousBytes { (UnsafeRawBufferPointer) in … }` — scoped raw access to the logical
+  bytes (`elementCount * 4`)
+
+The optimized vector types (`Vector384/512/768/1536Optimized`) conform with `alignment == 16`
+(their `ContiguousArray<SIMD4<Float>>` element region); `DynamicVector` conforms with
+`alignment == 4` (its storage may be inline). 16-byte alignment is enough to **read**, but not
+enough for `makeBuffer(bytesNoCopy:)`.
+
+### The page-aligned path (`makeBuffer(bytesNoCopy:)`)
+
+`makeBuffer(bytesNoCopy:length:options:deallocator:)` requires, on macOS, that **both** the base
+address and the length be page multiples (16 KB on Apple Silicon). `PageAlignedBuffer` satisfies
+both:
+
+- base allocated via `posix_memalign(pageSize)` → page-aligned
+- `allocatedByteCount` = logical bytes **rounded up to a whole page**, with the padding zero-filled
+  so the GPU never imports uninitialized memory
+- `baseAddress` + `allocatedByteCount` are exactly the `bytesNoCopy:` pointer and `length:`
+
+### Ownership handoff
+
+For true zero-copy the `MTLBuffer` outlives the Swift object and frees the memory through Metal's
+`bytesNoCopy` deallocator. To avoid a double free, choose one:
+
+- call `consumeAllocation()` → transfers ownership; `deinit` no longer frees; the caller (the Metal
+  deallocator) must `free()` the returned base (via `AlignedMemory.deallocate(_:)`), **or**
+- keep the `PageAlignedBuffer` alive for the buffer's lifetime and pass a no-op Metal deallocator.
+
+---
+
 ## Further Reading
 
 - [Intel Intrinsics Guide](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html)
@@ -430,6 +475,6 @@ A: 16 bytes satisfies SIMD4 alignment, but 64 bytes prevents cache line splits a
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: October 2025
-**Applies to**: VectorCore v0.1.0+
+**Document Version**: 1.1
+**Last Updated**: June 2026
+**Applies to**: VectorCore v0.1.0+ (Zero-Copy Buffer Contract: v0.3.0+)

--- a/Docs/Package_Boundaries.md
+++ b/Docs/Package_Boundaries.md
@@ -41,37 +41,73 @@ VectorCore is designed as part of a modular 4-package ecosystem, each with clear
 
 ## 1. VectorCore (Foundation)
 
-**Purpose**: Pure CPU vector mathematics and core abstractions
+**Purpose**: CPU-first vector mathematics and core abstractions
 
-**Scope** (v0.1.0):
+**Scope** (v0.3.0):
 - Vector data types (fixed & dynamic dimensions)
 - SIMD-optimized operations (512/768/1536 dimensions)
 - Distance metrics (Euclidean, Cosine, Manhattan, Chebyshev, Hamming, Minkowski, DotProduct)
+- CPU GEMM batch distance (`MatrixDistance`: `euclideanSquaredMatrix` / `cosineDistanceMatrix`, `prepare(_:normalized:)` → `PreparedCandidates`) via Accelerate `cblas_sgemm` (AMX on Apple Silicon)
 - Normalization, statistics, centroid computation
-- Top-K selection
+- Top-K selection (deterministic `TieBreaker`: `.smallerIndex` default / `.insertionOrder` / `.smallerValue`)
 - Memory management (aligned allocation, buffer pools)
-- Provider abstractions (SIMDProvider, ComputeProvider, BufferProvider)
+- Provider abstractions (`SIMDProvider`, `ComputeProvider`, `BufferProvider`, `BatchKernelProvider`)
+- Zero-copy GPU-bridge buffer contract (`UnifiedVectorBuffer` / `PageAlignedBuffer`) + frozen SoA layout (`SoALayout`)
 - Basic quantization primitives (INT8)
 - Serialization (Codable, in-memory binary)
+
+### 0.3.0 — "hold the line, sharpen the seams"
+
+The strategy this release is to keep VectorCore the small, CPU-first, allocation-free
+foundation while **redirecting** index / GPU / DB features to the siblings
+VectorIndex / VectorAccelerate / EmbedKit. Core does *not* grow into those domains; instead
+it **owns the seams** they plug into. What Core newly owns in 0.3.0:
+
+- **`MatrixDistance`** — CPU GEMM batch distance (Accelerate `cblas_sgemm` → AMX on Apple
+  Silicon), generic over `UnifiedVectorBuffer`. `euclideanSquaredMatrix` /
+  `cosineDistanceMatrix`; `prepare(_:normalized:)` → `PreparedCandidates`.
+- **Zero-copy GPU-bridge buffer contract** — the `UnifiedVectorBuffer` protocol + the
+  page-aligned `PageAlignedBuffer` class, valid for `MTLDevice.makeBuffer(bytesNoCopy:)`.
+- **Frozen SoA memory-layout contract** — the `SoALayout` descriptor, reachable as
+  `SoA.layoutDescriptor` (live) or `SoALayout.forType` (ahead of allocation). See
+  [SoA Layout Contract](SoA_Layout_Contract.md).
+- **`BatchKernelProvider`** — a `ComputeProvider` sub-protocol. `Operations.findNearest` /
+  `findNearestBatch` downcast the installed `computeProvider` to it and delegate, giving an
+  installed GPU provider precedence over the CPU GEMM path.
+- **`TieBreaker`** — deterministic Top-K ordering (`.smallerIndex` default / `.insertionOrder`
+  / `.smallerValue`).
+- **Pointer-level seams** — `SoA.pageAlignedBytes` / `consumeAllocation()`,
+  `PlatformConfiguration.roundUpToPage(_:)`.
+
+> **Owns the seam, not the kernel.** Core ships **no GPU/Metal kernels**. What it now owns is
+> the GPU *seam*: the `BatchKernelProvider` dispatch hook plus the page-aligned `bytesNoCopy`
+> buffer contract. The kernels themselves live in VectorAccelerate.
 
 **What's NOT in Core**:
 - ❌ Graph algorithms or data structures
 - ❌ Clustering algorithms (K-means, hierarchical, etc.)
-- ❌ GPU/Metal code
+- ❌ GPU/Metal **kernels** (Core owns the seam — `BatchKernelProvider` dispatch + the page-aligned `bytesNoCopy` buffer contract — but not the shaders)
 - ❌ Approximate nearest neighbor (ANN) indexes
 - ❌ Persistent storage formats
 - ❌ Mixed precision auto-tuning (device-specific)
 
-**Dependencies**: None (pure Swift + Foundation + Accelerate)
+**Dependencies**: None third-party (Swift + Foundation + Accelerate, plus an internal `VectorCoreC` C target)
 
 **Public API Surface**:
 - Vector types: `Vector<D>`, `DynamicVector`, `Vector{512,768,1536}Optimized`
-- Protocols: `VectorProtocol`, `VectorFactory`, `SIMDProvider`, `ComputeProvider`
-- Operations: `Operations`, `BatchOperations`
+- Protocols: `VectorProtocol`, `VectorFactory`, `SIMDProvider`, `ComputeProvider`, `BatchKernelProvider`, `UnifiedVectorBuffer`
+- Operations: `Operations`, `BatchOperations`, `MatrixDistance`
 - Distance metrics: `EuclideanDistance`, `CosineDistance`, etc.
+- GPU-bridge: `PageAlignedBuffer`, `SoALayout` (see [SoA Layout Contract](SoA_Layout_Contract.md))
 
-**CPU-Only Philosophy**:
-VectorCore is intentionally CPU-only to maintain simplicity, portability, and zero GPU dependencies. GPU acceleration is provided by VectorAccelerate through provider plugins.
+**CPU-First Philosophy (no GPU kernels, owns the GPU seam)**:
+VectorCore ships **no GPU/Metal kernels** — it stays CPU-first for simplicity, portability, and
+zero GPU *dependencies*. What it does own is the **GPU seam**: the `BatchKernelProvider`
+dispatch hook (`Operations.findNearest` / `findNearestBatch` downcast the installed
+`computeProvider` and delegate, GPU taking precedence over the CPU GEMM path) and the
+zero-copy page-aligned `bytesNoCopy` buffer contract (`UnifiedVectorBuffer` / `PageAlignedBuffer`,
+plus the frozen `SoALayout`). The actual kernels are provided by VectorAccelerate through these
+seams.
 
 ---
 
@@ -139,9 +175,10 @@ let neighbors = try index.search(query, k: 10)
   - FP16 candidate conversion
   - Strategy selection based on device capabilities
   - Performance profiling and adaptive selection
-- **SoA FP16 caching**:
-  - Structure-of-Arrays FP16 layouts
-  - Cache-efficient batch processing
+- **Device-adaptive SoA FP16 strategy**:
+  - Device-specific auto-tuning over FP16 layouts
+  - (Note: the `SoAFP16` cache type itself still ships in Core as an internal type; only the
+    device-adaptive *tuning* over it is Accelerate's concern.)
 - **Neural Engine support** (future):
   - CoreML-based vector operations
 
@@ -209,7 +246,7 @@ let strategy = await KernelAutoTuner.shared.selectStrategy(for: workload)
 - **I/O complexity**: File I/O and database integration are orthogonal to math
 - **Deployment flexibility**: Some users want in-memory only
 - **Format evolution**: Storage formats need independent versioning
-- **Zero dependencies in Core**: Core remains pure Swift with no I/O
+- **Zero third-party dependencies in Core**: Core stays Swift-first (one internal C target, no third-party deps) with no I/O
 
 **Usage Example**:
 ```swift
@@ -315,10 +352,10 @@ VectorCore has zero third-party dependencies. Other packages only depend on Core
 Users only pay (in binary size and complexity) for what they use. Need just vector math? Use Core. Need GPU? Add Accelerate.
 
 ### 4. **Protocol-Based Integration**
-Packages integrate via protocols (`ComputeProvider`, `SIMDProvider`, `BufferProvider`), enabling loose coupling and extensibility.
+Packages integrate via protocols (`ComputeProvider`, `SIMDProvider`, `BufferProvider`, `BatchKernelProvider`), enabling loose coupling and extensibility.
 
 ### 5. **Platform Portability**
-Core is pure Swift and works everywhere. Platform-specific features (Metal, Neural Engine) live in Accelerate.
+Core is Swift-first (with one internal `VectorCoreC` C target — so not literally 100% Swift, though it carries zero *third-party* dependencies) and works everywhere. Platform-specific features (Metal kernels, Neural Engine) live in Accelerate; Core owns only the seam they plug into.
 
 ---
 
@@ -333,20 +370,27 @@ VectorCore v0.1.0 started as a monolith with graph/clustering code. This was spl
 
 **Moved to VectorAccelerate**:
 - Mixed precision auto-tuning (`MixedPrecisionAutoTuner.swift`)
-- SoA FP16 caching (`SoAFP16Cache.swift`)
+- Device-adaptive SoA FP16 *tuning* (the `SoAFP16Cache` type itself remains an internal Core type)
 
-**Moved to VectorStore** (future):
-- Durable binary format with CRC validation
+**Moved to EmbedKit** (future):
+- Durable storage / embedding-store concerns (CRC-validated binary format, persistence)
+
+### 0.3.0 changes
+
+- **Breaking:** removed the no-op `blockSize:` parameter from `SoA.init(vectors:…)` and
+  `SoAFP16.init(vectors:…)`. It was a no-op and is gone (see the [SoA Layout Contract](SoA_Layout_Contract.md)).
+- **Deferred (specced, not built):** block-wise quantization `Q8_0` is consumer-gated — it is
+  *not* in 0.3.0.
 
 ---
 
 ## Version Compatibility
 
-| VectorCore | VectorIndex | VectorAccelerate | VectorStore |
-|------------|-------------|------------------|-------------|
-| 0.1.0      | -           | -                | -           |
-| 0.2.0      | 0.1.0       | 0.1.0            | 0.1.0       |
-| 0.3.0+     | 0.2.0+      | 0.2.0+           | 0.2.0+      |
+| VectorCore | VectorIndex | VectorAccelerate | EmbedKit |
+|------------|-------------|------------------|----------|
+| 0.1.0      | -           | -                | -        |
+| 0.2.0      | 0.1.0       | 0.1.0            | 0.1.0    |
+| 0.3.0+     | 0.2.0+      | 0.2.0+           | 0.2.0+   |
 
 **Policy**: All packages use SemVer 2.0. Minor version bumps in Core may require minor version bumps in dependent packages.
 
@@ -363,14 +407,14 @@ A: Yes! VectorIndex depends only on VectorCore. GPU acceleration is optional.
 **Q: What if I want CUDA instead of Metal?**
 A: You can implement a `CUDAComputeProvider` that conforms to `ComputeProvider`. VectorCore's protocol-based design supports custom backends.
 
-**Q: Will there be more packages (e.g., VectorML, VectorTransform)?**
-A: Possibly. The 4-package architecture is designed to be extensible. New packages can depend on Core and integrate via protocols.
+**Q: Will there be more packages?**
+A: The store/embed sibling is **EmbedKit** (the real embed package — not a speculative "VectorML"/"VectorTransform"). The architecture is designed to be extensible; new packages depend on Core and integrate via protocols.
 
 **Q: Why is quantization in Core but mixed precision auto-tuning in Accelerate?**
-A: Basic INT8 quantization is CPU-friendly and device-agnostic. Auto-tuning requires device-specific profiling and strategy selection, which is inherently accelerator-specific.
+A: Basic INT8 quantization is CPU-friendly and device-agnostic. Auto-tuning requires device-specific profiling and strategy selection, which is inherently accelerator-specific. Note: block-wise quantization (`Q8_0`) is **specced but deferred** (consumer-gated) — it is not in 0.3.0.
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: October 2025
-**Applies to**: VectorCore v0.1.0+
+**Document Version**: 1.1
+**Last Updated**: 2026-06-07
+**Applies to**: VectorCore v0.3.0+

--- a/Docs/Performance_Guide.md
+++ b/Docs/Performance_Guide.md
@@ -10,9 +10,10 @@ This guide explains how to maximize performance in VectorCore, covering optimize
 2. [Optimized Vectors Deep Dive](#optimized-vectors-deep-dive)
 3. [Provider Configuration](#provider-configuration)
 4. [Batch Operations](#batch-operations)
-5. [Memory Management](#memory-management)
-6. [Benchmarking](#benchmarking)
-7. [Performance Pitfalls](#performance-pitfalls)
+5. [GEMM / Matrix Batch-Distance](#gemm--matrix-batch-distance)
+6. [Memory Management](#memory-management)
+7. [Benchmarking](#benchmarking)
+8. [Performance Pitfalls](#performance-pitfalls)
 
 ---
 
@@ -107,10 +108,12 @@ public func dotProduct(_ other: Vector512Optimized) -> Float {
 - **Contiguous storage**: `ContiguousArray` ensures no ARC metadata in the middle
 - **Sequential access**: Prefetcher-friendly memory patterns
 
-**Typical Performance** (Apple Silicon M-series):
-- **Dot product**: ~100ns for 512 dimensions
-- **Euclidean distance**: ~120ns
-- **Normalization**: ~150ns
+**Typical Performance** (Apple Silicon M-series) — *indicative only; these are
+order-of-magnitude figures, not 0.3.0 measurements. Profile your own hardware with
+`vectorcore-bench` (the numbers below are flagged for re-measurement):*
+- **Dot product**: ~100ns for 512 dimensions *(indicative)*
+- **Euclidean distance**: ~120ns *(indicative)*
+- **Normalization**: ~150ns *(indicative)*
 
 ---
 
@@ -157,24 +160,59 @@ Controls batch operations and parallelization strategy
 **Available Implementations**:
 - `CPUComputeProvider.automatic`: Auto-parallelizes based on batch size
 - `CPUComputeProvider.sequential`: Single-threaded (for debugging)
-- `MetalComputeProvider` (VectorAccelerate): GPU-accelerated
+- `CPUComputeProvider.parallel`: Force multi-threaded execution
+- `CPUComputeProvider.performance` / `.efficiency`: Bias toward P- or E-cores
+- A `BatchKernelProvider` conformer (e.g. a GPU/Metal provider in VectorAccelerate):
+  supplies real hardware batch kernels (see below)
 
 **When to override**:
-- GPU-enabled devices: Use Metal for batches >1000
-- Debugging: Use sequential for reproducibility
-- Low latency: Use automatic for adaptive parallelization
+- GPU-enabled devices: Install a `BatchKernelProvider` for large brute-force search
+- Debugging: Use `.sequential` for reproducibility
+- Low latency: Use `.automatic` for adaptive parallelization
 
-**Example**:
+**Transparent GPU dispatch via `BatchKernelProvider`**
+
+`Operations.findNearest` / `findNearestBatch` *downcast* the installed `computeProvider`
+to the `BatchKernelProvider` protocol. When a conformer is present, they delegate the
+k-NN query to its kernel — and this path takes **precedence over the CPU GEMM routing**
+and the optimized Top-K fast paths. This makes GPU acceleration transparent through
+VectorCore's own entry points: no separate API, just a different provider.
+
 ```swift
-await Operations.$computeProvider.withValue(MetalComputeProvider()) {
+public protocol BatchKernelProvider: ComputeProvider {
+    func batchDistance<V: VectorProtocol>(
+        query: V, candidates: [V], metric: any DistanceMetric
+    ) async throws -> [Float] where V.Scalar == Float
+
+    func findNearest<V: VectorProtocol>(
+        query: V, candidates: [V], k: Int, metric: any DistanceMetric
+    ) async throws -> [(index: Int, distance: Float)] where V.Scalar == Float
+
+    // Default loops `findNearest`; a true batched GPU kernel should override this
+    // (one dispatch for the whole query set is the actual GPU win).
+    func findNearestBatch<V: VectorProtocol>(
+        queries: [V], candidates: [V], k: Int, metric: any DistanceMetric
+    ) async throws -> [[(index: Int, distance: Float)]] where V.Scalar == Float
+}
+```
+
+**Example** — install a GPU provider; existing `Operations` calls route to it:
+```swift
+await Operations.$computeProvider.withValue(yourGPUProvider) {
     let results = try await Operations.findNearest(
         to: query,
         in: database,  // 100K vectors
         k: 100
     )
-    // GPU-accelerated brute-force search
+    // Delegates to yourGPUProvider.findNearest (GPU brute-force search),
+    // ahead of the CPU GEMM / Top-K paths.
 }
 ```
+
+> `yourGPUProvider` is any type conforming to `BatchKernelProvider`. VectorCore defines
+> the protocol; the GPU-backed conformance ships in VectorAccelerate. To feed the GPU
+> efficiently, build candidate buffers with the zero-copy SoA layout described in
+> [Zero-Copy GPU Batches](#zero-copy-gpu-batches).
 
 #### 3. **BufferProvider**
 
@@ -220,15 +258,119 @@ let results = await BatchOperations.findNearest(to: query, in: vectors, k: 10)
 
 ### Manual Parallelization Control
 
+`BatchOperations` exposes a thread-safe global `Configuration` updated via a mutating
+closure. The tunable fields are `parallelThreshold` (default `1000`), `minimumChunkSize`
+(default `256`), `enableMatrixRouting` (default `true`), and `matrixRoutingMinN`
+(default `256`).
+
 ```swift
 // Override automatic tuning
-await BatchOperations.configure(
-    minBatchSizeForParallel: 500,
-    preferredChunkSize: 100
-)
+await BatchOperations.updateConfiguration { config in
+    config.parallelThreshold = 500   // Parallelize sooner
+    config.minimumChunkSize = 128    // Smaller chunks
+}
 
 let results = await BatchOperations.findNearest(to: query, in: vectors, k: 10)
 // Uses your configuration
+```
+
+> The `enableMatrixRouting` / `matrixRoutingMinN` fields control the GEMM batch-distance
+> fast path covered in [GEMM / Matrix Batch-Distance](#gemm--matrix-batch-distance).
+
+---
+
+## GEMM / Matrix Batch-Distance
+
+For large query × candidate matrices, computing each pair with a per-pair SIMD kernel
+leaves throughput on the table. VectorCore instead computes the **whole distance matrix
+with a single matrix multiply**, using the identity:
+
+```
+‖x − y‖² = ‖x‖² + ‖y‖² − 2⟨x, y⟩
+```
+
+The cross-term `⟨x, y⟩` is one `cblas_sgemm` call, which **routes to the AMX coprocessor
+on Apple Silicon**. This is the high-throughput path; the per-pair kernels remain the
+small-batch path.
+
+### `MatrixDistance` API
+
+`MatrixDistance` is generic over any `UnifiedVectorBuffer` — the optimized
+`Vector384/512/768/1536Optimized` types and `DynamicVector` all conform, so one
+implementation serves every dimension. Results are written **row-major**: `out[i*n + j]`
+is the distance from `queries[i]` to `candidates[j]`.
+
+```swift
+// Allocating convenience overloads (Euclidean SQUARED, clamped ≥ 0):
+let flat: [Float] = MatrixDistance.euclideanSquaredMatrix(
+    queries: queries, candidates: candidates
+)
+
+// Hot path — caller owns `out`; count MUST equal queries.count * candidates.count:
+var out = [Float](repeating: 0, count: queries.count * candidates.count)
+MatrixDistance.euclideanSquaredMatrix(queries: queries, candidates: candidates, into: &out)
+
+// Cosine has the same three overloads (result = 1 − cos, clamped to [0, 2]):
+MatrixDistance.cosineDistanceMatrix(queries: queries, candidates: candidates, into: &out)
+```
+
+### Reusing candidates with `PreparedCandidates`
+
+For **repeated** search against a fixed candidate set, pack the candidates **once** with
+`prepare` and reuse the `PreparedCandidates` across many query batches. This avoids
+re-packing and re-norming the (large) candidate side on every call. Pass
+`normalized: false` for Euclidean (raw rows + squared norms) and `normalized: true` for
+Cosine (L2-normalized rows). `PreparedCandidates` exposes `.count` and `.dimension`.
+
+```swift
+// Pack once (normalized: false → Euclidean; true → Cosine).
+let prepared = MatrixDistance.prepare(candidates, normalized: false)
+
+// Reuse across many query batches:
+var out = [Float](repeating: 0, count: queries.count * prepared.count)
+MatrixDistance.euclideanSquaredMatrix(queries: queries, prepared: prepared, into: &out)
+```
+
+### Automatic routing (crossover)
+
+You usually don't call `MatrixDistance` directly. `BatchOperations.pairwiseDistances` and
+`Operations.findNearestBatch` **auto-route** through it when both:
+
+- `enableMatrixRouting` is `true` (the default), **and**
+- the per-side count clears `matrixRoutingMinN` (default **256**),
+
+for optimized vector types with the Euclidean or Cosine metric. Below the threshold the
+per-pair kernels win; above it the matrix multiply amortizes the packing cost. This is the
+same auto-tuning machinery as the parallelization heuristics above — tune it the same way:
+
+```swift
+await BatchOperations.updateConfiguration { config in
+    config.matrixRoutingMinN = 512   // Raise the GEMM crossover
+    // config.enableMatrixRouting = false  // Force the exact per-pair path
+}
+```
+
+> An installed `BatchKernelProvider` (GPU) takes **precedence** over this CPU GEMM
+> routing in `Operations.findNearest` / `findNearestBatch` — see
+> [Transparent GPU dispatch](#2-computeprovider).
+
+### Accuracy caveat
+
+The GEMM result agrees with the per-pair kernels to **~1e-3 relative**, **not
+bit-identical**. The difference comes from evaluating distance through the
+`‖x‖² + ‖y‖² − 2⟨x, y⟩` identity (rather than summing `(xᵢ − yᵢ)²` directly) plus the final
+clamp: Euclidean is **squared** and clamped `≥ 0` (the identity can round slightly negative
+when `x ≈ y`); cosine is `1 − cos` clamped to `[0, 2]`. If you need exact per-pair values,
+set `enableMatrixRouting = false`.
+
+### Calibrating the crossover
+
+The ideal `matrixRoutingMinN` depends on dimension and hardware. The `vectorcore-bench`
+**`matrix`** suite (`MatrixDistanceBench`) measures GEMM vs per-pair kernels across N and
+dimension so you can pick the crossover for your target:
+
+```bash
+.build/release/vectorcore-bench --suites matrix
 ```
 
 ---
@@ -244,9 +386,12 @@ VectorCore uses 64-byte aligned allocations for SIMD operations:
 let vector = Vector512Optimized(repeating: 1.0)
 // storage is 64-byte aligned
 
-// Manual alignment (advanced)
-let ptr = try AlignedMemory.allocateAligned(Float.self, count: 512, alignment: 64)
+// Manual alignment (advanced) — Float convenience overload
+let ptr = try AlignedMemory.allocateAligned(count: 512, alignment: 64)
 defer { AlignedMemory.deallocate(ptr) }
+
+// For other element types, pass the type via the `type:` label:
+// let ptr = try AlignedMemory.allocateAligned(type: Float.self, count: 512, alignment: 64)
 ```
 
 **Why alignment matters**:
@@ -316,6 +461,13 @@ swift build --product vectorcore-bench -c release
 | `batch` | Batch operation throughput | Parallelization efficiency |
 | `normalize` | Normalization performance | vDSP integration |
 | `memory` | Allocation overhead | Buffer pool efficiency |
+| `matrix` | GEMM batch-distance vs per-pair kernels | Calibrate `matrixRoutingMinN` crossover |
+
+Run the GEMM calibration suite with:
+
+```bash
+.build/release/vectorcore-bench --suites matrix
+```
 
 ### Performance Regression Detection
 
@@ -432,7 +584,8 @@ for normalized in normalizedQueries {
 }
 ```
 
-**Impact**: Normalization is ~150ns per 512-dim vector; pre-normalize to save ~10% overhead
+**Impact**: Normalization costs roughly ~150ns per 512-dim vector (*indicative — profile
+your hardware*); pre-normalizing avoids repeating that work on every comparison.
 
 ---
 
@@ -452,35 +605,62 @@ Before deploying performance-critical code, verify:
 
 ## Advanced: Custom Providers
 
-Implement custom providers for specialized hardware:
+To plug in specialized hardware (GPU, accelerator), conform to `BatchKernelProvider`.
+Because it refines `ComputeProvider`, `Operations.findNearest` / `findNearestBatch`
+downcast to it and delegate — your kernel runs ahead of the CPU GEMM and Top-K paths.
+
+A conformer must honor the kernel contract:
+- `batchDistance` returns one distance per candidate, in candidate order.
+- `findNearest` returns up to `k` `(index, distance)` pairs sorted ascending by distance,
+  indexing into `candidates`, matching the CPU reference within a documented tolerance.
+- `findNearestBatch` has a default that loops `findNearest`; override it with a single
+  batched dispatch over the whole query set — that one-dispatch form is the real GPU win.
 
 ```swift
-struct CUDAComputeProvider: ComputeProvider {
+struct GPUKernelProvider: BatchKernelProvider {
+    func batchDistance<V: VectorProtocol>(
+        query: V, candidates: [V], metric: any DistanceMetric
+    ) async throws -> [Float] where V.Scalar == Float {
+        // Upload, run the distance kernel, read back one distance per candidate.
+        return try await gpuBatchDistance(query, candidates, metric)
+    }
+
     func findNearest<V: VectorProtocol>(
-        to query: V,
-        in vectors: [V],
-        k: Int
-    ) async throws -> [(index: Int, distance: Float)] {
-        // Transfer to GPU
-        let gpuQuery = cudaAllocate(query)
-        let gpuVectors = cudaAllocate(vectors)
+        query: V, candidates: [V], k: Int, metric: any DistanceMetric
+    ) async throws -> [(index: Int, distance: Float)] where V.Scalar == Float {
+        let distances = try await gpuBatchDistance(query, candidates, metric)
+        return gpuTopK(distances, k)  // (index, distance) sorted ascending by distance
+    }
 
-        // Compute distances on GPU
-        let gpuDistances = cudaDistances(gpuQuery, gpuVectors)
-
-        // Top-K selection on GPU
-        let gpuResults = cudaTopK(gpuDistances, k)
-
-        // Transfer back to CPU
-        return cudaCopyToHost(gpuResults)
+    func findNearestBatch<V: VectorProtocol>(
+        queries: [V], candidates: [V], k: Int, metric: any DistanceMetric
+    ) async throws -> [[(index: Int, distance: Float)]] where V.Scalar == Float {
+        // Override the default: one GPU dispatch for the whole query set.
+        return try await gpuFindNearestBatch(queries, candidates, k, metric)
     }
 }
 
-// Use it
-await Operations.$computeProvider.withValue(CUDAComputeProvider()) {
+// Install it — existing Operations calls now route through the GPU kernel.
+await Operations.$computeProvider.withValue(GPUKernelProvider()) {
     let results = try await Operations.findNearest(to: query, in: database, k: 100)
 }
 ```
+
+### Zero-Copy GPU Batches
+
+Feeding a GPU kernel is bandwidth-bound, so the buffer layout is itself a throughput
+lever. Build the candidate set with the page-aligned SoA layout to obtain
+`MTLDevice.makeBuffer(bytesNoCopy:)`-eligible storage (no host→device staging copy):
+
+```swift
+// Page-aligned SoA → bytesNoCopy-eligible backing for the Metal path.
+let soa = SoA.build(from: candidates, pageAligned: true)
+```
+
+`PageAlignedBuffer` / `SoA.build(from:pageAligned: true)` allocate page-aligned, page-
+rounded storage so the GPU can map the bytes directly. See
+[SoA_Layout_Contract.md](SoA_Layout_Contract.md) for the exact byte-count contract that
+`SoALayout` and `makeBuffer(bytesNoCopy:)` must agree on.
 
 ---
 
@@ -544,6 +724,6 @@ xcrun xctrace record --template 'Allocations' --launch .build/release/YourApp
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: October 2025
-**Applies to**: VectorCore v0.1.0+
+**Document Version**: 0.3.0
+**Last Updated**: 2026-06-07
+**Applies to**: VectorCore v0.3.0+

--- a/Docs/ROADMAP.md
+++ b/Docs/ROADMAP.md
@@ -1,8 +1,53 @@
 # VectorCore Improvement Roadmap
 
-**Current Version:** 0.2.0 (Released March 2026)
-**Last Updated:** March 2026
+**Current Version:** 0.2.2 → **0.3.0 in progress** (releasing 2026-06-07)
+**Last Updated:** 2026-06-07
 **Target Packages:** VectorIndex, VectorAccelerate, VectorIndexAccelerated, EmbedKit
+
+> **Strategy note (0.3.0):** "Hold the line, sharpen the seams." Several items previously
+> listed here as open Core backlog have either **shipped in 0.3.0** (see the "0.3.0 — Done"
+> section immediately below) or been **redirected to a sibling package** (VectorIndex /
+> VectorAccelerate). The authoritative 0.3.0 record of work is
+> `Docs/beta-evolution-4/be4-master.md` (+ `CHANGELOG`).
+
+---
+
+## ✅ 0.3.0 — Done (shipped on `feature/beta-evo-4`)
+
+The following items from the backlog below are **shipped in 0.3.0**. They are marked inline at
+their original locations as well; collected here for quick reference:
+
+- **Matrix / GEMM batch distance (CPU/AMX)** — §9.2 "Matrix Distance Computation" and §2.2
+  "Add `distanceMatrix(a:b:)`". Shipped as `MatrixDistance`
+  (`Sources/VectorCore/Operations/MatrixDistance.swift`): `euclideanSquaredMatrix` /
+  `cosineDistanceMatrix` (with `into:` / allocating / `prepared:` overloads),
+  `prepare(_:normalized:)`, `PreparedCandidates`. Uses Accelerate `cblas_sgemm` → AMX.
+- **Configurable tie-breaking** — §9.3. Shipped as `TieBreaker`
+  (`.smallerIndex` default / `.insertionOrder` / `.smallerValue`) in
+  `Sources/VectorCore/Operations/TopKSelection.swift`.
+- **Batch-distance protocol seam + provider seam** — §2.2 / §11.2. Shipped as
+  `BatchKernelProvider` (a `ComputeProvider` sub-protocol) in
+  `Sources/VectorCore/Protocols/BatchKernelProvider.swift`; enables transparent GPU dispatch
+  from `Operations.findNearest` / `findNearestBatch`.
+- **Zero-copy buffer contract + shared CPU↔GPU types** — §11.2 (ComputeProvider / Metal-buffer
+  compatibility / shared CPU↔GPU types). Shipped as the `UnifiedVectorBuffer` protocol +
+  `PageAlignedBuffer` (`Sources/VectorCore/Storage/UnifiedVectorBuffer.swift`) and the **frozen
+  `SoALayout` contract** (`Sources/VectorCore/Storage/SoALayout.swift`,
+  `Docs/SoA_Layout_Contract.md`), plus SoA page-alignment APIs in
+  `Sources/VectorCore/Storage/SoA.swift` (`build(from:pageAligned:)`,
+  `init(vectors:pageAligned:)`, `pageAlignedBytes`, `consumeAllocation()`,
+  `withUnsafeRawBuffer`) and `PlatformConfiguration.roundUpToPage(_:)`.
+- **Transparent matrix routing** — `BatchOperations.Configuration.enableMatrixRouting`
+  (default `true`) + `matrixRoutingMinN` (default `256`) route `pairwiseDistances` and
+  `Operations.findNearestBatch` through `MatrixDistance`.
+
+> **⚠️ BREAKING (0.3.0):** the no-op `blockSize:` parameter was removed from
+> `SoA.init(vectors:…)` **and** `SoAFP16.init(vectors:…)`.
+
+**Redirected to sibling packages (not open Core backlog):** `mmap` storage → VectorIndex (§10.2),
+prefetching → VectorIndex (§4.4), PQ / ADC → VectorIndex (§5.1), binary-packed + Hamming →
+VectorAccelerate (§5.2), sparse CSR → deferred (no producer). FP16 mixed precision and scalar
+INT8 quantization already shipped in Core pre-0.3.0.
 
 This document tracks identified improvement opportunities for VectorCore, organized by component and priority. Items marked with 🔒 may require API changes.
 
@@ -204,7 +249,7 @@ public protocol DistanceMetric: Sendable {
 
 **Recommendations:**
 - [x] Add optional `batchDistance(query:candidates:)` with default implementation ✅ (v0.2.0 — promoted to protocol requirement)
-- [ ] Add `distanceMatrix(a:b:)` for cross-product computations
+- [x] Add `distanceMatrix(a:b:)` for cross-product computations ✅ **shipped 0.3.0** as `MatrixDistance.euclideanSquaredMatrix` / `cosineDistanceMatrix` (`Sources/VectorCore/Operations/MatrixDistance.swift`, CPU `cblas_sgemm`→AMX)
 - [ ] Document when batch vs single operations should be used
 
 **VectorAccelerate Request:**
@@ -370,14 +415,18 @@ File is extremely large (64k+ tokens) which impacts compile time and maintainabi
 - [ ] Consider using conditional compilation for dimension-specific code
 - [ ] Add compilation time benchmarks to CI
 
-### 4.4 Prefetching for Batch Operations
+### 4.4 Prefetching for Batch Operations → **REDIRECTED to VectorIndex (0.3.0)**
 
-**Priority:** Medium
+**Priority:** Medium → **Redirected (not Core backlog)**
 **Impact:** Performance
 
 Explicit memory prefetching could improve cache utilization in batch loops.
 
-**Recommendations:**
+> **0.3.0 decision:** prefetch intrinsics are owned by VectorIndex
+> (`VectorIndex/Sources/VectorIndex/Operations/Support/Prefetch.swift`, real builtins). Core's
+> `prefetchRead/Write` remain no-ops by design; this is **not** a Core deliverable.
+
+**Recommendations (for the owning package, VectorIndex):**
 - [ ] Add `__builtin_prefetch` wrappers via C interop
 - [ ] Experiment with prefetch distance (1-3 cache lines ahead)
 - [ ] Measure impact on different batch sizes
@@ -398,28 +447,38 @@ Current kernels primarily use SIMD4. Larger SIMD widths might benefit some opera
 
 ## 5. Quantization System
 
-### 5.1 Product Quantization (PQ) Support
+### 5.1 Product Quantization (PQ) Support → **REDIRECTED to VectorIndex (0.3.0)**
 
 **File:** `Sources/VectorCore/Quantization/QuantizationSchemes.swift`
-**Priority:** High
+**Priority:** High → **Redirected (not Core backlog)**
 **Impact:** Memory, Performance (VectorIndex integration)
 
-Currently only INT8 quantization. Product quantization is essential for billion-scale search.
+Currently only scalar INT8 quantization (already shipped in Core). Product quantization is
+essential for billion-scale search.
 
-**Recommendations:**
+> **0.3.0 decision:** PQ and ADC look-up tables are owned by VectorIndex
+> (`VectorIndex/Sources/VectorIndex/Operations/Quantization/{ADCScan,PQLUT}.swift`). PQ/ADC are
+> index-topology-coupled and are **not** Core deliverables. Core keeps the topology-agnostic
+> scalar INT8 path only.
+
+**Recommendations (for the owning package, VectorIndex):**
 - [ ] Implement PQ encoding with configurable subspace count (typically 8-32)
 - [ ] Add PQ codebook training (k-means on subspaces)
 - [ ] Implement asymmetric distance computation (ADC) for PQ
 - [ ] Consider OPQ (Optimized Product Quantization) for better accuracy
 
-### 5.2 Binary Quantization
+### 5.2 Binary Quantization → **REDIRECTED to VectorAccelerate (0.3.0)**
 
-**Priority:** Medium
+**Priority:** Medium → **Redirected (not Core backlog)**
 **Impact:** Memory, Performance
 
 1-bit quantization for extreme memory efficiency.
 
-**Recommendations:**
+> **0.3.0 decision:** binary-packed vectors and Hamming/Jaccard are redirected to
+> VectorAccelerate (GPU versions already exist there); there is **no committed CPU consumer**, so
+> Core does not ship a packed binary type. Confirmed not in Core 0.3.0.
+
+**Recommendations (for the owning package, VectorAccelerate):**
 - [ ] Implement sign-based binary quantization
 - [ ] Add popcount-based Hamming distance
 - [ ] Document accuracy trade-offs
@@ -649,17 +708,24 @@ No native async support for batch operations.
 - [ ] Add progress reporting via `AsyncSequence`
 - [ ] Support cancellation
 
-### 9.2 Matrix Distance Computation
+### 9.2 Matrix Distance Computation → ✅ **SHIPPED 0.3.0**
 
-**Priority:** Medium
+**Priority:** Medium → **IMPLEMENTED**
 **Impact:** Performance (VectorIndex)
 
-Computing pairwise distances requires nested loops.
+Computing pairwise distances previously required nested loops.
 
-**Recommendations:**
-- [ ] Add `distanceMatrix(queries:candidates:)` returning 2D array
-- [ ] Implement using blocked matrix algorithms
-- [ ] Consider Metal acceleration for large matrices (VectorAccelerate hook)
+**Solution Implemented (0.3.0):**
+Shipped `MatrixDistance` (`Sources/VectorCore/Operations/MatrixDistance.swift`) — a CPU GEMM
+batch-distance path using Accelerate `cblas_sgemm` (→ AMX on Apple Silicon):
+`euclideanSquaredMatrix` / `cosineDistanceMatrix` with `into:` / allocating / `prepared:`
+overloads, `prepare(_:normalized:)`, and `PreparedCandidates`. `BatchOperations` routes
+`pairwiseDistances` and `Operations.findNearestBatch` through it via
+`Configuration.enableMatrixRouting` (default `true`) above `matrixRoutingMinN` (default `256`).
+
+- [x] Add `distanceMatrix(queries:candidates:)` ✅ (as `euclideanSquaredMatrix` / `cosineDistanceMatrix`)
+- [x] Implement using blocked matrix algorithms ✅ (`cblas_sgemm` → AMX)
+- [~] Metal acceleration for large matrices — provided via the `BatchKernelProvider` seam (VectorAccelerate hook), not in Core
 
 ### 9.3 ✅ Top-K Selection Kernel
 
@@ -700,9 +766,9 @@ Created public `TopKSelection` API with:
       ids: UnsafePointer<Int32>?  // Optional custom ID array
   ) -> (indices: [Int32], distances: [Float])
   ```
-- [ ] **Configurable tie-breaking** - Deterministic behavior for reproducibility:
+- [x] **Configurable tie-breaking** - Deterministic behavior for reproducibility ✅ **shipped 0.3.0** (`TieBreaker` in `Sources/VectorCore/Operations/TopKSelection.swift`; `.smallerIndex` is the default):
   ```swift
-  public enum TieBreaker { case insertionOrder, smallerIndex, smallerValue }
+  public enum TieBreaker { case smallerIndex /* default */, insertionOrder, smallerValue }
   ```
 
 ### 9.4 Batch Normalization
@@ -735,14 +801,20 @@ Frequent allocations in hot paths can cause memory pressure.
 - [ ] Implement pool size limits and eviction
 - [ ] Profile allocation patterns in VectorIndex workloads
 
-### 10.2 Memory-Mapped Vector Storage
+### 10.2 Memory-Mapped Vector Storage → **REDIRECTED to VectorIndex (0.3.0)**
 
-**Priority:** Medium
+**Priority:** Medium → **Redirected (not Core backlog)**
 **Impact:** Scalability (VectorIndex)
 
 Large vector collections don't fit in RAM.
 
-**Recommendations:**
+> **0.3.0 decision:** `mmap` storage is owned by VectorIndex
+> (`VectorIndex/Sources/VectorIndex/Kernels/VIndexMmap.swift`, real/WIP). It is persistence- and
+> index-coupled, so it is **not** a Core deliverable. Core's contribution is the zero-copy
+> page-aligned buffer contract (`PageAlignedBuffer` / frozen `SoALayout`) that an mmap backend
+> can build on.
+
+**Recommendations (for the owning package, VectorIndex):**
 - [ ] Add `MMapStorage` backend for vectors
 - [ ] Implement lazy loading with LRU cache
 - [ ] Support append-only growth for indexing
@@ -802,18 +874,27 @@ Created Integration module with protocols and types for VectorIndex:
 - VectorCore provides brute-force fallback
 - Clear ownership: VectorCore owns vectors, VectorIndex owns indices
 
-### 11.2 VectorAccelerate Metal Hooks
+### 11.2 VectorAccelerate Metal Hooks → ✅ **SHIPPED 0.3.0**
 
-**Priority:** High
+**Priority:** High → **IMPLEMENTED**
 **Impact:** Performance
 
-Prepare integration points for GPU acceleration.
+Integration points for GPU acceleration.
 
-**Recommendations:**
-- [ ] Add `ComputeProvider` protocol abstraction
-- [ ] Define Metal buffer compatibility requirements
-- [ ] Create shared types for CPU↔GPU data transfer
-- [ ] Add fallback mechanism when Metal unavailable
+**Solution Implemented (0.3.0):**
+- [x] `ComputeProvider` protocol abstraction ✅ — `BatchKernelProvider` (a `ComputeProvider`
+  sub-protocol) in `Sources/VectorCore/Protocols/BatchKernelProvider.swift`; enables transparent
+  GPU dispatch from `Operations.findNearest` / `findNearestBatch`.
+- [x] Define Metal buffer compatibility requirements ✅ — `UnifiedVectorBuffer` protocol +
+  `PageAlignedBuffer` (`Sources/VectorCore/Storage/UnifiedVectorBuffer.swift`): page-aligned
+  storage valid for `MTLDevice.makeBuffer(bytesNoCopy:)`.
+- [x] Create shared types for CPU↔GPU data transfer ✅ — frozen `SoALayout` descriptor + SoA
+  layout contract (`Sources/VectorCore/Storage/SoALayout.swift`, `Docs/SoA_Layout_Contract.md`),
+  plus SoA page-alignment APIs (`SoA.build(from:pageAligned:)`, `init(vectors:pageAligned:)`,
+  `pageAlignedBytes`, `consumeAllocation()`, `withUnsafeRawBuffer`) and
+  `PlatformConfiguration.roundUpToPage(_:)`.
+- [~] Add fallback mechanism when Metal unavailable — routing falls back to the CPU
+  `MatrixDistance` / kernel path when no `BatchKernelProvider` is installed.
 
 ### 11.3 EmbedKit Type Compatibility
 
@@ -931,26 +1012,26 @@ No record of design decisions.
 
 | Priority | Items | Rationale |
 |----------|-------|-----------|
-| **P0 - Critical** | ~~Dim384 Support~~ ✅, 4.1, 5.1, 9.1, ~~9.3~~ ✅, ~~11.1~~ ✅, 11.2 | Direct impact on EmbedKit/VectorIndex/VectorAccelerate |
-| **P1 - High** | ~~2.1~~ ✅, 3.1, ~~8.1~~ ✅, 12.1, Dim1024 Support, **9.3-Pointer API**, **2.2-Batch Protocol** | Performance or API quality |
-| **P2 - Medium** | 1.1, 1.4, 3.2, 4.2, 4.3, 4.4, 5.2, 5.3, 5.4, 7.2, 9.2, 9.4, 10.1, 10.2, 11.3, 12.2, 12.3, 13.1, 13.2, **4.2-Raw Buffer Normalize**, **9.3-TieBreaker** | Important but not blocking |
-| **P3 - Low** | 1.2, 1.3, 2.3, 2.4, 3.3, 3.4, 4.5, 6.1, 6.2, 6.3, 7.1, 7.3, 8.2, 8.3, 8.4, 10.3, 12.4, 13.3 | Nice to have |
+| **P0 - Critical** | ~~Dim384 Support~~ ✅, 4.1, ~~5.1~~ → VectorIndex, 9.1, ~~9.3~~ ✅, ~~11.1~~ ✅, ~~11.2~~ ✅ 0.3.0 | Direct impact on EmbedKit/VectorIndex/VectorAccelerate |
+| **P1 - High** | ~~2.1~~ ✅, 3.1, ~~8.1~~ ✅, 12.1, Dim1024 Support, **~~9.3-Pointer API~~ ✅**, **~~2.2-Batch Protocol~~ ✅ 0.3.0** | Performance or API quality |
+| **P2 - Medium** | ~~1.1~~ deferred (Q8_0), 1.4, 3.2, 4.2, 4.3, ~~4.4~~ → VectorIndex, ~~5.2~~ → VectorAccelerate, 5.3, 5.4, 7.2, ~~9.2~~ ✅ 0.3.0, 9.4, 10.1, ~~10.2~~ → VectorIndex, 11.3, 12.2, 12.3, 13.1, 13.2, **~~4.2-Raw Buffer Normalize~~ ✅ 0.3.0**, **~~9.3-TieBreaker~~ ✅ 0.3.0** | Important but not blocking |
+| **P3 - Low** | 1.2 → VectorAccelerate, ~~1.3~~ → VectorIndex, 2.3, 2.4, 3.3, 3.4, 4.5, 6.1, 6.2, 6.3, 7.1, 7.3, 8.2, 8.3, 8.4, 10.3, 12.4, 13.3 | Nice to have |
 
 ### Downstream Package Requests
 
 **VectorIndex** (documented in `VectorIndex/IMPROVEMENTS.md` Section 9.5):
 
-| Request | Section | Priority | Rationale |
-|---------|---------|----------|-----------|
-| Pointer-based TopK API | 9.3 | P1 | Zero-copy from GPU/mmap buffers |
-| Raw buffer normalization | 4.2 | P2 | Mmap/GPU buffer compatibility |
-| Configurable tie-breaking | 9.3 | P2 | Reproducibility in tests/benchmarks |
+| Request | Section | Priority | Rationale | Status |
+|---------|---------|----------|-----------|--------|
+| Pointer-based TopK API | 9.3 | P1 | Zero-copy from GPU/mmap buffers | ✅ v0.2.0 |
+| Raw buffer normalization | 4.2 | P2 | Mmap/GPU buffer compatibility | ✅ 0.3.0 |
+| Configurable tie-breaking | 9.3 | P2 | Reproducibility in tests/benchmarks | ✅ 0.3.0 (`TieBreaker`) |
 
 **VectorAccelerate** (analysis of integration patterns):
 
-| Request | Section | Priority | Rationale |
-|---------|---------|----------|-----------|
-| Batch distance protocol | 2.2 | P1 | Enables GPU-optimized batch operations via protocol dispatch |
+| Request | Section | Priority | Rationale | Status |
+|---------|---------|----------|-----------|--------|
+| Batch distance protocol | 2.2 | P1 | Enables GPU-optimized batch operations via protocol dispatch | ✅ 0.3.0 (`BatchKernelProvider`) |
 
 **Note:** Other VectorAccelerate suggestions were either already implemented in VectorCore (`withUnsafeBufferPointer`, `StaticDimension.value`, `VectorError`) or belong in VectorAccelerate's layer (GPU buffer protocols, acceleration providers). See analysis in VectorAccelerate agent prompt.
 
@@ -967,18 +1048,31 @@ No record of design decisions.
 
 ### v0.2.0 (API Enhancements)
 - [x] **Pointer-based TopK API** (VectorIndex request) - Zero-copy from GPU/mmap ✅ v0.2.0
-- [ ] **Batch distance protocol** (VectorAccelerate request) - GPU-optimized batch ops
-- [ ] **Raw buffer normalization** (VectorIndex request) - Mmap compatibility
-- [ ] **Configurable tie-breaking** (VectorIndex request) - Reproducibility
+- [x] **Batch distance protocol** (VectorAccelerate request) - GPU-optimized batch ops ✅ **0.3.0** (`BatchKernelProvider`)
+- [x] **Raw buffer normalization** (VectorIndex request) - Mmap compatibility ✅ **0.3.0**
+- [x] **Configurable tie-breaking** (VectorIndex request) - Reproducibility ✅ **0.3.0** (`TieBreaker`)
 - [ ] Resolve all 🔒 marked API changes
-- [ ] Complete remaining P0 items (4.1, 5.1, 9.1, 11.2)
+- [ ] Complete remaining P0 items (4.1, 9.1) — 5.1 redirected to VectorIndex; 11.2 ✅ shipped 0.3.0
 - [ ] Add Dim1024 optimized vector type (E5-large models)
 - [ ] Finalize protocol designs
 
-### v0.3.0 (Performance)
+### v0.3.0 — "Hold the line, sharpen the seams" (released 2026-06-07)
+
+**Shipped:**
+- [x] **CPU/AMX GEMM batch distance** — `MatrixDistance` (§9.2, §2.2)
+- [x] **Configurable tie-breaking** — `TieBreaker` (§9.3)
+- [x] **Provider seam** — `BatchKernelProvider` (§11.2)
+- [x] **Zero-copy buffer contract** — `UnifiedVectorBuffer` / `PageAlignedBuffer` + frozen `SoALayout` (§11.2)
+- [x] **SoA page-alignment APIs** + transparent matrix routing (`BatchOperations.Configuration.enableMatrixRouting` / `matrixRoutingMinN`)
+- [x] **⚠️ BREAKING:** removed no-op `blockSize:` from `SoA.init(vectors:…)` and `SoAFP16.init(vectors:…)`
+
+**Deferred / redirected:**
+- [ ] Block-wise quantization (`Q8_0`) — **deferred** (specced, consumer-gated; see DOCUMENT-3)
+- [→] `mmap` storage, prefetch, PQ/ADC → **VectorIndex**; binary-packed + Hamming → **VectorAccelerate**; sparse CSR → **deferred** (no producer)
+
+**Still open (carried forward):**
 - [ ] P1 kernel optimizations (3.1, 12.1 remaining)
-- [ ] Batch operation improvements
-- [ ] Memory management enhancements
+- [ ] Memory management enhancements (10.1, 10.3)
 
 ### v1.0.0 (Stable Release)
 - [ ] All P0-P2 items resolved
@@ -988,4 +1082,4 @@ No record of design decisions.
 
 ---
 
-*Last updated: November 2025*
+*Last updated: 2026-06-07 (0.3.0 reconciliation)*

--- a/Docs/SoA_Layout_Contract.md
+++ b/Docs/SoA_Layout_Contract.md
@@ -1,0 +1,238 @@
+# SoA Memory-Layout Contract
+
+**Status:** 🔒 **Frozen — stable as of VectorCore 0.3.0.**
+**Audience:** Any consumer that reads `SoA<Vector>` memory directly — primarily
+**VectorAccelerate** Metal kernels indexing a zero-copy `MTLBuffer` built from
+`SoA.pageAlignedBytes` / `SoA.consumeAllocation()`.
+**Programmatic source of truth:** `SoALayout` (`Sources/VectorCore/Storage/SoALayout.swift`),
+reachable as `SoA.layoutDescriptor` (live instance) or `SoALayout.forType(_:count:)` (ahead of allocation).
+
+> **What "frozen" means.** The element type, the index formula, and the lane stride
+> described here will not change without a major-version bump and advance notice to
+> downstream consumers. The contract is regression-locked by
+> `Tests/ComprehensiveTests/SoALayoutContractTests.swift` — if those tests change, this
+> document and the consumers must change with them.
+
+---
+
+## 1. The layout
+
+`SoA<Vector>` stores `count` candidate vectors **lane-major, then candidate index**:
+
+```
+element(lane ℓ, candidate j)  ==  buffer[ℓ * count + j]
+```
+
+- **Element type:** `SIMD4<Float>` — 4 contiguous dimensions, **16 bytes**
+  (`MemoryLayout<SIMD4<Float>>.stride == 16`).
+- **Lanes per vector:** `lanes = dimension / 4`. Exact for every supported type — see §4 —
+  so there are **no partial / tail lanes**. Every lane is a full `SIMD4<Float>`.
+- **Lane stride:** consecutive lanes are `count` elements apart, i.e.
+  `laneStrideBytes = count * 16`. This confirms VA's assumption exactly
+  (`count * MemoryLayout<SIMD4<Float>>.stride`).
+- **The candidate axis (`count`, "N") is never padded.** `count` *is* the stride between
+  lanes. There is no block padding of N to any multiple — see §3 for the one subtlety
+  (whole-buffer page rounding, which is **not** candidate-axis padding).
+
+Both producer and consumer inside VectorCore already agree on this single formula: the
+builder writes `buffer[i * count + j]` (`SoA.build(from:)`) and the hot CPU kernel reads
+`lanePointer(i)[j] = buffer[i * count + j]` (`BatchKernels_SoA`). Freezing it here changes
+nothing at runtime; it only publishes what is already true.
+
+### Byte-offset form (for a shader)
+
+```
+byteOffset(lane ℓ, candidate j)  ==  (ℓ * count + j) * 16
+```
+
+A Metal kernel indexing the candidate buffer as `device const float4*` reads candidate `j`'s
+lane `ℓ` at `buffer[ℓ * count + j]`. Pull `count` and `lanes` from the descriptor (§2); do
+**not** hardcode them and do **not** derive `count` from the buffer's byte length (§3).
+
+---
+
+## 2. The descriptor — `SoALayout`
+
+Derive constants from this type, not from magic numbers, so producer and consumer share one
+source of truth.
+
+| Member | Meaning | Formula |
+|---|---|---|
+| `lanes` | SIMD4 lanes per vector | `dimension / 4` |
+| `count` | candidate count **N** (the true stride) | — |
+| `elementStrideBytes` (static) | size of one element | `16` |
+| `laneStrideBytes` | bytes between consecutive lanes | `count * 16` |
+| `logicalByteCount` | bytes of real data | `lanes * count * 16` |
+| `allocatedByteCount` | bytes the allocation occupies | page-rounded (§3) |
+| `elementCount` | logical elements | `lanes * count` |
+| `elementIndex(lane:candidate:)` | the frozen index formula | `lane * count + candidate` |
+
+Obtain it two ways, which are guaranteed equal for the same `(type, count, pageAligned)`:
+
+```swift
+// From a live SoA:
+let layout = soa.layoutDescriptor
+
+// Ahead of allocation (e.g. to size a buffer or precompute shader constants):
+let layout = SoALayout.forType(Vector768Optimized.self, count: n, pageAligned: true)
+```
+
+> Page-alignment is **opt-in everywhere**: `forType`, `SoA.build`, and `SoA.init` all default
+> `pageAligned: false`. A GPU consumer sizing a zero-copy buffer must pass `pageAligned: true`
+> to `forType` so its `allocatedByteCount` matches a `build(from:pageAligned: true)` SoA. The
+> `lanes`, `count`, `laneStrideBytes`, and `logicalByteCount` are identical either way — only
+> `allocatedByteCount` (the `makeBuffer` length) depends on the flag.
+
+---
+
+## 3. Allocated vs. logical bytes — the one sharp edge
+
+For a **page-aligned** SoA, `MTLDevice.makeBuffer(bytesNoCopy:)` on macOS requires the
+*length* to be a page multiple, so the **whole buffer** is rounded up:
+
+```
+allocatedByteCount == roundUpToPage(logicalByteCount)   ≥   logicalByteCount
+```
+
+The trailing `allocatedByteCount - logicalByteCount` bytes are **zero-filled slack** beyond
+the data. This rounding is applied once, to the end of the entire buffer — it does **not**
+pad the candidate axis and does **not** change the lane stride.
+
+- **Pass `allocatedByteCount`** as the `length:` to `makeBuffer(bytesNoCopy:)`.
+- **Bound your kernel by `lanes` and `count`** from the descriptor. The valid indexed region
+  is exactly `[0, lanes * count)` elements.
+- 🚫 **Never reverse-engineer `count` from `allocatedByteCount`.** It is page-inflated:
+  e.g. at 512-dim, N=5 ⇒ `logicalByteCount = 10240`, but `allocatedByteCount = 16384`
+  (16 KB page). `16384 / (128 * 16) = 8 ≠ 5`. Take N from `count`.
+
+For a **non-page-aligned** SoA, `allocatedByteCount == logicalByteCount` and
+`pageAlignedBytes` is `nil` (there is no zero-copy pointer to offer).
+
+---
+
+## 4. `SoACompatible` coverage
+
+The zero-copy SoA path requires a **static** dimension/lane count, so it applies to the
+fixed-dimension optimized vector types — **not** `DynamicVector`:
+
+| Type | `dimension` | `lanes` | SoACompatible |
+|---|---|---|---|
+| `Vector384Optimized` | 384 | 96 | ✅ |
+| `Vector512Optimized` | 512 | 128 | ✅ |
+| `Vector768Optimized` | 768 | 192 | ✅ |
+| `Vector1536Optimized` | 1536 | 384 | ✅ |
+| `DynamicVector` | runtime | — | ❌ (no static `lanes`) |
+
+The two dimensions VA specifically asked about — **768 and 1536 — are both supported.**
+`DynamicVector` stays on the staged (copy) path by design.
+
+> Scope note: this contract covers the **FP32** `SoA<Vector>`. The separate `SoAFP16`
+> mixed-precision cache is an internal type and is *not* part of this zero-copy bridge
+> contract.
+
+---
+
+## 5. Lifetime & deallocation contract
+
+The page-aligned buffer is Core-owned memory. Two supported modes:
+
+### Borrow mode (recommended when the SoA outlives the buffer)
+Hold a strong reference to the `SoA` and read `pageAlignedBytes` **without consuming**:
+
+```swift
+guard let (base, byteCount) = soa.pageAlignedBytes else { /* not page-aligned */ }
+let mtlBuffer = device.makeBuffer(bytesNoCopy: UnsafeMutableRawPointer(mutating: base),
+                                  length: byteCount, options: .storageModeShared,
+                                  deallocator: nil)   // SoA frees on deinit
+```
+
+**Object lifetime is the sole validity guarantee** for the pointer: the `SoA` frees the
+memory on `deinit`, so it **must outlive** the `MTLBuffer`.
+
+### Transfer mode (hand ownership to Metal)
+Call `consumeAllocation()` to take ownership, then free from the Metal deallocator:
+
+```swift
+guard let (base, byteCount) = soa.consumeAllocation() else { /* not page-aligned */ }
+let mtlBuffer = device.makeBuffer(bytesNoCopy: base, length: byteCount,
+                                  options: .storageModeShared) { ptr, _ in
+    AlignedMemory.deallocate(ptr)   // ≡ free(ptr); see below
+}
+```
+
+- **The deallocator must call `AlignedMemory.deallocate(base)`**, which is exactly
+  `free(base)` — the buffer comes from `posix_memalign`, which is freed with `free`.
+  (`free(base)` directly is equivalent.)
+- **It is safe to free on an arbitrary thread** at `MTLBuffer`-release time — `free` is
+  thread-safe.
+- After `consumeAllocation()`, the `SoA` no longer frees on `deinit` and `pageAlignedBytes`
+  returns `nil`; do not use the `SoA` for CPU compute afterward.
+
+🚫 **Do not** mix modes (consume *and* rely on deinit) — that double-frees.
+
+---
+
+## 6. Golden parity fixture
+
+A small, fully reproducible fixture to validate a downstream shader against VectorCore's CPU
+kernel. Values below are regression-locked in `SoALayoutContractTests.swift`.
+
+**Construction** (512-dim, N = 5):
+
+```
+query     q   = [1, 1, …, 1]              (512 dims)
+candidate c_k = [1+k, 1+k, …, 1+k]        (512 dims), k = 0 … 4
+```
+
+Since `q − c_k = [−k, …]` over 512 dims, the Euclidean **squared** distance is `512 · k²`.
+
+**Expected outputs** (`BatchKernels_SoA.euclid2_512`, squared distance):
+
+| k | candidate value | ‖q − c_k‖² |
+|---|---|---|
+| 0 | 1.0 | 0 |
+| 1 | 2.0 | 512 |
+| 2 | 3.0 | 2048 |
+| 3 | 4.0 | 4608 |
+| 4 | 5.0 | 8192 |
+
+**Descriptor for this fixture** — all values are **host-invariant** except `allocatedByteCount`:
+
+| field | value | host-invariant? |
+|---|---|---|
+| `lanes` | 128 | ✅ |
+| `count` | 5 | ✅ |
+| `elementStrideBytes` | 16 | ✅ |
+| `laneStrideBytes` | 80 | ✅ |
+| `logicalByteCount` | 10240 | ✅ |
+| `allocatedByteCount` | 16384 (16 KB page) / 12288 (4 KB page) | ❌ depends on `getpagesize()` |
+| `elementIndex(lane: 1, candidate: 0)` | 5 | ✅ |
+| `elementIndex(lane: 127, candidate: 4)` | 639 | ✅ |
+
+> `allocatedByteCount` is `roundUpToPage(10240)` — **16384** on Apple Silicon (16 KB pages,
+> the VA target) but **12288** on a 4 KB-page host (most x86). It is the only value here that
+> varies by platform; always read it from the live descriptor and never hardcode it. Every
+> other value — the entire indexing core — is identical on every platform.
+
+**Buffer spot-check:** candidate `j` is the constant `1+j`, so for every lane `ℓ`,
+`buffer[ℓ * 5 + j] == SIMD4<Float>(repeating: Float(1 + j))`.
+
+---
+
+## 7. Notes & change policy
+
+- **`blockSize` removed (0.3.0).** The former `SoA.init(vectors:blockSize:pageAligned:)`
+  `blockSize` parameter was a **no-op** and was removed to eliminate any implication of
+  candidate-axis padding. (The only real block size is an internal CPU-kernel compute-tiling
+  constant that has no effect on this layout.)
+- **Breaking change = major bump + notice.** Any change to the index formula, element type,
+  or stride is breaking. The frozen tests are the tripwire.
+- **R4 / transparent dispatch is orthogonal to this contract.** The
+  `BatchKernelProvider` hook (`Sources/VectorCore/Protocols/BatchKernelProvider.swift`,
+  dispatched from `Operations.findNearest` / `Operations.findNearestBatch`) lets an installed
+  GPU provider service Core's k-NN entry points. It is independent of buffer layout; see
+  `Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md` (R4).
+
+### Related documents
+- `Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md` — R1/R2/R4 (page-align + accessor + dispatch).
+- `Docs/beta-evolution-4/DOCUMENT-6_Page_Alignment_Feasibility.md` — why batches (not per-vector) are page-aligned; the `PageBridgeable` option (not required for an SoA-only consumer).

--- a/Docs/beta-evolution-4/DOCUMENT-1_Redirections.md
+++ b/Docs/beta-evolution-4/DOCUMENT-1_Redirections.md
@@ -1,0 +1,161 @@
+# DOCUMENT-1 — Redirections & Deferrals
+
+This document records, for every proposal item that VectorCore will **not** implement, *why*
+and *where it lives instead*. The goal is that a future contributor (or the external agent) can
+see exactly which package owns each capability and what — if anything — Core exposes to support
+it. Each redirect cites a confirmed file in a sibling repo.
+
+Two harms motivate redirection over duplication:
+
+- **Format divergence.** A capability like `mmap` storage or ADC look-up tables has a binary
+  layout. Two implementations drift, and downstream files written by one cannot be read by the
+  other.
+- **Double maintenance.** Every numerical fix (the kind the `0.2.2` BE3 audit just did) would
+  have to be made twice, in two repos, forever.
+
+---
+
+## REDIRECT
+
+### R1 — `mmap` / out-of-core storage (proposal Task 3.1) → `VectorIndex`
+
+**Already owned.** `VectorIndex/Sources/VectorIndex/Kernels/VIndexMmap.swift` implements a real
+on-disk format: 256-byte header + TOC with CRC32, typed section accessors (centroids, codebooks,
+IDs, codes, vectors, norms), a write-ahead log with begin/commit/replay, and `msync` with
+acquire/release ordering for lock-free readers. Magic `VINDEX\0\0`.
+
+**Why not Core.** The format is index-shaped: it serializes IVF lists, PQ codes, and graph
+metadata — concepts Core deliberately does not know about (`Docs/Package_Boundaries.md` assigns
+durable formats out of Core). A second `MMapVectorStorage` in Core would be a *different* file
+format competing with the one downstream already reads.
+
+**What Core provides instead.** The zero-copy/page-alignment *contract* (DOCUMENT-4, S5): Core
+guarantees page-aligned, contiguous raw-pointer views so that whoever owns the mmap (VectorIndex
+today, a future `VectorStore`) can map a file region into a Core vector view without copying.
+
+---
+
+### R2 — Pinned Metal arena / ring buffer (proposal Task 3.2) → `VectorAccelerate`
+
+**Already owned.** `VectorAccelerate/Sources/VectorAccelerate/Core/BufferPool.swift` is a
+token-based ring-buffer pool with power-of-2 bucketing and `keepAlive(until:)` lifecycle
+anchoring; `Core/MetalBufferFactory.swift` selects `MTLStorageModeShared` on unified-memory
+devices for zero-copy CPU↔GPU.
+
+**Why not Core.** The proposal explicitly frames this arena as existing "so VectorAccelerate can
+stream query vectors to the GPU" — i.e. it is *defined by* its GPU consumer. Putting a
+Metal-aware arena in Core would force a Metal dependency and break Core's "zero GPU
+dependencies" guarantee for one consumer's benefit.
+
+**What Core provides instead.** A `BufferManagementProvider` protocol (DOCUMENT-4, S4) so Core
+code can request/return buffers through an abstraction that `VectorAccelerate` backs with its
+pinned Metal pool — the seam, not the implementation.
+
+---
+
+### R3 — ADC look-up tables (proposal Task 4.1) → `VectorIndex`
+
+**Already owned.** `VectorIndex/Sources/VectorIndex/Operations/Quantization/PQLUT.swift` builds
+the query LUT and `ADCScan.swift` performs asymmetric distance computation; `PQEncode.swift`
+(u8 ks=256, u4 ks=16 packed) and `PQTrain.swift` complete the PQ pipeline.
+
+**Why not Core.** ADC only has meaning relative to a trained PQ codebook and an IVF list layout
+— both of which are index concerns. `Docs/Package_Boundaries.md` already lists Product
+Quantization as deferred-to-VectorIndex. The proposal's "ADC generator in Core" would need to
+reach into index structures Core does not (and should not) model.
+
+**Note on the errata.** The proposal's "zero floating-point drift" requirement for LUT
+summation is unattainable; VectorIndex's implementation already accumulates with the
+`‖x−c‖² = ‖x‖² + ‖c‖² − 2⟨x,c⟩` dot-trick. If accumulation precision becomes a concern, the fix
+(pairwise/Kahan summation) belongs in `ADCScan.swift`, not a new Core type.
+
+---
+
+### R4 — Generation-count visited list (proposal Task 4.2) → `VectorIndex`
+
+**Already owned.** `VectorIndex/Sources/VectorIndex/Kernels/HNSWTraversal.swift` tracks visited
+nodes with a `UInt64`-word bitset (`visitedTestAndSet`), reset per search. This is a graph-
+traversal primitive with no meaning outside an adjacency structure.
+
+**Why not Core.** Core has no graph, no node IDs, and no traversal — a visited-list here would be
+a type with no caller. (The generation-counter variant the proposal describes is a valid
+*alternative* to per-search bitset reset; if VectorIndex wants it, it is a local optimization in
+`HNSWTraversal.swift`.)
+
+---
+
+### R5 — Concurrent / bounded priority queue (proposal Task 4.3) → `VectorIndex`
+
+**Already owned.** `VectorIndex/Sources/VectorIndex/Operations/Selection/TopK.swift` provides
+`TopKHeap` (fixed-capacity, 64-byte-aligned SoA, used under actor isolation) plus `TopKMerge`
+for batch results.
+
+**Why not Core.** Core's `TopKBuffer`
+(`Sources/VectorCore/Operations/Kernels/TopKSelectionKernels.swift`) already serves single-
+threaded selection. A *concurrent* queue is needed only during multi-threaded HNSW graph
+*building* — a VectorIndex activity. Per the errata, the proposal's "lock-free via os_unfair_lock"
+is self-contradictory; any real concurrent queue should use `swift-atomics` and live with its
+caller.
+
+**What Core provides instead.** A pointer-level Top-K entry point (DOCUMENT-4, S1) so VectorIndex
+can stop maintaining a second heap purely to avoid Core's allocation overhead.
+
+---
+
+### R6 — Prefetch intrinsics (proposal Task 1.3) → `VectorIndex`
+
+**Already owned (where it matters).** `VectorIndex/Sources/VectorIndex/Operations/Support/Prefetch.swift`
+wraps real prefetch builtins and applies them during HNSW neighbor gathering — the exact
+random-pointer-chasing workload the proposal cites.
+
+**Why low-value in Core.** Core's batch kernels are *sequential* over contiguous SoA storage,
+where the hardware prefetcher already wins; Core's current `prefetchRead/Write`
+(`Sources/VectorCore/Optimization/OptimizationAttributes.swift`) are no-op pointer dereferences
+precisely because there is little to gain. The benefit lives in graph traversal, which is
+downstream. If Core ever needs a *real* `__builtin_prefetch`, the home is the existing
+`VectorCoreC` shim — but there is no Core caller today, so this stays deferred.
+
+---
+
+## DEFER
+
+### D1 — Binary packed vectors + Hamming/Jaccard (proposal Task 1.2)
+
+**Sound, but no committed CPU consumer.** GPU Hamming/Jaccard already exist in
+`VectorAccelerate`. Core's `HammingDistance`
+(`Sources/VectorCore/Operations/DistanceMetrics.swift`) operates on *float* vectors via
+threshold, not packed bits — so a real `UInt64`-packed `BinaryVector` with `nonzeroBitCount`
+Hamming and a correct Jaccard *is* a genuine gap.
+
+**Why defer, not accept.** Binary screening pays off inside an index's candidate-generation
+stage (USearch-style), which is VectorIndex territory, and VectorIndex has not requested it.
+Accept it the moment VectorIndex or EmbedKit commits to a binary-screening path; the design is
+small (packed storage + two popcount kernels) and can be lifted from this note directly.
+
+### D2 — Sparse CSR vectors + SparseBLAS (proposal Task 2.2)
+
+**Sound, but no producer.** Hybrid dense+sparse (SPLADE/BM25) search is real and valuable, but
+**no package in the suite produces sparse embeddings today** — EmbedKit emits dense `[Float]`
+only, and lists hybrid search as a *P2 roadmap* item
+(`EmbedKit/dev_EKRefactor/Future_Improvements.md`). A `SparseVector` in Core would be an
+unexercised type.
+
+**Why defer, not accept.** This is a strategic expansion of the whole suite's mission (into
+keyword/lexical retrieval), not a Core-local gap. It should be driven top-down from an EmbedKit
+SPLADE model + a VectorIndex hybrid index, with Core's CSR type added last to serve them. Revisit
+when EmbedKit schedules SPLADE.
+
+---
+
+## Summary
+
+| Item | Verdict | Owner / trigger |
+|---|---|---|
+| mmap storage | Redirect | `VectorIndex/.../VIndexMmap.swift` |
+| Pinned Metal arena | Redirect | `VectorAccelerate/.../BufferPool.swift` |
+| ADC look-up tables | Redirect | `VectorIndex/.../{ADCScan,PQLUT}.swift` |
+| Visited list | Redirect | `VectorIndex/.../HNSWTraversal.swift` |
+| Concurrent priority queue | Redirect | `VectorIndex/.../TopK.swift` |
+| Prefetch | Redirect | `VectorIndex/.../Prefetch.swift` |
+| Binary vectors + Hamming/Jaccard | Defer | Trigger: VectorIndex/EmbedKit binary-screening commitment |
+| Sparse CSR + SparseBLAS | Defer | Trigger: EmbedKit SPLADE + VectorIndex hybrid index |

--- a/Docs/beta-evolution-4/DOCUMENT-2_Spec_GEMM_Batch_Distance.md
+++ b/Docs/beta-evolution-4/DOCUMENT-2_Spec_GEMM_Batch_Distance.md
@@ -15,11 +15,20 @@ before any distance is consumed. 7 parity/edge tests (`MatrixDistanceTests.swift
 direct `EuclideanKernels`/double-precision cosine within tolerance, `x==y` clamps to 0, all three
 optimized dims + `DynamicVector`, empty no-op.
 
-**Deferred to follow-ups** (kept out of this slice to stay focused):
-- Internal routing: wiring the GEMM path into `BatchOperations.findNearest` / `pairwiseDistances`
-  behind the crossover heuristic (`AutoTuning`) — the standalone `MatrixDistance` entry is public
-  now so `VectorIndex` can call it directly.
-- Crossover calibration benchmark (`MatrixDistanceBench`) to measure the `q×n×d` threshold.
+**Routing implemented.** `BatchOperations.pairwiseDistances` now routes to the GEMM path for
+optimized types (512/768/1536) + Euclidean/Cosine when `N ≥ matrixRoutingMinN` (default 256),
+gated by `Configuration.enableMatrixRouting` (default on; flip off to force the exact per-pair
+path). 5 parity tests (`BatchGEMMRoutingTests.swift`) confirm routed ≈ per-pair within tolerance,
+non-routable inputs (Manhattan, `DynamicVector`) fall back, and routing on/off agree. Full suite
+(1048 tests) green with routing on by default.
+
+**Crossover calibration implemented.** `MatrixDistanceBench` (opt-in: `--suites matrix`) measures
+GEMM ns/pair across N × dim. Initial dim-512 sweep: 142 ns/pair @ N=64 → 102 @ N=256 → 94 @
+N=1024 — the curve flattens by N≈256, validating the `matrixRoutingMinN = 256` default.
+
+**Still deferred** (further increments):
+- `findNearest` / `findNearestBatch` routing (multi-query GEMM); the public `MatrixDistance`
+  entry already lets `VectorIndex` do this directly today.
 - Allocation gate: the packing temporaries (`X`, `Y`, norms) still allocate; a scratch-buffer
   overload would be needed for `mallocCountTotal == 0`.
 

--- a/Docs/beta-evolution-4/DOCUMENT-2_Spec_GEMM_Batch_Distance.md
+++ b/Docs/beta-evolution-4/DOCUMENT-2_Spec_GEMM_Batch_Distance.md
@@ -1,0 +1,139 @@
+# DOCUMENT-2 — Design Spec: CPU GEMM Batch-Distance (AMX)
+
+**Verdict:** Accept for `0.3.0`. Highest throughput ROI of the accepted set.
+**Scope:** CPU-only. The GPU GEMM path already exists in `VectorAccelerate`; this spec is the
+missing *CPU* path that routes to the Apple AMX coprocessor via Accelerate BLAS.
+
+---
+
+## 1. Motivation
+
+`BatchOperations.findNearest` / `pairwiseDistances`
+(`Sources/VectorCore/Operations/BatchOperations.swift`) currently compute batched Euclidean and
+cosine distances with hand-tuned SoA kernels that evaluate each query–candidate pair directly
+(`Operations/Kernels/BatchKernels.swift`, `BatchKernels_SoA.swift`). These are excellent for
+small/medium batches but leave the matrix coprocessor idle.
+
+For large batches the standard reformulation turns the whole problem into one matrix multiply:
+
+```
+‖x − y‖² = ‖x‖² + ‖y‖² − 2·⟨x, y⟩
+```
+
+Stacking queries as `X (q × d)` and candidates as `Y (n × d)`, the cross-term `X·Yᵀ (q × n)` is
+a single GEMM. Accelerate's `cblas_sgemm` dispatches to **AMX on Apple Silicon**, so this is the
+documented, supported route to coprocessor throughput — no private intrinsics.
+
+This is exactly how Faiss computes its L2 distance matrices.
+
+---
+
+## 2. API surface
+
+Additive only — existing kernels remain the small-batch fast path.
+
+```swift
+public enum MatrixDistance {
+
+    /// Squared-Euclidean distance matrix via GEMM. Result is row-major (q × n):
+    /// out[i*n + j] = ‖queries[i] − candidates[j]‖², clamped at 0.
+    public static func euclideanSquaredMatrix(
+        queries: [Vector512Optimized],     // + 768 / 1536 overloads
+        candidates: [Vector512Optimized],
+        into out: inout [Float]            // caller-owned, count == q*n
+    )
+
+    /// Cosine *distance* matrix (1 − cosine similarity) via GEMM on L2-normalized inputs.
+    public static func cosineDistanceMatrix(
+        queries: [Vector512Optimized],
+        candidates: [Vector512Optimized],
+        into out: inout [Float]
+    )
+}
+```
+
+`BatchOperations.findNearest` and `pairwiseDistances` gain an **internal** GEMM path selected by
+the crossover heuristic (§5); their public signatures do not change. The standalone
+`MatrixDistance` entry is public so `VectorIndex` (IVF centroid assignment) can call it directly
+without the Top-K wrapper.
+
+**Why `into out:`** — the result matrix dominates allocation cost (`q*n` floats). A caller-owned
+buffer keeps the hot path allocation-free and satisfies the malloc-gate (§6).
+
+---
+
+## 3. Algorithm
+
+For each dimension family (512/768/1536), reusing the existing
+`public var storage: ContiguousArray<SIMD4<Float>>`:
+
+1. **Pack** `X` and `Y` into contiguous row-major `[Float]` (`q×d`, `n×d`). The optimized
+   storage is already contiguous `SIMD4<Float>` — reinterpret via `withUnsafeBufferPointer` +
+   `withMemoryRebound(to: Float.self)`; no per-element copy beyond the row gather.
+2. **Norms.** Precompute `‖xᵢ‖²` and `‖yⱼ‖²` with `vDSP_svesq` (already used in
+   `Platform/AccelerateSIMDProvider.swift`). Candidate norms are cacheable across queries.
+3. **GEMM.** `cblas_sgemm(RowMajor, NoTrans, Trans, q, n, d, -2.0, X, d, Y, d, 0.0, out, n)`
+   → `out = −2·X·Yᵀ`.
+4. **Norm assembly.** `out[i*n + j] += ‖xᵢ‖² + ‖yⱼ‖²` (vectorized via `vDSP_vsadd` per row).
+5. **Clamp.** `out = max(out, 0)` with `vDSP_vthr` (see §4).
+6. Euclidean (non-squared) defers `sqrt` to the consumer / Top-K stage; cosine path normalizes
+   inputs first so the cross-term *is* the similarity.
+
+---
+
+## 4. Numerical contract
+
+- **Cancellation → clamp.** `‖x‖² + ‖y‖² − 2⟨x,y⟩` is catastrophic cancellation when `x ≈ y`:
+  the true value ≈ 0 but rounding yields a small **negative** number. Unclamped, `sqrt`
+  produces `NaN`. The spec mandates a clamp at 0 (step 5) and documents that distances below
+  ~`√(ε·‖x‖²)` are not reliable in absolute terms (they round to 0) — acceptable for
+  nearest-neighbor ranking where such pairs are the trivial top match.
+- **Accumulation.** BLAS accumulates the dot-product in the coprocessor; we do not promise
+  bit-exact agreement with the SoA kernel. The contract is **`|gemm − soa| < 1e-4` relative**
+  for normalized embedding magnitudes (consistent with the existing FP16 parity bound).
+- This corrects the proposal's "zero drift" wording (see master §5): the contract is *bounded*,
+  not zero.
+
+---
+
+## 5. Crossover heuristic
+
+GEMM wins only when the `O(q·n·d)` multiply amortizes packing + BLAS setup. Extend
+`Providers/AutoTuning.swift` (`ParallelHeuristic`) with a matrix branch:
+
+- Route to `MatrixDistance` when `q ≥ Q_MIN && n ≥ N_MIN` (initial guess `Q_MIN≈8`,
+  `N_MIN≈256`); else keep the candidate-tiled SoA kernel.
+- Thresholds are **measured, not guessed**: a crossover benchmark (below) sweeps `q × n × d`
+  and picks the breakeven per dimension family. Mirrors how `VectorAccelerate/GPUDecisionEngine.swift`
+  calibrates its CPU/GPU crossover.
+
+---
+
+## 6. Validation
+
+1. **Epsilon-parity test.** Identically seeded `X`, `Y`; assert
+   `abs(euclideanSquaredMatrix − soaKernel) < 1e-4` element-wise (512/768/1536). This is the
+   cross-implementation parity test the original ecosystem doc (Finding 3) asked for, applied
+   *within* Core between the GEMM and SoA paths.
+2. **Cancellation test.** `X == Y` rows must yield exactly `0.0` (clamped), never `NaN`/negative.
+3. **Allocation gate.** A benchmark asserting `mallocCountTotal == 0` inside the GEMM matrix
+   call given a caller-owned `out`. Core has **zero external dependencies today**; adding the
+   `ordo-one/package-benchmark` plugin is a deliberate dependency decision — alternatively the
+   existing `VectorCoreBench` executable can host a lightweight allocation counter. *Decision
+   point flagged for implementation: adopt package-benchmark vs. extend the in-house harness.*
+4. **Crossover benchmark.** New `MatrixDistanceBench` suite (alongside `BatchBench`) sweeping
+   `q ∈ {1,8,64}`, `n ∈ {64,256,1k,10k}`, `d ∈ {512,768,1536}`; emits the threshold table feeding §5.
+
+---
+
+## 7. Reuse / touch-points
+
+| Reuse | Path |
+|---|---|
+| Optimized storage (`ContiguousArray<SIMD4<Float>>`) | `Vectors/Vector{512,768,1536}Optimized.swift` |
+| `vDSP_svesq`, `vDSP_vsadd`, vDSP threshold | `Platform/AccelerateSIMDProvider.swift` |
+| Existing batch entry points (internal routing) | `Operations/BatchOperations.swift` |
+| Small-batch fast path (unchanged) | `Operations/Kernels/BatchKernels*.swift` |
+| Crossover heuristic extension | `Providers/AutoTuning.swift` |
+
+**No new public vector types. No GPU. No new external dependency** (modulo the §6.3 decision).

--- a/Docs/beta-evolution-4/DOCUMENT-2_Spec_GEMM_Batch_Distance.md
+++ b/Docs/beta-evolution-4/DOCUMENT-2_Spec_GEMM_Batch_Distance.md
@@ -33,10 +33,18 @@ seams. 3 parity tests (`BatchKNNGEMMTests.swift`) confirm it matches the per-que
 (nearest index exact, distances within tolerance) and that small batches fall back. Full
 correctness suite (`VECTORCORE_TEST_EXTENDED=0`): 1051 tests green.
 
+**Reusable candidate packing implemented.** `MatrixDistance.prepare(candidates:normalized:)`
+returns a `PreparedCandidates` (packed rows + precomputed norms / normalized rows) that the
+`euclideanSquaredMatrix(queries:prepared:into:)` and `cosineDistanceMatrix(queries:prepared:into:)`
+overloads reuse across many query batches — eliminating the repeated re-packing/re-norming of the
+large candidate side in repeated search (the VectorIndex hot loop). The one-shot
+`queries:candidates:` overloads now delegate to this path (bit-identical; verified). 3 parity/reuse
+tests. Full correctness suite: 1054 tests green.
+
 **Still deferred** (further increments):
 - Single-query `findNearest` GEMM (low value: q=1 is gemv; the optimized kernel + heap already wins).
-- Allocation gate: the packing temporaries (`X`, `Y`, norms) still allocate; a scratch-buffer
-  overload would be needed for `mallocCountTotal == 0`.
+- Full zero-alloc: the per-call query packing (`X`, query norms) and `out` reshape still allocate;
+  a query-side scratch overload would be needed for `mallocCountTotal == 0` on the steady state.
 
 ---
 

--- a/Docs/beta-evolution-4/DOCUMENT-2_Spec_GEMM_Batch_Distance.md
+++ b/Docs/beta-evolution-4/DOCUMENT-2_Spec_GEMM_Batch_Distance.md
@@ -26,9 +26,15 @@ non-routable inputs (Manhattan, `DynamicVector`) fall back, and routing on/off a
 GEMM ns/pair across N × dim. Initial dim-512 sweep: 142 ns/pair @ N=64 → 102 @ N=256 → 94 @
 N=1024 — the curve flattens by N≈256, validating the `matrixRoutingMinN = 256` default.
 
+**Batch k-NN routing implemented.** `Operations.findNearestBatch` now routes large multi-query
+searches (q ≥ 8, n ≥ 256, optimized types, Euclidean/Cosine) through one GEMM matrix followed by
+per-row pointer Top-K (S1) with deterministic tie-breaking (S3) — composing DOCUMENT-2 + the S1/S3
+seams. 3 parity tests (`BatchKNNGEMMTests.swift`) confirm it matches the per-query reference
+(nearest index exact, distances within tolerance) and that small batches fall back. Full
+correctness suite (`VECTORCORE_TEST_EXTENDED=0`): 1051 tests green.
+
 **Still deferred** (further increments):
-- `findNearest` / `findNearestBatch` routing (multi-query GEMM); the public `MatrixDistance`
-  entry already lets `VectorIndex` do this directly today.
+- Single-query `findNearest` GEMM (low value: q=1 is gemv; the optimized kernel + heap already wins).
 - Allocation gate: the packing temporaries (`X`, `Y`, norms) still allocate; a scratch-buffer
   overload would be needed for `mallocCountTotal == 0`.
 

--- a/Docs/beta-evolution-4/DOCUMENT-2_Spec_GEMM_Batch_Distance.md
+++ b/Docs/beta-evolution-4/DOCUMENT-2_Spec_GEMM_Batch_Distance.md
@@ -4,6 +4,25 @@
 **Scope:** CPU-only. The GPU GEMM path already exists in `VectorAccelerate`; this spec is the
 missing *CPU* path that routes to the Apple AMX coprocessor via Accelerate BLAS.
 
+## Implementation status (updated 2026-06-06)
+
+**Core implemented + tested.** `Sources/VectorCore/Operations/MatrixDistance.swift` ships
+`MatrixDistance.euclideanSquaredMatrix` and `cosineDistanceMatrix` (both `into:` hot-path and
+allocating overloads), written **generically over `UnifiedVectorBuffer`** (the S5 protocol) so a
+single implementation serves 512/768/1536 and `DynamicVector`. Uses `cblas_sgemm` (AMX on Apple
+Silicon) for the `−2·X·Yᵀ` cross term, `vDSP_svesq` for norms, and the cancellation **clamp at 0**
+before any distance is consumed. 7 parity/edge tests (`MatrixDistanceTests.swift`): GEMM vs the
+direct `EuclideanKernels`/double-precision cosine within tolerance, `x==y` clamps to 0, all three
+optimized dims + `DynamicVector`, empty no-op.
+
+**Deferred to follow-ups** (kept out of this slice to stay focused):
+- Internal routing: wiring the GEMM path into `BatchOperations.findNearest` / `pairwiseDistances`
+  behind the crossover heuristic (`AutoTuning`) — the standalone `MatrixDistance` entry is public
+  now so `VectorIndex` can call it directly.
+- Crossover calibration benchmark (`MatrixDistanceBench`) to measure the `q×n×d` threshold.
+- Allocation gate: the packing temporaries (`X`, `Y`, norms) still allocate; a scratch-buffer
+  overload would be needed for `mallocCountTotal == 0`.
+
 ---
 
 ## 1. Motivation

--- a/Docs/beta-evolution-4/DOCUMENT-3_Spec_Block_Quantization.md
+++ b/Docs/beta-evolution-4/DOCUMENT-3_Spec_Block_Quantization.md
@@ -1,0 +1,120 @@
+# DOCUMENT-3 — Design Spec: Block-Wise Quantization (`Q8_0`)
+
+**Verdict:** Accept for `0.3.0` — **gated on a committed consumer** (see §6).
+**Scope:** A new CPU storage *format* and its dot-product kernel. Sits alongside the existing
+whole-vector quantization in `Sources/VectorCore/Quantization/QuantizationSchemes.swift` and
+`Operations/Kernels/QuantizedKernels.swift`.
+
+---
+
+## 1. Motivation
+
+Today's INT8 quantization (`LinearQuantizationParams`) derives **one** scale (and zero-point)
+for the entire vector. Modern LLM embeddings contain *outlier features* — a few dimensions with
+activations far larger than the rest. A whole-vector scale is set by the outlier, so the
+remaining ~99% of dimensions collapse into a handful of quantization levels and lose resolution.
+
+GGML's fix, `Q8_0`, is **block-wise**: split the vector into fixed blocks and give each block its
+own scale. An outlier corrupts only its own 32-element block.
+
+---
+
+## 2. Format (`Q8_0`, correctly specified)
+
+- **Block size:** 32 elements (GGML's `QK8_0`). A 512-dim vector → 16 blocks; 768 → 24; 1536 → 48.
+- **Per block:** one `Float16` **scale** `d`, plus 32 × `Int8` quantized values `q`.
+  Reconstruction: `xᵢ ≈ d · qᵢ`.
+- **Symmetric, scale-only.** `Q8_0` stores *no* offset/min. (The proposal's "scale *and* offset
+  per block" is `Q8_1`, which adds a per-block min for asymmetric ranges — noted as a future
+  variant, not the `0.3.0` target. See master §5.)
+- **Quantization:** per block, `d = max(|xᵢ|) / 127`; `qᵢ = round(xᵢ / d)` clamped to
+  `[−127, 127]` (127, not 128, keeps it symmetric).
+
+```swift
+public struct Vector512Q8_0: Sendable {            // + 768 / 1536 variants
+    // 16 blocks × (1 Float16 scale + 32 Int8 values)
+    public var scales: ContiguousArray<Float16>     // count = 16
+    public var codes:  ContiguousArray<Int8>        // count = 512
+}
+```
+
+Storage: `512·1 + 16·2 = 544` bytes vs `512·4 = 2048` for FP32 → **~3.76×** compression,
+materially better fidelity than whole-vector INT8 at the same size.
+
+---
+
+## 3. Dot-product kernel
+
+Block-local accumulation, FP32 reduction:
+
+```
+acc_f32 = 0
+for each block b:
+    acc_i32 = Σ over 32 lanes of  Int32(qA[i]) * Int32(qB[i])     // SIMD widening multiply
+    acc_f32 += Float(acc_i32) * Float(scaleA[b]) * Float(scaleB[b])
+return acc_f32
+```
+
+- Integer products accumulate in `Int32` *within* a block (max magnitude `32·127·127 ≈ 5.2e5`,
+  safely inside `Int32`) — this avoids the `Int16` overflow class of bug fixed in the `0.2.2`
+  BE3 audit for whole-vector INT8 (`QuantizedKernels.swift`).
+- The block scale is applied once per block in FP32, so different blocks' scales never mix in
+  integer space.
+- Euclidean follows from the dot identity (`‖a−b‖²` expanded), or a direct per-block squared-
+  difference kernel; cosine reuses the dot plus stored norms.
+
+Hardware: ARM64 NEON `vmull`/`vdot` and x86 AVX2 `vpmaddubsw`-style widening live in the existing
+`VectorCoreC` shim (`Sources/VectorCoreC/arm64/vc_arm64.c`, `x86_64/vc_x86.c`) — the same place
+the current INT8 dot (`vc_dot_int8`) already lives. The Swift kernel provides a portable fallback.
+
+---
+
+## 4. Numerical contract
+
+- **Quantization error per block:** `|xᵢ − d·qᵢ| ≤ d/2 = max(|x|_block)/254`. Bounded by the
+  block's own dynamic range, not the vector's global outlier — the entire point.
+- **Dot-product error:** bounded; accumulation is exact in `Int32` within a block, and the
+  cross-block FP32 sum is ordered (optionally Kahan if a parity test shows drift). No "zero
+  drift" claim (master §5).
+- **Parity test target:** for outlier-free vectors, `Q8_0` dot vs FP32 dot within the empirical
+  INT8 bound; for vectors with injected outliers, `Q8_0` must beat whole-vector INT8 on
+  reconstruction MSE (this is the test that *justifies* the format).
+
+---
+
+## 5. Validation
+
+1. **Reconstruction MSE test:** synthetic embeddings with planted outlier dimensions; assert
+   `MSE(Q8_0) < MSE(wholeVectorINT8)` by a meaningful margin.
+2. **Overflow test:** worst-case all-`±127` blocks must not overflow `Int32` accumulation.
+3. **Round-trip test:** quantize → dequantize within the per-block bound.
+4. **Kernel parity:** Swift fallback vs `VectorCoreC` NEON/AVX path agree to integer-exact.
+5. **Allocation gate:** quantize/dot over preallocated buffers with `mallocCountTotal == 0`
+   (same harness decision as DOCUMENT-2 §6.3).
+
+---
+
+## 6. Consumer gate (blocking condition)
+
+A storage format is dead weight without a producer and a consumer. **This spec does not ship
+until one of the following commits:**
+
+- **EmbedKit** stores embeddings as `Q8_0` (it already has a quantization layer with INT8/INT4/
+  FP16/binary — `EmbedKit/Sources/EmbedKit/Optimization/Quantization.swift` — but per-vector;
+  `Q8_0` would be an additive format with better outlier behavior), **or**
+- **VectorIndex** adopts `Q8_0` as a raw-vector code path (distinct from its existing PQ codes).
+
+Until then, `Q8_0` remains specified-but-unbuilt. **Action for implementation:** confirm a
+consumer before scheduling; if none commits this cycle, this document moves to the same "Defer"
+status as binary/sparse in DOCUMENT-1, with the design preserved here for immediate pickup.
+
+---
+
+## 7. Reuse / touch-points
+
+| Reuse | Path |
+|---|---|
+| Existing quant params / schemes | `Quantization/QuantizationSchemes.swift` |
+| Existing INT8 kernels + overflow lessons | `Operations/Kernels/QuantizedKernels.swift` |
+| C SIMD shim (NEON/AVX) | `Sources/VectorCoreC/{arm64,x86_64}/` (`vc_dot_int8` neighbor) |
+| Float16 storage support | `Operations/Kernels/MixedPrecisionKernels.swift` |

--- a/Docs/beta-evolution-4/DOCUMENT-4_S4_Provider_Conformance.md
+++ b/Docs/beta-evolution-4/DOCUMENT-4_S4_Provider_Conformance.md
@@ -1,0 +1,118 @@
+# DOCUMENT-4 / S4 — Provider Conformance Contract
+
+**Status:** Implemented (contract + conformance tests) for `0.3.0`.
+**Audience:** Anyone conforming a type to VectorCore's provider protocols — primarily
+`VectorAccelerate` (`ComputeEngine: ComputeProvider`, `BufferPool: BufferProvider`,
+`MetalContext: AccelerationProvider`, per its `VECTORCORE_ALIGNMENT_ROADMAP.md`).
+
+The three protocols already exist in Core (`Protocols/ComputeProvider.swift`,
+`Protocols/BufferProvider.swift`, `Protocols/CoreProtocols.swift`). S4 does **not** add
+protocols — it pins the *semantic laws* a conformer must satisfy and ships an executable
+conformance suite (`Tests/ComprehensiveTests/ProviderConformanceTests.swift`) that validates
+Core's own conformers and minimal mocks. Downstream packages should mirror that suite against
+their conformers.
+
+A type that compiles against a protocol is not the same as a *correct* conformer. The laws
+below are the difference.
+
+---
+
+## `ComputeProvider`
+
+A strategy for executing work (CPU, GPU, Neural). Conformers must satisfy:
+
+- **C1 — execute fidelity.** `execute { x }` returns `x`; a thrown error propagates unchanged.
+- **C2 — parallelExecute order & completeness.** `parallelExecute(items:work:)` returns an
+  array of length `items.count` where `result[j] == work(items.lowerBound + j)`. Results are in
+  **index order regardless of completion order** — a conformer that returns results in the order
+  tasks finished is non-conformant. Each index's `work` is invoked exactly once.
+- **C3 — parallelForEach completeness.** `body` is invoked **exactly once per item** — no index
+  skipped, none duplicated.
+- **C4 — parallelReduce partition.** `rangeWork` is invoked on a set of disjoint sub-ranges
+  whose union is exactly `items` (or the whole range once). The result is the fold of the
+  partial results with `combine`, seeded by `initial`.
+- **C5 — reduce algebra (caller + conformer contract).** The caller MUST supply a `combine`
+  that is **associative and commutative**, and an `initial` that is the **identity element**
+  for `combine` (e.g. `0` for `+`, `[]` for concat, an empty `TopKBuffer` for a top-k merge).
+  Under this contract the result is deterministic for any chunking. *Conformer note:* because
+  `initial` is the identity, a conformer may fold it once, many times, or omit it in a
+  single-chunk fast path — all are equivalent. (Core's `CPUComputeProvider` omits it on the
+  sequential path; this is conformant precisely because `initial` is the identity. A conformer
+  that wants to be robust to misuse may fold `initial` uniformly.)
+- **C6 — empty range.** `parallelExecute → []`; `parallelForEach → ` no `body` calls;
+  `parallelReduce → initial`.
+- **C7 — metadata sanity.** `maxConcurrency ≥ 1`, `deviceInfo.maxThreads ≥ 1`,
+  `deviceInfo.preferredChunkSize ≥ 1`.
+- **C8 — error propagation.** A throw from any `work`/`body`/`rangeWork` propagates out of the
+  call. No rollback is promised: side effects already performed by other items may persist.
+
+*GPU conformer guidance.* A provider may dispatch `execute`/`parallel*` to the GPU, but the
+observable semantics above are mandatory. In particular, batching many items into one GPU
+dispatch is fine **only if** results are returned in index order (C2).
+
+---
+
+## `BufferProvider`
+
+Managed, poolable memory. Conformers must satisfy:
+
+- **B1 — size.** `acquire(size:)` returns a handle whose backing buffer is **at least** `size`
+  bytes (`handle.size` may report the requested size; the allocation is ≥ that).
+- **B2 — alignment.** `handle.pointer` is aligned to `alignment`, and `alignment` is a power of
+  two ≥ 1. (Core's default is 64.)
+- **B3 — writability.** The first `size` bytes are writable and read back what was written.
+- **B4 — non-aliasing while active.** Two buffers that are simultaneously *active* (acquired,
+  not yet released) never overlap; their handle ids and pointers differ. After `release`, the
+  memory may be reused by a later `acquire`.
+- **B5 — release contract.** `release` returns the buffer to the pool; its contents are
+  undefined afterward and its pointer must not be used.
+- **B6 — clear keeps active handles valid.** `clear()` frees *cached* (released) buffers only;
+  buffers still active remain valid.
+- **B7 — statistics sanity.** Counters are non-negative; `hitRate ∈ [0, 1]`.
+
+*GPU integration caveat (stability finding).* `BufferHandle.pointer` is a **CPU-addressable**
+`UnsafeMutableRawPointer`. This maps cleanly onto Metal `.shared` storage on unified memory
+(`MTLBuffer.contents()` yields such a pointer). It does **not** map onto GPU-*private* buffers,
+which have no CPU pointer — `BufferProvider` is not the right seam for those, and VectorAccelerate
+should expose private-storage buffers through a separate, Metal-typed API rather than forcing
+them through `BufferHandle`.
+
+---
+
+## `AccelerationProvider`
+
+Hardware acceleration with a provider-specific `Config` (a PAT; `init(configuration:) async throws`).
+Conformers must satisfy:
+
+- **A1 — isSupported purity.** `isSupported(for:)` is deterministic and side-effect free.
+- **A2 — correctness parity (the critical law).** For a supported operation, `accelerate`
+  returns a value of the **same type** as `input` whose value matches the CPU reference within a
+  documented tolerance (`|accelerated − reference| < ε`, e.g. `1e-4` for FP32 distance — see
+  DOCUMENT-2 and the ecosystem doc's "Finding 3"). An accelerator that is fast but wrong is
+  non-conformant.
+- **A3 — unsupported throws.** `accelerate` for an unsupported operation **throws** rather than
+  returning an incorrect or silently-CPU result; callers gate on `isSupported` first.
+- **A4 — init is all-or-nothing.** `init(configuration:)` returns a ready provider or throws
+  (e.g. hardware unavailable). No half-initialized state.
+
+*Parity is VA's responsibility to test against its own kernels* — Core cannot run Metal. The
+conformance suite validates A1/A3/A4 and type-preservation with a mock; A2 (numerical parity)
+must be asserted in VectorAccelerate using identically-seeded inputs versus a Core reference.
+
+---
+
+## Conformance suite
+
+`Tests/ComprehensiveTests/ProviderConformanceTests.swift` provides reusable checkers —
+`checkComputeProvider`, `checkBufferProvider`, `checkAccelerationProvider` — and runs them
+against:
+
+- `CPUComputeProvider` in `.sequential`, `.parallel`, and `.automatic` modes;
+- the protocol **default** implementations (via `MockComputeProvider`, which implements only
+  `execute` and inherits the rest) — so VA can rely on the defaults;
+- `SwiftBufferPool` and a `MockBufferProvider`;
+- a `MockAccelerator` for A1/A3/A4 + type preservation.
+
+Downstream packages should copy these checkers and run them against their own conformers
+(`ComputeEngine`, `BufferPool`, `MetalContext`), adding the A2 numerical-parity assertion that
+only they can run.

--- a/Docs/beta-evolution-4/DOCUMENT-4_Spec_Ecosystem_Seams.md
+++ b/Docs/beta-evolution-4/DOCUMENT-4_Spec_Ecosystem_Seams.md
@@ -19,14 +19,14 @@ spec below describes the intended surface; this table is the accurate state:
 
 | Seam | Status | Notes |
 |---|---|---|
-| **S1** pointer Top-K | ✅ Already implemented | `TopKSelection.select(k:from:UnsafePointer<Float>,count:,ids:)` exists (`Operations/TopKSelection.swift`), returns `[Int32]` with `ids` remap |
-| **S2** in-place normalize | ✅ Already implemented | `NormalizeKernels.normalizeUnchecked(_:dimension:)` (public, Kahan two-pass, inherits BE3 stability fixes) |
+| **S1** pointer Top-K | ✅ Already implemented + regression-locked | `TopKSelection.select(k:from:UnsafePointer<Float>,count:,ids:)` exists (`Operations/TopKSelection.swift`), returns `[Int32]` with `ids` remap. 6 regression tests pin parity/ids/sorting/edge cases/both paths |
+| **S2** in-place normalize | ✅ Already implemented + regression-locked | `NormalizeKernels.normalizeUnchecked(_:dimension:)` (public, Kahan two-pass, inherits BE3 stability fixes; requires 16-byte-aligned buffer). 5 regression tests pin unit-norm/typed-parity/tails/overflow/subnormal |
 | **S3** tie-breaking | ✅ Implemented this cycle | `TieBreaker` enum (`smallerIndex` default / `insertionOrder` / `smallerValue`) threaded through array, pointer, generic, and optimized paths; array path unified onto `TopKBuffer` so boundary membership *and* result order are deterministic. 7 tests |
 | **S4** provider protocols | ◻️ Open | `ComputeProvider`/`BufferProvider`/`AccelerationProvider` already exist; conformance contract + tests not written |
 | **S5** zero-copy contract | ✅ Implemented this cycle | `UnifiedVectorBuffer` + `PageAlignedBuffer` (`Storage/UnifiedVectorBuffer.swift`): page-aligned/page-length, ownership transfer, optimized + dynamic conformances, 8 tests |
 
-Remaining open work: S4's conformance contract + tests (medium). S1/S2 need only regression tests
-to lock the behavior VectorIndex depends on.
+Remaining open work: **S4's conformance contract + tests** (medium). S1/S2 are now
+regression-locked (11 tests) and S3/S5 are implemented — only S4 remains to complete DOCUMENT-4.
 
 ---
 

--- a/Docs/beta-evolution-4/DOCUMENT-4_Spec_Ecosystem_Seams.md
+++ b/Docs/beta-evolution-4/DOCUMENT-4_Spec_Ecosystem_Seams.md
@@ -1,0 +1,165 @@
+# DOCUMENT-4 — Design Spec: Ecosystem Seams
+
+**Verdict:** Accept for `0.3.0`. **Highest leverage, lowest cost** of the entire suite.
+**Scope:** Thin, additive API seams that the downstream packages have *explicitly requested* and
+that `VectorIndex` is currently working around by bypassing Core. None of this is in the external
+proposal; all of it is in the downstream repos' own request lists.
+
+> **Why this matters more than the math.** `VectorIndex/IMPROVEMENTS.md` documents that it
+> "intentionally bypasses most of VectorCore's type-safe abstractions for performance, using raw
+> `[Float]` arrays and `UnsafePointer<Float>` throughout." Every seam below removes a reason to
+> bypass Core. The win is ecosystem cohesion — the suite converging *onto* Core instead of
+> routing *around* it.
+
+---
+
+## S1 — Pointer-level Top-K selection
+
+**Requested:** `VectorIndex/IMPROVEMENTS.md` §9.5 (item 1), costing 15–20% per hot-path call to
+array bridging today.
+
+**Today:** `Operations/TopKSelection.swift` exposes `select(k:from: [Float])` and typed overloads
+— all array-based. Wrapping a raw distance buffer in `[Float]`/`DynamicVector` to call them costs
+two allocations.
+
+**Add (additive overload):**
+```swift
+public extension TopKSelection {
+    static func select(
+        k: Int,
+        from distances: UnsafePointer<Float>,
+        count: Int,
+        ids: UnsafePointer<Int32>? = nil,
+        tieBreaker: TieBreaker = .smallerIndex      // see S3
+    ) -> TopKResult
+}
+```
+Reuses the existing `TopKBuffer` heap (`Operations/Kernels/TopKSelectionKernels.swift`) — only
+the entry point changes. Zero allocation given caller-owned buffers.
+
+---
+
+## S2 — In-place raw-buffer normalize
+
+**Requested:** `VectorIndex/IMPROVEMENTS.md` §9.5 (item 2). Core's existing
+`normalizedUnchecked()` (`Vectors/Vector512Optimized.swift:231` et al.) returns a *new value* and
+only accepts `VectorProtocol` types; VectorIndex must wrap raw buffers in `DynamicVector` (two
+allocations) to use it.
+
+**Add:**
+```swift
+public extension Operations {
+    /// L2-normalize a raw buffer in place. Precondition-checked, allocation-free.
+    static func normalizeUnchecked(
+        _ buffer: UnsafeMutablePointer<Float>,
+        dimension: Int
+    )
+}
+```
+Implementation reuses `NormalizeKernels` (`Operations/Kernels/NormalizeKernels.swift`) operating
+directly on the pointer. Inherits the `0.2.2` BE3 normalization fixes (subnormal-reciprocal
+guard, `Float.leastNormalMagnitude` floor) — which is precisely why this should live in Core once
+rather than be re-derived in VectorIndex.
+
+---
+
+## S3 — Configurable tie-breaking
+
+**Requested:** `VectorIndex/IMPROVEMENTS.md` §9.5 (item 3). VectorIndex needs deterministic
+`smallerIndex` tie-breaking; Core's Top-K currently fixes a single policy.
+
+**Add:**
+```swift
+public enum TieBreaker: Sendable {
+    case insertionOrder   // current behavior (default preserved for source compat)
+    case smallerIndex     // VectorIndex's required deterministic order
+    case smallerValue
+}
+```
+Threaded through `TopKSelection.select(...)` and `TopKBuffer.pushIfBetter`. Default stays
+`insertionOrder` so existing callers are unaffected; VectorIndex opts into `smallerIndex`.
+
+---
+
+## S4 — Stabilize provider protocols (they already exist)
+
+**Requested:** `VectorAccelerate/docs/ADD/VECTORCORE_ALIGNMENT_ROADMAP.md` — VA "implements 2 of
+7+ available protocols" and wants to conform to three more.
+
+**Key finding:** the protocols VA names — `ComputeProvider`, `BufferProvider`,
+`AccelerationProvider` — **already exist in Core** (`Protocols/ComputeProvider.swift`,
+`Protocols/BufferProvider.swift`, `Protocols/CoreProtocols.swift`). This is **not a "define new
+protocols" task.** The seam work is:
+
+1. **API-stability review** of those three protocols against VA's intended conformances
+   (`ComputeEngine: ComputeProvider`, `BufferPool: BufferProvider`,
+   `MetalContext: AccelerationProvider` per the roadmap), so VA can implement without Core
+   churning the signatures underneath it.
+2. **Fill capability gaps** the roadmap surfaces (e.g. `BufferProvider` must reconcile with VA's
+   `BufferToken`/`BufferHandle` lifecycle; `AccelerationProvider` capability-query hooks).
+3. **A conformance-contract doc + protocol-level tests** in Core so a downstream conformance is
+   verifiably "correct," not best-effort.
+
+**Explicitly not in scope:** Core implementing any of these with GPU code. Core owns the
+*protocol*; VA owns the Metal-backed conformance. This is the boundary that keeps "zero GPU
+dependencies" intact while still unblocking VA.
+
+---
+
+## S5 — Zero-copy buffer contract
+
+**Requested (implicitly, by all three):** EmbedKit lists "zero-copy pipelines" as a P1
+(`EmbedKit/dev_EKRefactor/Future_Improvements.md`); its current path copies
+`MLMultiArray → [Float] → DynamicVector`. VectorAccelerate consumes via
+`MTLStorageModeShared`/`makeBuffer(bytesNoCopy:)`. The original ecosystem note's "Finding 1"
+(cross-package bridging penalty) is the same problem.
+
+**Add — a contract, not a subsystem.** Core already guarantees aligned allocation
+(`Storage/AlignedMemory.swift`, `posix_memalign`, 64-byte default; `Docs/Memory_Alignment.md`).
+The seam is a documented, page-alignable raw view:
+```swift
+public protocol UnifiedVectorBuffer {
+    /// Contiguous, alignment-guaranteed base for the vector's elements.
+    func withUnsafeContiguousBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
+    var elementCount: Int { get }
+    var alignment: Int { get }            // ≥ 64; page-aligned variant for bytesNoCopy
+}
+```
+- Optimized vector types and a page-aligned allocator variant conform.
+- **No Metal/IOSurface import in Core.** Core guarantees alignment + contiguity; `VectorAccelerate`
+  calls `makeBuffer(bytesNoCopy:)` on the exposed pointer on *its* side; `EmbedKit` writes
+  CoreML output into a Core-provided aligned buffer once and hands the pointer downstream.
+- `makeBuffer(bytesNoCopy:)` requires **page-aligned base and length** — so the contract
+  specifies an opt-in page-aligned (16 KB on Apple Silicon) allocation path beyond the default
+  64-byte SIMD alignment. This is the concrete, CPU-only deliverable that satisfies the
+  proposal's zero-copy "UnifiedVectorBuffer" idea without pulling GPU types into Core.
+
+---
+
+## Validation
+
+1. **Allocation gates:** S1/S2 over caller-owned buffers assert `mallocCountTotal == 0`
+   (harness decision per DOCUMENT-2 §6.3).
+2. **Parity:** pointer-level `select` (S1) vs array `select` produce identical `TopKResult`;
+   in-place normalize (S2) vs `normalizedUnchecked()` agree within `1e-6`.
+3. **Tie-break determinism (S3):** seeded equal-distance inputs yield the policy-specified order.
+4. **Protocol conformance tests (S4):** Core ships a test a downstream provider can run to prove
+   correct conformance; validate against a mock provider in Core's own suite.
+5. **Alignment contract (S5):** page-aligned path returns base & length both `% pageSize == 0`;
+   round-trip a buffer through the contract and assert pointer identity (no copy).
+
+---
+
+## Sequencing note
+
+S1–S3 are tiny and unblock VectorIndex immediately — ship first in `0.3.0`. S4 is a review +
+hardening pass (no new types). S5 is the largest (new allocation path + protocol) but is the one
+that pays off the whole-suite "Finding 1" bridging penalty, so it anchors the release.
+
+| Seam | Requested by | Existing Core surface | New surface |
+|---|---|---|---|
+| S1 pointer Top-K | VectorIndex §9.5 | `TopKSelection.select`, `TopKBuffer` | 1 overload |
+| S2 in-place normalize | VectorIndex §9.5 | `NormalizeKernels`, `normalizedUnchecked()` | 1 function |
+| S3 tie-breaking | VectorIndex §9.5 | `TopKBuffer.pushIfBetter` | 1 enum + param |
+| S4 provider protocols | VectorAccelerate roadmap | `ComputeProvider`, `BufferProvider`, `AccelerationProvider` (exist) | stability review + tests |
+| S5 zero-copy contract | EmbedKit P1 / Finding 1 | `AlignedMemory`, `Docs/Memory_Alignment.md` | `UnifiedVectorBuffer` + page-aligned path |

--- a/Docs/beta-evolution-4/DOCUMENT-4_Spec_Ecosystem_Seams.md
+++ b/Docs/beta-evolution-4/DOCUMENT-4_Spec_Ecosystem_Seams.md
@@ -22,11 +22,13 @@ spec below describes the intended surface; this table is the accurate state:
 | **S1** pointer Top-K | ✅ Already implemented + regression-locked | `TopKSelection.select(k:from:UnsafePointer<Float>,count:,ids:)` exists (`Operations/TopKSelection.swift`), returns `[Int32]` with `ids` remap. 6 regression tests pin parity/ids/sorting/edge cases/both paths |
 | **S2** in-place normalize | ✅ Already implemented + regression-locked | `NormalizeKernels.normalizeUnchecked(_:dimension:)` (public, Kahan two-pass, inherits BE3 stability fixes; requires 16-byte-aligned buffer). 5 regression tests pin unit-norm/typed-parity/tails/overflow/subnormal |
 | **S3** tie-breaking | ✅ Implemented this cycle | `TieBreaker` enum (`smallerIndex` default / `insertionOrder` / `smallerValue`) threaded through array, pointer, generic, and optimized paths; array path unified onto `TopKBuffer` so boundary membership *and* result order are deterministic. 7 tests |
-| **S4** provider protocols | ◻️ Open | `ComputeProvider`/`BufferProvider`/`AccelerationProvider` already exist; conformance contract + tests not written |
+| **S4** provider protocols | ✅ Implemented this cycle | Conformance contract (`DOCUMENT-4_S4_Provider_Conformance.md`) pinning the semantic laws (parallelExecute order-preservation, parallelReduce partition + identity-`initial`, buffer alignment/non-aliasing, acceleration parity) + executable suite validating `CPUComputeProvider` (3 modes), protocol defaults, `SwiftBufferPool`, and mocks. 8 tests |
 | **S5** zero-copy contract | ✅ Implemented this cycle | `UnifiedVectorBuffer` + `PageAlignedBuffer` (`Storage/UnifiedVectorBuffer.swift`): page-aligned/page-length, ownership transfer, optimized + dynamic conformances, 8 tests |
 
-Remaining open work: **S4's conformance contract + tests** (medium). S1/S2 are now
-regression-locked (11 tests) and S3/S5 are implemented — only S4 remains to complete DOCUMENT-4.
+**DOCUMENT-4 complete.** All five seams done: S1/S2 already shipped + regression-locked (11
+tests), S3 (7 tests), S4 (8 tests), S5 (8 tests) — 34 tests this cycle. The ecosystem can now
+converge onto Core's pointer APIs, deterministic Top-K, verified provider protocols, and
+zero-copy buffer contract instead of routing around them.
 
 ---
 

--- a/Docs/beta-evolution-4/DOCUMENT-4_Spec_Ecosystem_Seams.md
+++ b/Docs/beta-evolution-4/DOCUMENT-4_Spec_Ecosystem_Seams.md
@@ -11,6 +11,23 @@ proposal; all of it is in the downstream repos' own request lists.
 > bypass Core. The win is ecosystem cohesion — the suite converging *onto* Core instead of
 > routing *around* it.
 
+## Implementation status (updated 2026-06-06, during execution)
+
+Reviewing the live `0.2.2` source during implementation revealed that **S1 and S2 were already
+shipped** (the BE3 / API-surface-cleaning cycle landed them) and **S3 is partially present**. The
+spec below describes the intended surface; this table is the accurate state:
+
+| Seam | Status | Notes |
+|---|---|---|
+| **S1** pointer Top-K | ✅ Already implemented | `TopKSelection.select(k:from:UnsafePointer<Float>,count:,ids:)` exists (`Operations/TopKSelection.swift`), returns `[Int32]` with `ids` remap |
+| **S2** in-place normalize | ✅ Already implemented | `NormalizeKernels.normalizeUnchecked(_:dimension:)` (public, Kahan two-pass, inherits BE3 stability fixes) |
+| **S3** tie-breaking | ⚠️ Partial | Kernel path (`TopKBuffer.isWorse`) already deterministic `smallerIndex`; configurable `TieBreaker` enum + array-path parity still open |
+| **S4** provider protocols | ◻️ Open | `ComputeProvider`/`BufferProvider`/`AccelerationProvider` already exist; conformance contract + tests not written |
+| **S5** zero-copy contract | ✅ Implemented this cycle | `UnifiedVectorBuffer` + `PageAlignedBuffer` (`Storage/UnifiedVectorBuffer.swift`): page-aligned/page-length, ownership transfer, optimized + dynamic conformances, 8 tests |
+
+Remaining open work: S3's configurable `TieBreaker` (small) and S4's conformance contract + tests
+(medium). S1/S2 need only regression tests to lock the behavior VectorIndex depends on.
+
 ---
 
 ## S1 — Pointer-level Top-K selection

--- a/Docs/beta-evolution-4/DOCUMENT-4_Spec_Ecosystem_Seams.md
+++ b/Docs/beta-evolution-4/DOCUMENT-4_Spec_Ecosystem_Seams.md
@@ -21,12 +21,12 @@ spec below describes the intended surface; this table is the accurate state:
 |---|---|---|
 | **S1** pointer Top-K | ✅ Already implemented | `TopKSelection.select(k:from:UnsafePointer<Float>,count:,ids:)` exists (`Operations/TopKSelection.swift`), returns `[Int32]` with `ids` remap |
 | **S2** in-place normalize | ✅ Already implemented | `NormalizeKernels.normalizeUnchecked(_:dimension:)` (public, Kahan two-pass, inherits BE3 stability fixes) |
-| **S3** tie-breaking | ⚠️ Partial | Kernel path (`TopKBuffer.isWorse`) already deterministic `smallerIndex`; configurable `TieBreaker` enum + array-path parity still open |
+| **S3** tie-breaking | ✅ Implemented this cycle | `TieBreaker` enum (`smallerIndex` default / `insertionOrder` / `smallerValue`) threaded through array, pointer, generic, and optimized paths; array path unified onto `TopKBuffer` so boundary membership *and* result order are deterministic. 7 tests |
 | **S4** provider protocols | ◻️ Open | `ComputeProvider`/`BufferProvider`/`AccelerationProvider` already exist; conformance contract + tests not written |
 | **S5** zero-copy contract | ✅ Implemented this cycle | `UnifiedVectorBuffer` + `PageAlignedBuffer` (`Storage/UnifiedVectorBuffer.swift`): page-aligned/page-length, ownership transfer, optimized + dynamic conformances, 8 tests |
 
-Remaining open work: S3's configurable `TieBreaker` (small) and S4's conformance contract + tests
-(medium). S1/S2 need only regression tests to lock the behavior VectorIndex depends on.
+Remaining open work: S4's conformance contract + tests (medium). S1/S2 need only regression tests
+to lock the behavior VectorIndex depends on.
 
 ---
 

--- a/Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md
+++ b/Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md
@@ -1,0 +1,98 @@
+# DOCUMENT-5 — VectorAccelerate Integration Requests (gap analysis + plan)
+
+**Source:** `future/VectorAccelerate/docs/VECTORCORE_INTEGRATION_REQUESTS.md` (filed vs VectorCore ≥ 0.2.2).
+**Status:** Verified against the live source + the `v0.2.2` tag during the beta-evo-4 branch.
+**Verdict:** None of R1/R2/R4 are supported yet; R3 rests on an incorrect premise. Adding the
+P1 blockers (R1+R2) to the beta-evo-4 scope before merge, with R4 (P2) and R3 (a reply) tracked.
+
+VectorAccelerate's `makeNoCopyBuffer(bytes:length:)` (page-aligned region → shared `MTLBuffer`,
+zero-copy on UMA) is ready to consume aligned Core storage. The blocker is entirely on Core's side:
+the high-value object to bridge — the `SoA` candidate database — is neither page-aligned (R1) nor
+publicly addressable (R2).
+
+---
+
+## R1 — Page-align the SoA batch buffer (P1, blocks zero-copy batch search)
+
+**Status: NOT supported.** `Sources/VectorCore/Storage/SoA.swift:67` allocates
+`UnsafeMutablePointer<SIMD4<Float>>.allocate(capacity: bufferCapacity)` (≈16-byte alignment) and
+frees via `.deallocate()` (`deinit`, ~L76–81). `makeBuffer(bytesNoCopy:)` needs page alignment
+(16 KB) for both base and length, so it rejects this pointer → VA falls back to a full copy.
+
+**Plan (opt-in, to avoid bloating every SoA to a 16 KB page):**
+- Add a page-aligned allocation mode to `SoA` (e.g. `SoA.build(from:pageAligned: Bool = false)` or
+  a dedicated initializer). When set, allocate the buffer via
+  `AlignedMemory.allocateAligned(type: SIMD4<Float>.self, count: paddedCapacity, alignment: PlatformConfiguration.pageSize)`
+  and **round the byte length up to a whole page** (as `PageAlignedBuffer` does) so the `bytesNoCopy`
+  length requirement is met; zero-fill the padding lanes.
+- `deinit` must free via the matching allocator: track an `ownsViaAlignedMemory` flag and call
+  `AlignedMemory.deallocate(...)` (→ `free`) for the page-aligned path, `.deallocate()` otherwise.
+  (Mismatched free is UB — the BE3 audit fixed exactly this class of bug.)
+- Default stays 16-byte (no memory regression for the common CPU-only SoA).
+
+## R2 — Publicly expose the SoA buffer pointer + byte length (P1)
+
+**Status: NOT supported.** `SoA.swift:57` `buffer` is `@usableFromInline internal`; there is no
+public raw accessor and `SoA` does not conform to `UnifiedVectorBuffer`.
+
+**Plan:**
+- Add a public, escaping accessor for the `bytesNoCopy` hand-off, gated on page alignment so VA
+  only gets a pointer it can actually wrap:
+  ```swift
+  /// Page-aligned base + page-rounded byte length, or nil if this SoA was not built
+  /// page-aligned. The SoA MUST outlive any MTLBuffer created from this pointer
+  /// (hold a strong reference, or use a deallocator handshake).
+  public var pageAlignedBytes: (base: UnsafeRawPointer, byteCount: Int)? { get }
+  ```
+- Also add a scoped `withUnsafeRawBuffer { (UnsafeRawPointer, Int) in … }` for read-only CPU use.
+- Document the **lifetime contract** explicitly (the request calls this out): the MTLBuffer borrows
+  Core-owned memory; Core frees it on `SoA` deinit, so the SoA must outlive the buffer.
+
+## R3 — Confirm the release that ships page alignment (reply, not code)
+
+**Status: premise incorrect — needs a correction sent to VA.** Verified at the `v0.2.2` tag and in
+the working copy: page alignment did **not** land on `AlignedMemory` or `AlignedDynamicArrayStorage`
+— both use `optimalAlignment` (64 bytes), not page size. `getpagesize()` lives only in
+`PlatformConfiguration.pageSize`. The **only** page-aligned allocation in VectorCore is
+`PageAlignedBuffer` (`Storage/UnifiedVectorBuffer.swift`), **added in this beta-evo-4 branch and not
+yet released**.
+
+**Reply to VA:** pin your floor to the release beta-evo-4 ships as (target **0.3.0**), not 0.2.2 —
+and note that even 0.3.0 does not page-align `SoA` until R1 lands. The 64-byte `AlignedMemory` path
+they referenced is not `bytesNoCopy`-eligible.
+
+## R4 — `BatchKernelProvider` hook for transparent GPU dispatch (P2)
+
+**Status: NOT supported.** No `BatchKernelProvider` exists; `Operations.findNearest`/batch paths
+dispatch on concrete vector type, never downcasting the provider to a GPU kernel protocol;
+`findNearestGPU` (`ExecutionOperations.swift:169`) is an internal stub that throws.
+
+**Plan (matches VA's proposed shape):**
+```swift
+public protocol BatchKernelProvider: ComputeProvider {
+    func batchDistance<V: VectorProtocol>(query: V, candidates: [V], metric: any DistanceMetric)
+        async throws -> [Float] where V.Scalar == Float
+    func findNearest<V: VectorProtocol>(query: V, candidates: [V], k: Int, metric: any DistanceMetric)
+        async throws -> [(index: Int, distance: Float)] where V.Scalar == Float
+}
+```
+- In `Operations.findNearest` (and the batch-distance path), downcast `computeProvider as? BatchKernelProvider`
+  and delegate when present, else the existing CPU path. Composes with S4 (the conformance contract
+  gets a `BatchKernelProvider` section + a mock test).
+- Interaction with the new CPU GEMM routing (DOCUMENT-2): the GPU provider, when installed, takes
+  precedence; CPU GEMM remains the default when none is installed. Document the precedence order.
+
+---
+
+## Recommendation for this branch (before merge)
+
+| Req | Priority | Recommendation |
+|---|---|---|
+| R1 page-align SoA | P1 (blocks zero-copy batch) | **Build before merge** — on-theme with S5, completes the actual GPU-bridge object |
+| R2 public SoA accessor | P1 (blocks zero-copy batch) | **Build before merge** — trivial once R1 exists |
+| R3 version reply | — | **Reply now** (no code): correct the premise; floor = 0.3.0, gated on R1 |
+| R4 BatchKernelProvider | P2 (transparent dispatch) | Build this branch *or* fast-follow; low risk, composes with S4 |
+
+R1+R2 are the blocking pair and the natural completion of the S5 zero-copy contract (which today
+covers vector types and `PageAlignedBuffer` but not `SoA`). R4 is independent and can land alongside
+or immediately after.

--- a/Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md
+++ b/Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md
@@ -110,3 +110,14 @@ or immediately after.
 - **R3 — version reply (sent):** page alignment was never on `AlignedMemory`/`AlignedDynamicArrayStorage`
   (those are 64-byte). Page-aligned storage (`PageAlignedBuffer`, and now opt-in `SoA`) ships in the
   **0.3.0** release that includes beta-evo-4 — **pin your floor to 0.3.0**, not 0.2.2.
+
+### Post-review refinements (final review findings)
+
+- **F2 — batched GPU dispatch:** `BatchKernelProvider` gained `findNearestBatch(queries:…)` with a
+  default looping implementation, and `Operations.findNearestBatch` dispatches to it — so a Metal
+  conformer can encode the whole query set in one kernel (the real GPU win) instead of per-query.
+- **F3 — ownership handoff:** `SoA.consumeAllocation()` (mirrors `PageAlignedBuffer`) transfers the
+  page-aligned buffer to a Metal `bytesNoCopy` deallocator without a double free; after consuming,
+  the `SoA` no longer frees on deinit and `pageAlignedBytes` returns `nil`.
+- **F1 — `batchDistance` doc:** clarified it's for direct consumer use (reranking), not routed by
+  `Operations`' k-NN entry points.

--- a/Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md
+++ b/Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md
@@ -121,3 +121,24 @@ or immediately after.
   the `SoA` no longer frees on deinit and `pageAlignedBytes` returns `nil`.
 - **F1 — `batchDistance` doc:** clarified it's for direct consumer use (reranking), not routed by
   `Operations`' k-NN entry points.
+
+### Follow-up: layout-freeze (post-0.3.0-preview, VA review round 2)
+
+After previewing 0.3.0, VA committed to making the page-aligned `SoA` candidate DB their
+zero-copy bridge target and asked us to **freeze and publish the SoA memory layout** their
+Metal kernel now indexes directly. Delivered:
+
+- **`SoALayout` descriptor** (`Storage/SoALayout.swift`) + `SoA.layoutDescriptor` and
+  `SoALayout.forType(_:count:)` — the machine-readable single source of truth for `lanes`,
+  `count`, `laneStrideBytes`, `logicalByteCount`, `allocatedByteCount`, and the
+  `lane * count + candidate` index formula. Replaces hardcoded shader constants.
+- **`Docs/SoA_Layout_Contract.md`** — the permanent frozen contract (index formula, packing,
+  the page-rounded-`allocatedByteCount` caveat, SoACompatible coverage incl. 768/1536,
+  borrow-vs-transfer free contract, and a golden parity fixture).
+- **`blockSize` removed** from `SoA.init` — it was a no-op that implied (non-existent)
+  candidate-axis padding; a hazard for a frozen contract.
+- **Regression lock:** `Tests/ComprehensiveTests/SoALayoutContractTests.swift` (descriptor +
+  golden parity fixture). The free/lifetime answers (`AlignedMemory.deallocate ≡ free`,
+  thread-safe, borrow mode = object-lifetime validity) are confirmed there and in the doc.
+- **R4 pointer (their §7):** `Protocols/BatchKernelProvider.swift` + the
+  `Operations.findNearest`/`findNearestBatch` dispatch sites — orthogonal to the layout.

--- a/Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md
+++ b/Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md
@@ -96,3 +96,17 @@ public protocol BatchKernelProvider: ComputeProvider {
 R1+R2 are the blocking pair and the natural completion of the S5 zero-copy contract (which today
 covers vector types and `PageAlignedBuffer` but not `SoA`). R4 is independent and can land alongside
 or immediately after.
+
+## Status (implemented on feature/beta-evo-4)
+
+- **R1 — page-align SoA:** ✅ `SoA.build(from:pageAligned:)` / `init(vectors:…:pageAligned:)` allocate
+  via `AlignedMemory` (page-aligned base, page-rounded length, allocator-correct deinit). Opt-in;
+  default stays 16-byte.
+- **R2 — public accessor:** ✅ `SoA.pageAlignedBytes` (bytesNoCopy base + page-rounded length, lifetime
+  contract documented) and `withUnsafeRawBuffer { (UnsafeRawBufferPointer) in … }`.
+- **R4 — BatchKernelProvider:** ✅ protocol added (`Protocols/BatchKernelProvider.swift`);
+  `Operations.findNearest` / `findNearestBatch` downcast the installed `computeProvider` and delegate
+  (precedence over the CPU fast paths and the CPU GEMM routing).
+- **R3 — version reply (sent):** page alignment was never on `AlignedMemory`/`AlignedDynamicArrayStorage`
+  (those are 64-byte). Page-aligned storage (`PageAlignedBuffer`, and now opt-in `SoA`) ships in the
+  **0.3.0** release that includes beta-evo-4 — **pin your floor to 0.3.0**, not 0.2.2.

--- a/Docs/beta-evolution-4/DOCUMENT-6_Page_Alignment_Feasibility.md
+++ b/Docs/beta-evolution-4/DOCUMENT-6_Page_Alignment_Feasibility.md
@@ -1,0 +1,136 @@
+# DOCUMENT-6 — Page-Alignment Feasibility: making more storage `bytesNoCopy`-eligible
+
+**Question (from VA, follow-up to DOCUMENT-5 R3):** VectorAccelerate observed that
+`AlignedMemory` / `AlignedDynamicArrayStorage` are not `MTLDevice.makeBuffer(bytesNoCopy:)`-eligible.
+What's the complexity/viability of supporting page-aligned storage more broadly?
+
+**Short answer:** The complexity is *low* — the alignment machinery already exists. But for the
+**per-vector** storages it's the wrong unit (catastrophic memory bloat), and the **batch** case it's
+actually meant for is already shipped (`SoA`, `PageAlignedBuffer`). Recommendation below, plus a
+`PageBridgeable` extraction if we expect to bridge more types.
+
+---
+
+## 1. Findings — the alignment machinery is already there
+
+The base-alignment half is essentially free; it's already plumbed:
+
+- `AlignedMemory.allocateAligned(type:count:alignment:)` (`Storage/AlignedMemory.swift:53`) accepts
+  **arbitrary power-of-two alignment ≥ 16**. `PlatformConfiguration.pageSize` (16 KB on Apple
+  Silicon) qualifies. `deallocate` is `free()`.
+- `AlignedDynamicArrayStorage.init(dimension:alignment:)` (`Storage/AlignedDynamicArrayStorage.swift:29`)
+  and `AlignedValueStorage.init(count:alignment:)` (`Storage/AlignedValueStorage.swift:168`) **already
+  take an `alignment:` parameter** that flows straight into `posix_memalign`. Passing `pageSize`
+  page-aligns the *base* today.
+- Both already **track which allocator they used** and free correctly (`AlignedMemory.deallocate(ptr)`
+  vs `.deallocate()` — `AlignedDynamicArrayStorage.swift:109–111`). The allocator-correct-deinit
+  hazard (the BE3 bug class) is already solved in these types.
+
+So "support page alignment" is **not** blocked on the allocator. The two genuine gaps are:
+
+1. **Length page-rounding.** These allocate exactly `count * MemoryLayout<Float>.stride` bytes.
+   `makeBuffer(bytesNoCopy:)` on macOS requires the **length** to be a page multiple *as well as* the
+   base — so a page-aligned base with an unrounded length is still rejected. Fix: when page-aligning,
+   over-allocate to `roundUpToPage(count*stride)` and track the padded length (exactly what
+   `PageAlignedBuffer`/`SoA` do).
+2. **Escaping accessor + ownership handoff.** Need `pageAlignedBytes` (escaping base+length) and
+   `consumeAllocation()` (transfer to a Metal deallocator without double-free). Today these types
+   expose only scoped `withUnsafeMutableBufferPointer`.
+
+Both are the **exact pattern already shipped** in `SoA` and `PageAlignedBuffer` this cycle.
+
+---
+
+## 2. The catch — economics, not difficulty
+
+A page is **16 KB**. Page-aligning *per-vector* storage means a 384-dim `DynamicVector`
+(1,536 bytes) rounds up to a full page — **~10.7× memory bloat per vector**. For a database of
+millions of individually-stored vectors that is a non-starter.
+
+Page alignment only pays for itself when the per-page overhead **amortizes across a contiguous
+batch** — one page-rounded slab holding many vectors, where the rounding waste is a single trailing
+page (well under 0.01%). So the unit that should be page-aligned is a **batch/contiguous layout**,
+never per-vector storage.
+
+This is already covered:
+
+- **`SoA<Vector>`** — opt-in page-aligned (`build(from:pageAligned: true)`); the batch candidate
+  database. The high-value GPU-bridge target. ✅ shipped (DOCUMENT-5 R1/R2).
+- **`PageAlignedBuffer`** — an arbitrary page-aligned `[Float]` slab (`Storage/UnifiedVectorBuffer.swift`).
+  This is the answer for the **EmbedKit → VectorAccelerate dense handoff**: EmbedKit allocates
+  `PageAlignedBuffer(elementCount: N*dim)`, writes its N embeddings in once, and hands the
+  page-aligned pointer to VA — no per-vector bloat, no retrofit. ✅ shipped (DOCUMENT-4 S5).
+
+---
+
+## 3. Foreseeable approaches
+
+| # | Approach | Complexity | Memory | When |
+|---|---|---|---|---|
+| **A** | **Status quo** — use `SoA`/`PageAlignedBuffer` for batches; don't page-align per-vector storage | — (done) | optimal | **Default. Recommended.** Covers the batch handoff today. |
+| **B** | **Add an opt-in page-aligned batch type on demand** — e.g. a contiguous page-aligned `[Vector512Optimized]` slab, or a page-aligned `DynamicVector` *batch* | ~½ day/type | optimal (batch) | When a concrete bridge target appears that `SoA`/`PageAlignedBuffer` don't fit |
+| **C** | **Extract a shared `PageBridgeable` helper**, then adopt it in `SoA` + future types | ~1 day once | optimal | If we expect ≥ 2 more bridged types — makes each subsequent one ~1–2 h and contains the double-free risk in one place |
+| **D** | **Page-align the per-vector storages** (`AlignedDynamicArrayStorage`/`AlignedValueStorage`) | ~½ day/type | **~10× bloat at scale** | **Not recommended** — wrong unit |
+
+### Approach C sketch — `PageBridgeable`
+
+Today the page-round + accessor + `consumeAllocation` + allocator-correct-free logic is implemented
+*twice* (`SoA`, `PageAlignedBuffer`) and would be copy-pasted a third time per new type — each copy
+re-risks the double-free. Centralize it:
+
+```swift
+/// The zero-copy GPU-bridge surface: a contiguous region whose base + length are
+/// page multiples, handable to MTLDevice.makeBuffer(bytesNoCopy:).
+public protocol PageBridgeable: AnyObject {
+    /// Page-aligned base + page-rounded length, or nil if not page-aligned.
+    var pageAlignedBytes: (base: UnsafeRawPointer, byteCount: Int)? { get }
+    /// Transfer ownership to the caller (for a Metal bytesNoCopy deallocator). After
+    /// this the object no longer frees on deinit and `pageAlignedBytes` returns nil;
+    /// the caller frees via AlignedMemory.deallocate / free.
+    func consumeAllocation() -> (base: UnsafeMutableRawPointer, byteCount: Int)?
+}
+
+/// Embeddable owner of a page-aligned, page-length-rounded allocation. A storage
+/// type composes this instead of re-implementing page alignment + the free contract.
+struct PageAlignedRegion {            // value type, embedded in the (class) storage
+    let base: UnsafeMutableRawPointer
+    let byteCount: Int                // page multiple
+    private(set) var owns: Bool = true
+
+    init?(logicalBytes: Int) {        // nil for empty
+        guard logicalBytes > 0 else { return nil }
+        let page = PlatformConfiguration.pageSize
+        let padded = ((logicalBytes + page - 1) / page) * page
+        let raw = try? AlignedMemory.allocateAligned(type: UInt8.self, count: padded, alignment: page)
+        guard let raw else { return nil }
+        UnsafeMutableRawPointer(raw).initializeMemory(as: UInt8.self, repeating: 0, count: padded)
+        self.base = UnsafeMutableRawPointer(raw); self.byteCount = padded
+    }
+    mutating func consume() -> (UnsafeMutableRawPointer, Int)? {
+        guard owns else { return nil }; owns = false; return (base, byteCount)
+    }
+    func freeIfOwned() { if owns { AlignedMemory.deallocate(base) } }   // call from deinit
+}
+```
+
+A bridged storage then holds an optional `PageAlignedRegion` (non-nil only on the opt-in path),
+forwards `pageAlignedBytes`/`consumeAllocation` to it, and calls `region?.freeIfOwned()` in `deinit`.
+`SoA`'s current bespoke fields collapse into this; new types adopt it in a few lines. (Swift protocols
+can't add stored state, so composition — not a protocol default — is the right tool for the shared
+*implementation*; the protocol just names the public contract.)
+
+---
+
+## 4. Recommendation
+
+1. **Default to Approach A.** The GPU-bridge value is in batches, and both batch primitives ship in
+   0.3.0. Point VA at `SoA(pageAligned: true)` for candidate databases and `PageAlignedBuffer` for the
+   EmbedKit dense handoff. **Do not** page-align per-vector storage (Approach D).
+2. **Reach for Approach C** if a second/third bridge target is on the horizon — the `PageBridgeable`
+   extraction is a 1-day investment that de-risks every future adoption and removes the copy-pasted
+   double-free hazard. Otherwise defer it (YAGNI).
+3. **Approach B** is the per-need fallback: a concrete new batch slab is ~½ day with tests, low risk,
+   because the alignment + allocator-correct-free machinery already exists.
+
+**Net:** technically cheap, already solved for the cases that matter; the only thing to actively avoid
+is page-aligning the per-vector storages.

--- a/Docs/beta-evolution-4/PLAN_R1_R2_R4.md
+++ b/Docs/beta-evolution-4/PLAN_R1_R2_R4.md
@@ -1,0 +1,540 @@
+# VectorAccelerate Integration (R1, R2, R4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unblock VectorAccelerate's zero-copy batch GPU search and transparent GPU dispatch by page-aligning the `SoA` candidate buffer (R1), exposing it publicly with a lifetime contract (R2), and adding a `BatchKernelProvider` hook so an installed GPU provider transparently services `Operations.findNearest`/`findNearestBatch` (R4).
+
+**Architecture:** R1/R2 add an *opt-in* page-aligned allocation mode to `SoA` (default stays 16-byte, no memory regression) plus public accessors — reusing the existing `AlignedMemory` (`posix_memalign`/`free`) + `PlatformConfiguration.pageSize`, mirroring the `PageAlignedBuffer` page-rounding pattern. R4 defines a `ComputeProvider` sub-protocol and downcasts the `@TaskLocal` `Operations.computeProvider` to it, taking precedence over the CPU paths (including the new GEMM routing).
+
+**Tech Stack:** Swift 6 (strict concurrency), swift-testing (`import Testing`), Accelerate (already a dep), `@testable import VectorCore`.
+
+---
+
+## Context (why)
+
+VectorAccelerate filed `future/VectorAccelerate/docs/VECTORCORE_INTEGRATION_REQUESTS.md`. Verification (see `DOCUMENT-5_VectorAccelerate_Integration_Requests.md`) found **none of R1/R2/R4 are supported**, and R3 rests on a wrong premise (page alignment never landed on `AlignedMemory`; the only page-aligned storage is `PageAlignedBuffer`, new on this branch). VA's `makeNoCopyBuffer` is ready to consume aligned Core storage; the `SoA` candidate database is the high-value object to bridge but is neither page-aligned nor publicly addressable.
+
+## File structure
+
+- **Modify:** `Sources/VectorCore/Storage/SoA.swift` — add opt-in page-aligned allocation + `pageAlignedBytes` / `withUnsafeRawBuffer` accessors + allocator-correct `deinit`. (R1, R2)
+- **Create:** `Sources/VectorCore/Protocols/BatchKernelProvider.swift` — the `ComputeProvider` sub-protocol. (R4)
+- **Modify:** `Sources/VectorCore/Operations/Operations.swift` — downcast `computeProvider` to `BatchKernelProvider` in `findNearest` and `findNearestBatch`. (R4)
+- **Create:** `Tests/ComprehensiveTests/SoAPageAlignTests.swift` — R1/R2 tests.
+- **Create:** `Tests/ComprehensiveTests/BatchKernelProviderTests.swift` — R4 tests.
+- **Modify:** `Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md` — mark R1/R2/R4 done; record the R3 reply. (R3)
+
+Facts this plan relies on (verified):
+- `SoA.swift:57` `@usableFromInline internal let buffer: UnsafeMutablePointer<SIMD4<Float>>`; `:58` `private let bufferCapacity: Int`; allocated `:67`/`:95` via `.allocate(capacity:)`; freed `:76–81` via `.deinitialize`+`.deallocate()`. Two inits: `private init(count:)` and `public init(vectors:blockSize:)`; `static func build(from:)`. `SoACompatible.lanes` = dimension/4 (512 → 128).
+- `AlignedMemory.allocateAligned(type:count:alignment:)` (posix_memalign, throws `VectorError.allocationFailed`) and `AlignedMemory.deallocate(_ ptr:)` (→ `free`). `PlatformConfiguration.pageSize` = `getpagesize()`.
+- `Operations.computeProvider` is `@TaskLocal public static var ... = CPUComputeProvider.automatic`. `Operations.findNearest` returns `[NearestNeighborResult]` (`.index`/`.distance`, public init). `findNearestBatch` returns `[[NearestNeighborResult]]` and currently routes to `gemmFindNearestBatch` then a per-query `parallelExecute`.
+
+---
+
+## Task 1: Page-aligned SoA buffer + public accessors (R1, R2)
+
+**Files:**
+- Modify: `Sources/VectorCore/Storage/SoA.swift`
+- Test: `Tests/ComprehensiveTests/SoAPageAlignTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/ComprehensiveTests/SoAPageAlignTests.swift`:
+
+```swift
+//
+//  SoAPageAlignTests.swift
+//  VectorCore
+//
+//  R1/R2: opt-in page-aligned SoA buffer + public bytesNoCopy-ready accessor.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+@Suite("SoA page alignment (R1/R2)")
+struct SoAPageAlignTests {
+    private func makeCandidates(_ n: Int) -> [Vector512Optimized] {
+        (0..<n).map { k in try! Vector512Optimized((0..<512).map { Float(($0 + k) % 13) }) }
+    }
+
+    @Test("Page-aligned SoA exposes a page-aligned, page-length pointer")
+    func pageAlignedExposesBytes() {
+        let page = PlatformConfiguration.pageSize
+        let soa = SoA512.build(from: makeCandidates(300), pageAligned: true)
+        let bytes = soa.pageAlignedBytes
+        #expect(bytes != nil)
+        if let (base, byteCount) = bytes {
+            #expect(Int(bitPattern: base) % page == 0, "base must be page-aligned")
+            #expect(byteCount % page == 0, "length must be a page multiple")
+            #expect(byteCount >= 300 * 128 * 16)   // count * lanes * sizeof(SIMD4<Float>)
+        }
+    }
+
+    @Test("Non-page-aligned SoA returns nil for pageAlignedBytes")
+    func defaultReturnsNil() {
+        let soa = SoA512.build(from: makeCandidates(300))   // pageAligned defaults false
+        #expect(soa.pageAlignedBytes == nil)
+    }
+
+    @Test("Page alignment preserves the SoA data layout")
+    func dataIntegrity() {
+        let candidates = makeCandidates(64)
+        let aligned = SoA512.build(from: candidates, pageAligned: true)
+        let plain = SoA512.build(from: candidates, pageAligned: false)
+        for lane in 0..<aligned.lanes {
+            let a = aligned.lanePointer(lane)
+            let p = plain.lanePointer(lane)
+            for j in 0..<64 { #expect(a[j] == p[j], "lane \(lane) candidate \(j)") }
+        }
+    }
+
+    @Test("withUnsafeRawBuffer exposes the logical data length")
+    func rawBufferLength() {
+        let soa = SoA512.build(from: makeCandidates(10), pageAligned: true)
+        soa.withUnsafeRawBuffer { base, byteCount in
+            #expect(byteCount == 10 * 128 * 16)
+            #expect(Int(bitPattern: base) % 16 == 0)
+        }
+    }
+
+    @Test("Empty page-aligned SoA has no bytesNoCopy pointer")
+    func emptyAligned() {
+        let soa = SoA512.build(from: [], pageAligned: true)
+        #expect(soa.pageAlignedBytes == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --filter SoAPageAlignTests`
+Expected: FAIL to compile — `extra argument 'pageAligned'`, `value of type 'SoA<…>' has no member 'pageAlignedBytes'` / `withUnsafeRawBuffer`.
+
+- [ ] **Step 3: Add stored properties and the allocation helper to `SoA`**
+
+In `Sources/VectorCore/Storage/SoA.swift`, add two stored properties immediately after `private let bufferCapacity: Int` (line 58):
+
+```swift
+    /// True when `buffer` was allocated via AlignedMemory (posix_memalign) and so must
+    /// be freed with free(); false for the default Swift allocation.
+    private let ownsViaAlignedMemory: Bool
+
+    /// Total allocated bytes. Page-rounded when page-aligned (the length to pass to
+    /// makeBuffer(bytesNoCopy:)); otherwise bufferCapacity * sizeof(SIMD4<Float>).
+    private let allocatedByteCount: Int
+```
+
+Add this static helper (place it just above `deinit`):
+
+```swift
+    /// Allocate (and zero) the SoA buffer. When `pageAligned` and non-empty, uses
+    /// AlignedMemory (page-aligned base + page-rounded length) so the region is valid
+    /// for MTLDevice.makeBuffer(bytesNoCopy:); otherwise the default 16-byte allocation.
+    private static func allocateBuffer(
+        capacity: Int, pageAligned: Bool
+    ) -> (buffer: UnsafeMutablePointer<SIMD4<Float>>, ownsViaAligned: Bool, allocatedBytes: Int) {
+        let elemSize = MemoryLayout<SIMD4<Float>>.stride   // 16
+        if pageAligned && capacity > 0 {
+            let page = PlatformConfiguration.pageSize
+            let logical = capacity * elemSize
+            let padded = ((logical + page - 1) / page) * page   // round up to a whole page
+            let paddedCapacity = padded / elemSize
+            let ptr: UnsafeMutablePointer<SIMD4<Float>>
+            do {
+                ptr = try AlignedMemory.allocateAligned(type: SIMD4<Float>.self,
+                                                        count: paddedCapacity, alignment: page)
+            } catch {
+                fatalError("SoA: page-aligned allocation of \(padded) bytes failed: \(error)")
+            }
+            ptr.initialize(repeating: .zero, count: paddedCapacity)   // zero logical + padding
+            return (ptr, true, padded)
+        } else {
+            let ptr = UnsafeMutablePointer<SIMD4<Float>>.allocate(capacity: max(0, capacity))
+            if capacity > 0 { ptr.initialize(repeating: .zero, count: capacity) }
+            return (ptr, false, max(0, capacity) * elemSize)
+        }
+    }
+```
+
+- [ ] **Step 4: Route both initializers through the helper and add `pageAligned`**
+
+Replace the `private init(count:)` (lines 60–74) with:
+
+```swift
+    private init(count: Int, pageAligned: Bool = false) {
+        self.count = count
+        self.lanes = Vector.lanes
+        self.bufferCapacity = self.lanes * self.count
+        let alloc = SoA.allocateBuffer(capacity: self.bufferCapacity, pageAligned: pageAligned)
+        self.buffer = alloc.buffer
+        self.ownsViaAlignedMemory = alloc.ownsViaAligned
+        self.allocatedByteCount = alloc.allocatedBytes
+    }
+```
+
+Replace the allocation block of `public init(vectors:blockSize:)` (lines 88–99) so the signature and allocation become:
+
+```swift
+    public init(vectors: [Vector], blockSize: Int = 32, pageAligned: Bool = false) {
+        let count = vectors.count
+        self.count = count
+        self.lanes = Vector.lanes
+        self.bufferCapacity = self.lanes * self.count
+        let alloc = SoA.allocateBuffer(capacity: self.bufferCapacity, pageAligned: pageAligned)
+        self.buffer = alloc.buffer
+        self.ownsViaAlignedMemory = alloc.ownsViaAligned
+        self.allocatedByteCount = alloc.allocatedBytes
+
+        // Populate the SoA structure from vectors
+        guard count > 0 else { return }
+        let lanes = Vector.lanes
+        let bufferPtr = self.buffer
+        for j in 0..<count {
+            let vectorStorage = vectors[j].storage
+            for i in 0..<lanes {
+                bufferPtr[i * count + j] = vectorStorage[i]
+            }
+        }
+    }
+```
+
+(Leave the `blockSize` doc comment as-is; only the allocation lines and signature change.)
+
+- [ ] **Step 5: Make `deinit` free with the matching allocator**
+
+Replace `deinit` (lines 76–81) with:
+
+```swift
+    deinit {
+        if ownsViaAlignedMemory {
+            // posix_memalign memory MUST be freed with free(), never .deallocate().
+            AlignedMemory.deallocate(buffer)
+        } else {
+            if bufferCapacity > 0 { buffer.deinitialize(count: bufferCapacity) }
+            buffer.deallocate()
+        }
+    }
+```
+
+- [ ] **Step 6: Add `pageAligned` to `build(from:)`**
+
+Replace the `static func build(from:)` signature + `SoA<Vector>(count:)` call (lines 122–124) so they read:
+
+```swift
+    public static func build(from candidates: [Vector], pageAligned: Bool = false) -> SoA<Vector> {
+        let N = candidates.count
+        let soa = SoA<Vector>(count: N, pageAligned: pageAligned)
+```
+
+(The rest of `build` is unchanged.)
+
+- [ ] **Step 7: Add the public accessors (R2)**
+
+Add these two public members (place after `lanePointer(_:)`, around line 159):
+
+```swift
+    /// Page-aligned base pointer + page-rounded byte length for zero-copy GPU import
+    /// via `MTLDevice.makeBuffer(bytesNoCopy:)`, or `nil` if this SoA was not built
+    /// page-aligned (`build(from:pageAligned: true)` / `init(..., pageAligned: true)`).
+    ///
+    /// - Important: The `SoA` MUST outlive any `MTLBuffer` created from this pointer.
+    ///   The memory is freed on `SoA` deinit, so hold a strong reference to the `SoA`
+    ///   for the buffer's lifetime (or arrange a deallocator handshake).
+    public var pageAlignedBytes: (base: UnsafeRawPointer, byteCount: Int)? {
+        guard ownsViaAlignedMemory else { return nil }
+        return (UnsafeRawPointer(buffer), allocatedByteCount)
+    }
+
+    /// Scoped read-only access to the raw SoA data (logical bytes = `count * lanes * 16`).
+    /// The pointer is valid only for the duration of `body`.
+    public func withUnsafeRawBuffer<R>(_ body: (UnsafeRawPointer, Int) throws -> R) rethrows -> R {
+        try body(UnsafeRawPointer(buffer), bufferCapacity * MemoryLayout<SIMD4<Float>>.stride)
+    }
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `swift test --filter SoAPageAlignTests`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 9: Run the existing SoA suites to confirm no regression**
+
+Run: `swift test --filter "SoA Memory Layout" --filter BatchKernels_SoATests`
+Expected: PASS (the default-path allocation/deinit behavior is unchanged).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Sources/VectorCore/Storage/SoA.swift Tests/ComprehensiveTests/SoAPageAlignTests.swift
+git commit -m "feat(soa): opt-in page-aligned buffer + bytesNoCopy accessors (R1/R2)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `BatchKernelProvider` protocol (R4, part 1)
+
+**Files:**
+- Create: `Sources/VectorCore/Protocols/BatchKernelProvider.swift`
+- Test: `Tests/ComprehensiveTests/BatchKernelProviderTests.swift`
+
+- [ ] **Step 1: Write the failing conformance test**
+
+Create `Tests/ComprehensiveTests/BatchKernelProviderTests.swift`:
+
+```swift
+//
+//  BatchKernelProviderTests.swift
+//  VectorCore
+//
+//  R4: a ComputeProvider sub-protocol that supplies real batch kernels, so an
+//  installed GPU provider transparently services Operations.findNearest.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+/// A mock GPU provider that returns an impossible-from-CPU sentinel, so tests can
+/// detect that dispatch was delegated to it.
+private struct MockGPUProvider: BatchKernelProvider {
+    let device: ComputeDevice = .cpu
+    var maxConcurrency: Int { 1 }
+    var deviceInfo: ComputeDeviceInfo {
+        ComputeDeviceInfo(name: "mock-gpu", availableMemory: nil, maxThreads: 1, preferredChunkSize: 1)
+    }
+    func execute<T: Sendable>(_ work: @Sendable @escaping () async throws -> T) async throws -> T {
+        try await work()
+    }
+    func batchDistance<V: VectorProtocol>(query: V, candidates: [V], metric: any DistanceMetric)
+        async throws -> [Float] where V.Scalar == Float {
+        Array(repeating: Float(-1), count: candidates.count)
+    }
+    func findNearest<V: VectorProtocol>(query: V, candidates: [V], k: Int, metric: any DistanceMetric)
+        async throws -> [(index: Int, distance: Float)] where V.Scalar == Float {
+        [(index: 999, distance: -42)]   // impossible from the CPU path
+    }
+}
+
+@Suite("BatchKernelProvider GPU dispatch (R4)")
+struct BatchKernelProviderTests {
+
+    @Test("A BatchKernelProvider is usable as a ComputeProvider")
+    func conformsToComputeProvider() async throws {
+        let p: any ComputeProvider = MockGPUProvider()
+        let mapped = try await p.parallelExecute(items: 0..<4) { $0 * 2 }
+        #expect(mapped == [0, 2, 4, 6])   // inherits the ComputeProvider default
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter BatchKernelProviderTests`
+Expected: FAIL to compile — `cannot find type 'BatchKernelProvider' in scope`.
+
+- [ ] **Step 3: Define the protocol**
+
+Create `Sources/VectorCore/Protocols/BatchKernelProvider.swift`:
+
+```swift
+// VectorCore: Batch Kernel Provider Protocol
+//
+// beta-evolution-4, DOCUMENT-5 (R4). A ComputeProvider that can substitute real
+// batch kernels (e.g. Metal) for VectorCore's CPU kernels. `Operations` downcasts
+// the installed `computeProvider` to this protocol and, when present, delegates —
+// so GPU acceleration becomes transparent through VectorCore's own findNearest.
+//
+// VectorCore defines the protocol; the GPU-backed conformance lives in VectorAccelerate.
+
+import Foundation
+
+/// A `ComputeProvider` that supplies hardware batch kernels rather than only a
+/// scheduling strategy. Conformers compute the kernel themselves (CPU SIMD, Metal,
+/// etc.) instead of running an opaque closure.
+///
+/// Semantics a conformer must honor (see DOCUMENT-4 S4 conformance contract):
+/// - `batchDistance` returns one distance per candidate, in candidate order.
+/// - `findNearest` returns up to `k` `(index, distance)` pairs sorted ascending by
+///   distance, indexing into `candidates`; results match the CPU reference within a
+///   documented tolerance.
+public protocol BatchKernelProvider: ComputeProvider {
+    /// Distance from `query` to each candidate, in candidate order.
+    func batchDistance<V: VectorProtocol>(
+        query: V, candidates: [V], metric: any DistanceMetric
+    ) async throws -> [Float] where V.Scalar == Float
+
+    /// Up to `k` nearest candidates, sorted ascending by distance.
+    func findNearest<V: VectorProtocol>(
+        query: V, candidates: [V], k: Int, metric: any DistanceMetric
+    ) async throws -> [(index: Int, distance: Float)] where V.Scalar == Float
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --filter BatchKernelProviderTests`
+Expected: PASS — 1 test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/VectorCore/Protocols/BatchKernelProvider.swift Tests/ComprehensiveTests/BatchKernelProviderTests.swift
+git commit -m "feat(providers): add BatchKernelProvider protocol (R4)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Wire transparent GPU dispatch into `Operations` (R4, part 2)
+
+**Files:**
+- Modify: `Sources/VectorCore/Operations/Operations.swift`
+- Test: `Tests/ComprehensiveTests/BatchKernelProviderTests.swift` (extend)
+
+- [ ] **Step 1: Add the delegation tests**
+
+Append these tests inside `struct BatchKernelProviderTests` (before its closing brace):
+
+```swift
+    @Test("Operations.findNearest delegates to an installed BatchKernelProvider")
+    func findNearestDelegates() async throws {
+        let q = try Vector512Optimized(Array(repeating: 1, count: 512))
+        let cs = (0..<10).map { _ in try! Vector512Optimized(Array(repeating: 0, count: 512)) }
+        let result = try await Operations.$computeProvider.withValue(MockGPUProvider()) {
+            try await Operations.findNearest(to: q, in: cs, k: 3)
+        }
+        #expect(result.count == 1)
+        #expect(result[0].index == 999)        // the sentinel ⇒ delegation happened
+        #expect(result[0].distance == -42)
+    }
+
+    @Test("findNearestBatch delegates per query (GPU precedence over CPU GEMM)")
+    func findNearestBatchDelegates() async throws {
+        // n = 300 ≥ 256 would normally hit the CPU GEMM path; the GPU provider must win.
+        let qs = (0..<5).map { _ in try! Vector512Optimized(Array(repeating: 1, count: 512)) }
+        let cs = (0..<300).map { _ in try! Vector512Optimized(Array(repeating: 0, count: 512)) }
+        let result = try await Operations.$computeProvider.withValue(MockGPUProvider()) {
+            try await Operations.findNearestBatch(queries: qs, in: cs, k: 3)
+        }
+        #expect(result.count == 5)
+        for row in result { #expect(row.first?.index == 999) }
+    }
+
+    @Test("Default provider uses the CPU path (no sentinel)")
+    func defaultUsesCPU() async throws {
+        let q = try Vector512Optimized((0..<512).map { Float($0) })
+        let cs = (0..<10).map { k in try! Vector512Optimized((0..<512).map { Float($0 + k) }) }
+        let result = try await Operations.findNearest(to: q, in: cs, k: 3)
+        #expect(result.count == 3)
+        #expect(result[0].index != 999)        // real CPU result, not the sentinel
+    }
+```
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+Run: `swift test --filter BatchKernelProviderTests`
+Expected: `findNearestDelegates` / `findNearestBatchDelegates` FAIL (CPU path runs; index is not 999). `defaultUsesCPU` and `conformsToComputeProvider` still pass.
+
+- [ ] **Step 3: Downcast in `Operations.findNearest`**
+
+In `Sources/VectorCore/Operations/Operations.swift`, in `findNearest` (line 46), insert the downcast immediately after the input-validation block (after the `for v in vectors where v.scalarCount != expectedDim { … }` loop, i.e. after line 66, before the `// Optimized Top‑K fast paths` comment on line 68):
+
+```swift
+        // R4 — transparent GPU dispatch: an installed BatchKernelProvider supplies real
+        // batch kernels; delegate to it (precedence over the CPU fast paths below).
+        if let gpu = computeProvider as? BatchKernelProvider {
+            let pairs = try await gpu.findNearest(query: query, candidates: vectors, k: k, metric: metric)
+            return pairs.map { NearestNeighborResult(index: $0.index, distance: $0.distance) }
+        }
+```
+
+- [ ] **Step 4: Downcast in `Operations.findNearestBatch`**
+
+In `findNearestBatch` (line 125), insert this immediately before the `// GEMM fast path (DOCUMENT-2)` block (i.e. right after the dimension-validation loops and before `if let routed = gemmFindNearestBatch(...)`):
+
+```swift
+        // R4 — transparent GPU dispatch: if a GPU kernel provider is installed, dispatch
+        // each query through it (its findNearest); this takes precedence over CPU GEMM.
+        if computeProvider as? BatchKernelProvider != nil {
+            return try await computeProvider.parallelExecute(items: 0..<queries.count) { i in
+                try await findNearest(to: queries[i], in: vectors, k: k, metric: metric)
+            }
+        }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `swift test --filter BatchKernelProviderTests`
+Expected: PASS — 4 tests (`conformsToComputeProvider`, `findNearestDelegates`, `findNearestBatchDelegates`, `defaultUsesCPU`).
+
+- [ ] **Step 6: Run the GEMM routing/batch suites to confirm the default path still works**
+
+Run: `swift test --filter BatchKNNGEMMTests --filter MatrixDistanceTests`
+Expected: PASS (no provider installed ⇒ `as? BatchKernelProvider` is nil ⇒ unchanged behavior).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/VectorCore/Operations/Operations.swift Tests/ComprehensiveTests/BatchKernelProviderTests.swift
+git commit -m "feat(operations): downcast computeProvider to BatchKernelProvider for transparent GPU dispatch (R4)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: R3 reply + status update + full-suite verification
+
+**Files:**
+- Modify: `Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md`
+
+- [ ] **Step 1: Mark R1/R2/R4 done and record the R3 reply**
+
+In `DOCUMENT-5_VectorAccelerate_Integration_Requests.md`, change the recommendation table's status column to reflect completion, and append this section at the end:
+
+```markdown
+## Status (implemented on feature/beta-evo-4)
+
+- **R1 — page-align SoA:** ✅ `SoA.build(from:pageAligned:)` / `init(vectors:…:pageAligned:)`
+  allocate via `AlignedMemory` (page-aligned base, page-rounded length, allocator-correct deinit).
+- **R2 — public accessor:** ✅ `SoA.pageAlignedBytes` (bytesNoCopy base+length, lifetime contract
+  documented) and `withUnsafeRawBuffer { (ptr, byteCount) in … }`.
+- **R4 — BatchKernelProvider:** ✅ protocol added; `Operations.findNearest` / `findNearestBatch`
+  downcast the installed `computeProvider` and delegate (precedence over CPU GEMM).
+- **R3 — version reply (sent):** page alignment was never on `AlignedMemory`/`AlignedDynamicArrayStorage`
+  (those are 64-byte). Page-aligned storage (`PageAlignedBuffer`, and now opt-in `SoA`) ships in the
+  **0.3.0** release that includes beta-evo-4 — **pin your floor to 0.3.0**, not 0.2.2.
+```
+
+- [ ] **Step 2: Run the full correctness suite**
+
+Run: `VECTORCORE_TEST_EXTENDED=0 swift test`
+Expected: PASS — all tests, 0 issues. (Use `VECTORCORE_TEST_EXTENDED=0`: the extended wall-clock `PerformanceComparisonTests` are load-flaky and excluded from the correctness gate, matching CI.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Docs/beta-evolution-4/DOCUMENT-5_VectorAccelerate_Integration_Requests.md
+git commit -m "docs(beta-evo-4): mark VA integration R1/R2/R4 done + R3 version reply
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Verification (end-to-end)
+
+1. `swift test --filter SoAPageAlignTests` → 5 pass (R1/R2).
+2. `swift test --filter BatchKernelProviderTests` → 4 pass (R4).
+3. `VECTORCORE_TEST_EXTENDED=0 swift test` → full suite green, 0 issues.
+4. Manual contract check (optional): a page-aligned `SoA512.build(from: …, pageAligned: true)` returns `pageAlignedBytes` with `base % pageSize == 0` and `byteCount % pageSize == 0` — the two invariants `makeBuffer(bytesNoCopy:)` requires.
+
+## Notes / non-goals
+
+- Default `SoA` allocation stays 16-byte (no memory regression); page alignment is strictly opt-in for the GPU-bridge path.
+- This plan does not implement a GPU `BatchKernelProvider` conformance — that lives in VectorAccelerate (`MetalComputeProvider` is "a thin adapter away" per their doc). Core only owns the protocol + the downcast.
+- `batchDistance` is defined on the protocol for VA's use; Core wires the downcast into the k-NN paths (`findNearest`/`findNearestBatch`). Routing a Core entry point to `batchDistance` is deferred (no public Core "distance vector" entry beyond `BatchOperations`, which already has its own path).

--- a/Docs/beta-evolution-4/be4-master.md
+++ b/Docs/beta-evolution-4/be4-master.md
@@ -146,3 +146,4 @@ Recorded so they are not silently propagated into implementation:
 | `DOCUMENT-4_S4_Provider_Conformance.md` | Provider conformance contract (ComputeProvider/BufferProvider/AccelerationProvider) |
 | `DOCUMENT-5_VectorAccelerate_Integration_Requests.md` | Gap analysis + plan for VA's R1–R4 (SoA page-align/accessor, version reply, BatchKernelProvider) |
 | `DOCUMENT-6_Page_Alignment_Feasibility.md` | Feasibility of broader `bytesNoCopy`-eligible storage; why batches (SoA/PageAlignedBuffer) not per-vector; `PageBridgeable` sketch |
+| `../SoA_Layout_Contract.md` | 🔒 **Frozen** SoA memory-layout contract (0.3.0) — the permanent reference VA's zero-copy Metal kernels pin to. Index formula, `SoALayout` descriptor, page-rounding caveat, free/lifetime contract, golden parity fixture. Promoted out of beta-evo-4 because it is a durable contract, not a planning doc. |

--- a/Docs/beta-evolution-4/be4-master.md
+++ b/Docs/beta-evolution-4/be4-master.md
@@ -143,3 +143,5 @@ Recorded so they are not silently propagated into implementation:
 | `DOCUMENT-2_Spec_GEMM_Batch_Distance.md` | CPU AMX GEMM batch-distance design spec |
 | `DOCUMENT-3_Spec_Block_Quantization.md` | `Q8_0` block-wise quantization design spec |
 | `DOCUMENT-4_Spec_Ecosystem_Seams.md` | Downstream-requested seams (pointer APIs, protocols, zero-copy) |
+| `DOCUMENT-4_S4_Provider_Conformance.md` | Provider conformance contract (ComputeProvider/BufferProvider/AccelerationProvider) |
+| `DOCUMENT-5_VectorAccelerate_Integration_Requests.md` | Gap analysis + plan for VA's R1–R4 (SoA page-align/accessor, version reply, BatchKernelProvider) |

--- a/Docs/beta-evolution-4/be4-master.md
+++ b/Docs/beta-evolution-4/be4-master.md
@@ -145,3 +145,4 @@ Recorded so they are not silently propagated into implementation:
 | `DOCUMENT-4_Spec_Ecosystem_Seams.md` | Downstream-requested seams (pointer APIs, protocols, zero-copy) |
 | `DOCUMENT-4_S4_Provider_Conformance.md` | Provider conformance contract (ComputeProvider/BufferProvider/AccelerationProvider) |
 | `DOCUMENT-5_VectorAccelerate_Integration_Requests.md` | Gap analysis + plan for VA's R1–R4 (SoA page-align/accessor, version reply, BatchKernelProvider) |
+| `DOCUMENT-6_Page_Alignment_Feasibility.md` | Feasibility of broader `bytesNoCopy`-eligible storage; why batches (SoA/PageAlignedBuffer) not per-vector; `PageBridgeable` sketch |

--- a/Docs/beta-evolution-4/be4-master.md
+++ b/Docs/beta-evolution-4/be4-master.md
@@ -1,0 +1,145 @@
+# Beta-Evolution-4 — Master Decision Review
+
+**Status:** Strategic review + design specs (no source changes in this phase)
+**Target release:** VectorCore `0.3.0`
+**Date:** 2026-06-06
+**Inputs reviewed:** External "Documents 0–4" strategy (Gemini); VectorCore `0.2.2` source;
+downstream packages `VectorIndex` `0.1.5`, `VectorAccelerate` `0.5.0`, `EmbedKit` `0.1.0`.
+
+---
+
+## 1. Thesis: Hold the line, sharpen the seams
+
+The external proposal asks VectorCore to become a SOTA "micro-kernel & memory primitive
+provider" that competes with Faiss / USearch / DiskANN / GGML by absorbing block quantization,
+binary vectors, prefetch, GEMM, sparse algebra, `mmap` storage, pinned Metal arenas, ADC
+look-up tables, HNSW visited-lists, and concurrent priority queues.
+
+The proposal is technically literate, but it was written **without visibility into the three
+real downstream packages.** When measured against them, most of its recommendations describe
+code that already ships:
+
+- **Documents 3 and 4 are, almost line-for-line, already implemented downstream.**
+- The few genuinely *missing* primitives are a small subset of Documents 1–2.
+- The proposal **omits the work the ecosystem actually asks Core for** — thin pointer-level
+  APIs and shared provider protocols, published as explicit "requests" in the downstream repos.
+
+The correct strategy is therefore not "grow Core to match the proposal," nor "reject everything,"
+but: **redirect the already-owned items to their real owners, accept the narrow CPU-primitive
+gaps, and invest the real effort in the seams downstream is requesting.** VectorCore's leverage
+is not feature breadth — it is being the small, correct, allocation-free foundation that the rest
+of the suite is *currently bypassing* because the seams are too coarse.
+
+> **Smell test for "does this belong in Core?"** A primitive belongs in Core when it is
+> (a) CPU-only, (b) distance-metric / index-topology agnostic, (c) reusable by ≥2 downstream
+> packages, and (d) not already owned by exactly one of them. By this test, GEMM-batch (CPU),
+> block-quant format, and the seam APIs qualify; mmap, GPU arenas, ADC, visited-lists, and
+> priority queues do not.
+
+---
+
+## 2. Ecosystem maturity map
+
+| Package | Version | Size | Owns today (relevant to the proposal) |
+|---|---|---|---|
+| **VectorCore** | 0.2.2 | — | Vector types, SIMD/SoA kernels, INT8 + FP16 quant primitives, Top-K heap, aligned memory, provider protocols |
+| **VectorIndex** | 0.1.5 | ~25k LoC | HNSW (bitset visited-list), `TopKHeap`, full PQ/IVF + ADC LUTs, `mmap` layout (WIP), prefetch |
+| **VectorAccelerate** | 0.5.0 | ~53k LoC, 81 Metal shaders | GPU tiled GEMM, zero-copy `MTLStorageModeShared` bridging, ring-buffer pinned arenas, CPU/GPU routing facade, GPU Hamming/Jaccard |
+| **EmbedKit** | 0.1.0 | ~31k LoC | text → dense `[Float]` → `DynamicVector`; INT8/INT4/FP16/binary quant (per-vector, GPU) |
+
+`VectorAccelerate` lives under a `future/` directory only because it requires Metal 4
+(macOS 26+) — it is a real, released, production package, not a stub.
+
+Two downstream signals dominate this review:
+
+1. **`VectorIndex` deliberately bypasses Core's typed API** in hot paths (uses raw `[Float]` /
+   `UnsafePointer<Float>`) because the typed API allocates. See `VectorIndex/IMPROVEMENTS.md`.
+2. **Both `VectorIndex` and `VectorAccelerate` publish concrete "asks" of Core** that the
+   proposal never mentions (pointer-level Top-K, raw-buffer normalize, configurable tie-breaking,
+   `ComputeProvider`/`BufferManagementProvider`/`QuantizationProvider`). These are the real gaps.
+
+---
+
+## 3. Verdict table
+
+Legend: **Accept** = design spec in this suite, slated for `0.3.0`. **Defer** = sound but no
+ready producer/consumer; documented for later. **Redirect** = already owned by a sibling; Core
+duplicating it would fork live code.
+
+| # | Proposal task | In Core `0.2.2`? | Verdict | Evidence / owner (file pointer) |
+|---|---|---|---|---|
+| 1.1 | Block-wise quant (`Q8_0`) | Per-vector INT8 only | **Accept** | Gap: `Quantization/QuantizationSchemes.swift` is whole-vector. Spec → DOCUMENT-3 |
+| 1.2 | Binary vectors + Hamming/Jaccard | Hamming-on-float only; no packed type | **Defer** | GPU versions exist in `VectorAccelerate`; no committed CPU consumer. DOCUMENT-1 |
+| 1.3 | Prefetch intrinsics | `prefetchRead/Write` are no-ops | **Redirect** | `VectorIndex/Sources/VectorIndex/Operations/Support/Prefetch.swift` (real builtins) |
+| 2.1 | GEMM batch distance (GPU) | None | **Redirect** | `VectorAccelerate` tiled GPU GEMM (`Metal/Shaders/OptimizedMatrixOps.metal`) |
+| 2.1 | GEMM batch distance (**CPU/AMX**) | None | **Accept** | Gap: nobody has the CPU `cblas_sgemm` path. Spec → DOCUMENT-2 |
+| 2.2 | Sparse CSR + SparseBLAS | None | **Defer** | No producer (EmbedKit dense-only; hybrid is a P2 roadmap item). DOCUMENT-1 |
+| 3.1 | `mmap` storage | None | **Redirect** | `VectorIndex/Sources/VectorIndex/Kernels/VIndexMmap.swift` (real, WIP) |
+| 3.2 | Pinned Metal arena | `MemoryPool` (not pinned) | **Redirect** | `VectorAccelerate/Sources/VectorAccelerate/Core/BufferPool.swift` |
+| 4.1 | ADC look-up tables | None; PQ deferred | **Redirect** | `VectorIndex/Sources/VectorIndex/Operations/Quantization/{ADCScan,PQLUT}.swift` |
+| 4.2 | Generation visited-list | None | **Redirect** | `VectorIndex/Sources/VectorIndex/Kernels/HNSWTraversal.swift` (bitset) |
+| 4.3 | Concurrent priority queue | Single-thread `TopKBuffer` | **Redirect** | `VectorIndex/Sources/VectorIndex/Operations/Selection/TopK.swift` (`TopKHeap`) |
+| — | Pointer-level Top-K API | None | **Accept** | Requested: `VectorIndex/IMPROVEMENTS.md` §9.5. Spec → DOCUMENT-4 |
+| — | Raw-buffer in-place normalize | Typed only | **Accept** | Requested: `VectorIndex/IMPROVEMENTS.md` §9.5. Spec → DOCUMENT-4 |
+| — | Configurable tie-breaking | Insertion-order only | **Accept** | Requested: `VectorIndex/IMPROVEMENTS.md` §9.5. Spec → DOCUMENT-4 |
+| — | Provider protocols | Partial | **Accept** | Requested: `VectorAccelerate/docs/ADD/VECTORCORE_ALIGNMENT_ROADMAP.md`. DOCUMENT-4 |
+| — | Zero-copy buffer contract | `AlignedMemory` exists | **Accept** | EmbedKit P1 zero-copy (`EmbedKit/dev_EKRefactor/Future_Improvements.md`). DOCUMENT-4 |
+
+**Net `0.3.0` Core work:** two CPU math/format primitives (DOCUMENT-2, DOCUMENT-3) and one
+seam-hardening track (DOCUMENT-4). Everything else is redirected or deferred with rationale.
+
+---
+
+## 4. Corrected execution order
+
+The proposal's Document 0 sequences GEMM → quant → numerical-rigor → mmap, justified as
+"GEMM needs no new memory structures." After pruning to the accepted set, the dependency that
+actually matters is **layouts before the math that consumes them**, and **seams before the
+primitives that ride on them** (so downstream can adopt incrementally):
+
+1. **Seams first (DOCUMENT-4).** Pointer APIs, tie-breaking, and provider protocols are
+   additive, low-risk, and immediately unblock `VectorIndex`/`VectorAccelerate` — they stop
+   bypassing Core. Ship these early in `0.3.0`.
+2. **GEMM batch-distance (DOCUMENT-2).** Pure CPU, reuses existing optimized storage, highest
+   throughput ROI, no new public types beyond an entry point.
+3. **Block quant (DOCUMENT-3) — gated.** Only proceed once a consumer (EmbedKit storage or
+   VectorIndex codes) commits; otherwise it is an unexercised format.
+
+This inverts the proposal's "GEMM first" because the seams are what the ecosystem is blocked on
+*today*, and they cost the least.
+
+---
+
+## 5. Corrections appendix (technical errata in the proposal)
+
+Recorded so they are not silently propagated into implementation:
+
+1. **"Lock-free … using `os_unfair_lock` (Spinlocks)"** (Task 4.3) is a contradiction. A
+   spinlock is a *lock*; lock-free means progress without mutual exclusion (CAS loops). The
+   downstream `TopKHeap` is correctly actor-isolated, not "lock-free." If a true concurrent
+   queue is ever needed, it belongs in `VectorIndex` and should use `swift-atomics` /
+   `Synchronization.Atomic`, not the deprecated `OSAtomic`.
+2. **"Zero floating-point accumulation drift"** (Task 4.1) is unattainable — IEEE-754 addition
+   is non-associative. The correct contract is *bounded* drift via Kahan/Neumaier or pairwise
+   summation. DOCUMENT-2 and DOCUMENT-3 state error bounds rather than promising zero.
+3. **GGML `Q8_0` stores a per-block scale only** (symmetric). The proposal's "scale *and*
+   offset per block" describes `Q8_1`. DOCUMENT-3 specifies `Q8_0` correctly and notes `Q8_1`
+   as a variant.
+4. **"GPU pages vector data directly from SSD … without CPU intervention"** (Task 3.1)
+   overstates it: `mmap` + `makeBuffer(bytesNoCopy:)` still services page faults through the
+   kernel/VM subsystem. The DiskANN benefit is real but is not literally CPU-free.
+5. **AMX routing claim is correct.** Accelerate's BLAS (`cblas_sgemm`) does dispatch to the AMX
+   coprocessor on Apple Silicon; DOCUMENT-2 relies on this and treats it as the intended path
+   (no undocumented intrinsics).
+
+---
+
+## 6. Document index
+
+| Doc | Contents |
+|---|---|
+| `be4-master.md` | This file — thesis, ecosystem map, verdict table, execution order, errata |
+| `DOCUMENT-1_Redirections.md` | Per-item redirect/defer rationale with sibling-repo pointers |
+| `DOCUMENT-2_Spec_GEMM_Batch_Distance.md` | CPU AMX GEMM batch-distance design spec |
+| `DOCUMENT-3_Spec_Block_Quantization.md` | `Q8_0` block-wise quantization design spec |
+| `DOCUMENT-4_Spec_Ecosystem_Seams.md` | Downstream-requested seams (pointer APIs, protocols, zero-copy) |

--- a/Docs/beta-evolution-4/be4-master.md
+++ b/Docs/beta-evolution-4/be4-master.md
@@ -1,8 +1,8 @@
 # Beta-Evolution-4 — Master Decision Review
 
-**Status:** Strategic review + design specs (no source changes in this phase)
+**Status:** Strategic review + design specs — **implemented on `feature/beta-evo-4`, targeting 0.3.0** (released 2026-06-07)
 **Target release:** VectorCore `0.3.0`
-**Date:** 2026-06-06
+**Date:** 2026-06-06 (implementation reconciled 2026-06-07)
 **Inputs reviewed:** External "Documents 0–4" strategy (Gemini); VectorCore `0.2.2` source;
 downstream packages `VectorIndex` `0.1.5`, `VectorAccelerate` `0.5.0`, `EmbedKit` `0.1.0`.
 
@@ -64,29 +64,41 @@ Two downstream signals dominate this review:
 
 Legend: **Accept** = design spec in this suite, slated for `0.3.0`. **Defer** = sound but no
 ready producer/consumer; documented for later. **Redirect** = already owned by a sibling; Core
-duplicating it would fork live code.
+duplicating it would fork live code. ✅ **shipped 0.3.0** marks rows whose accepted spec is now
+implemented on `feature/beta-evo-4`; **⏸ Deferred** marks accepted specs that remain unbuilt
+(consumer-gated).
 
 | # | Proposal task | In Core `0.2.2`? | Verdict | Evidence / owner (file pointer) |
 |---|---|---|---|---|
-| 1.1 | Block-wise quant (`Q8_0`) | Per-vector INT8 only | **Accept** | Gap: `Quantization/QuantizationSchemes.swift` is whole-vector. Spec → DOCUMENT-3 |
-| 1.2 | Binary vectors + Hamming/Jaccard | Hamming-on-float only; no packed type | **Defer** | GPU versions exist in `VectorAccelerate`; no committed CPU consumer. DOCUMENT-1 |
-| 1.3 | Prefetch intrinsics | `prefetchRead/Write` are no-ops | **Redirect** | `VectorIndex/Sources/VectorIndex/Operations/Support/Prefetch.swift` (real builtins) |
-| 2.1 | GEMM batch distance (GPU) | None | **Redirect** | `VectorAccelerate` tiled GPU GEMM (`Metal/Shaders/OptimizedMatrixOps.metal`) |
-| 2.1 | GEMM batch distance (**CPU/AMX**) | None | **Accept** | Gap: nobody has the CPU `cblas_sgemm` path. Spec → DOCUMENT-2 |
-| 2.2 | Sparse CSR + SparseBLAS | None | **Defer** | No producer (EmbedKit dense-only; hybrid is a P2 roadmap item). DOCUMENT-1 |
-| 3.1 | `mmap` storage | None | **Redirect** | `VectorIndex/Sources/VectorIndex/Kernels/VIndexMmap.swift` (real, WIP) |
-| 3.2 | Pinned Metal arena | `MemoryPool` (not pinned) | **Redirect** | `VectorAccelerate/Sources/VectorAccelerate/Core/BufferPool.swift` |
-| 4.1 | ADC look-up tables | None; PQ deferred | **Redirect** | `VectorIndex/Sources/VectorIndex/Operations/Quantization/{ADCScan,PQLUT}.swift` |
-| 4.2 | Generation visited-list | None | **Redirect** | `VectorIndex/Sources/VectorIndex/Kernels/HNSWTraversal.swift` (bitset) |
-| 4.3 | Concurrent priority queue | Single-thread `TopKBuffer` | **Redirect** | `VectorIndex/Sources/VectorIndex/Operations/Selection/TopK.swift` (`TopKHeap`) |
-| — | Pointer-level Top-K API | None | **Accept** | Requested: `VectorIndex/IMPROVEMENTS.md` §9.5. Spec → DOCUMENT-4 |
-| — | Raw-buffer in-place normalize | Typed only | **Accept** | Requested: `VectorIndex/IMPROVEMENTS.md` §9.5. Spec → DOCUMENT-4 |
-| — | Configurable tie-breaking | Insertion-order only | **Accept** | Requested: `VectorIndex/IMPROVEMENTS.md` §9.5. Spec → DOCUMENT-4 |
-| — | Provider protocols | Partial | **Accept** | Requested: `VectorAccelerate/docs/ADD/VECTORCORE_ALIGNMENT_ROADMAP.md`. DOCUMENT-4 |
-| — | Zero-copy buffer contract | `AlignedMemory` exists | **Accept** | EmbedKit P1 zero-copy (`EmbedKit/dev_EKRefactor/Future_Improvements.md`). DOCUMENT-4 |
+| 1.1 | Block-wise quant (`Q8_0`) | Per-vector INT8 only | **⏸ Deferred** (specced, **not built** — consumer-gated) | Gap: `Quantization/QuantizationSchemes.swift` is whole-vector. Spec → DOCUMENT-3; held until a consumer (EmbedKit storage / VectorIndex codes) commits |
+| 1.2 | Binary vectors + Hamming/Jaccard | Hamming-on-float only; no packed type | **Defer** → **Redirect** (VectorAccelerate) | GPU versions exist in `VectorAccelerate`; binary-packed + Hamming/Jaccard redirected there, no committed CPU consumer (confirmed not in Core 0.3.0). DOCUMENT-1 |
+| 1.3 | Prefetch intrinsics | `prefetchRead/Write` are no-ops | **Redirect** (confirmed not in Core 0.3.0) | `VectorIndex/Sources/VectorIndex/Operations/Support/Prefetch.swift` (real builtins) |
+| 2.1 | GEMM batch distance (GPU) | None | **Redirect** (confirmed not in Core 0.3.0) | `VectorAccelerate` tiled GPU GEMM (`Metal/Shaders/OptimizedMatrixOps.metal`) |
+| 2.1 | GEMM batch distance (**CPU/AMX**) | None | **Accept** ✅ **shipped 0.3.0** | Gap closed: CPU `cblas_sgemm`→AMX path → `Sources/VectorCore/Operations/MatrixDistance.swift` (`euclideanSquaredMatrix` / `cosineDistanceMatrix`, `prepare(_:normalized:)`, `PreparedCandidates`). Spec → DOCUMENT-2 |
+| 2.2 | Sparse CSR + SparseBLAS | None | **Defer** (no producer) | No producer (EmbedKit dense-only; hybrid is a P2 roadmap item); deferred — confirmed not in Core 0.3.0. DOCUMENT-1 |
+| 3.1 | `mmap` storage | None | **Redirect** (confirmed not in Core 0.3.0) | `VectorIndex/Sources/VectorIndex/Kernels/VIndexMmap.swift` (real, WIP) |
+| 3.2 | Pinned Metal arena | `MemoryPool` (not pinned) | **Redirect** (confirmed not in Core 0.3.0) | `VectorAccelerate/Sources/VectorAccelerate/Core/BufferPool.swift` |
+| 4.1 | ADC look-up tables | None; PQ deferred | **Redirect** (confirmed not in Core 0.3.0) | `VectorIndex/Sources/VectorIndex/Operations/Quantization/{ADCScan,PQLUT}.swift` |
+| 4.2 | Generation visited-list | None | **Redirect** (confirmed not in Core 0.3.0) | `VectorIndex/Sources/VectorIndex/Kernels/HNSWTraversal.swift` (bitset) |
+| 4.3 | Concurrent priority queue | Single-thread `TopKBuffer` | **Redirect** (confirmed not in Core 0.3.0) | `VectorIndex/Sources/VectorIndex/Operations/Selection/TopK.swift` (`TopKHeap`) |
+| — | Pointer-level Top-K API | None | **Accept** ✅ **shipped 0.3.0** | Requested: `VectorIndex/IMPROVEMENTS.md` §9.5 → `Sources/VectorCore/Operations/TopKSelection.swift`. Spec → DOCUMENT-4 |
+| — | Raw-buffer in-place normalize | Typed only | **Accept** ✅ **shipped 0.3.0** | Requested: `VectorIndex/IMPROVEMENTS.md` §9.5. Spec → DOCUMENT-4 |
+| — | Configurable tie-breaking | Insertion-order only | **Accept** ✅ **shipped 0.3.0** | Requested: `VectorIndex/IMPROVEMENTS.md` §9.5 → `TieBreaker` (`.smallerIndex` default / `.insertionOrder` / `.smallerValue`) in `Operations/TopKSelection.swift`. Spec → DOCUMENT-4 |
+| — | Provider protocols | Partial | **Accept** ✅ **shipped 0.3.0** | Requested: `VectorAccelerate/docs/ADD/VECTORCORE_ALIGNMENT_ROADMAP.md` → `BatchKernelProvider` (`Sources/VectorCore/Protocols/BatchKernelProvider.swift`). DOCUMENT-4 |
+| — | Zero-copy buffer contract | `AlignedMemory` exists | **Accept** ✅ **shipped 0.3.0** | EmbedKit P1 zero-copy (`EmbedKit/dev_EKRefactor/Future_Improvements.md`) → `UnifiedVectorBuffer` + `PageAlignedBuffer` (`Storage/UnifiedVectorBuffer.swift`) and frozen `SoALayout` contract (`Storage/SoALayout.swift`). DOCUMENT-4 |
 
-**Net `0.3.0` Core work:** two CPU math/format primitives (DOCUMENT-2, DOCUMENT-3) and one
-seam-hardening track (DOCUMENT-4). Everything else is redirected or deferred with rationale.
+**Net `0.3.0` Core work (as shipped):** the seam-hardening track (DOCUMENT-4) and the CPU GEMM
+batch-distance primitive (DOCUMENT-2) shipped on `feature/beta-evo-4`; the block-quant format
+(DOCUMENT-3) was **deferred** (specced, not built — consumer-gated). Everything else is
+redirected or deferred with rationale.
+
+Additionally shipped under the DOCUMENT-4 / SoA-layout track in `0.3.0`: the frozen `SoALayout`
+descriptor and SoA layout contract (`SoALayout.forType(_:count:pageAligned:)`, `SoA.layoutDescriptor`),
+SoA page-alignment APIs (`SoA.build(from:pageAligned:)`, `init(vectors:pageAligned:)`,
+`pageAlignedBytes`, `consumeAllocation()`, `withUnsafeRawBuffer`), `BatchOperations.Configuration`
+matrix routing (`enableMatrixRouting` default `true`, `matrixRoutingMinN` default `256`),
+`PlatformConfiguration.roundUpToPage(_:)`, and the **breaking** removal of the no-op `blockSize:`
+parameter from `SoA.init(vectors:…)` and `SoAFP16.init(vectors:…)`.
 
 ---
 
@@ -97,13 +109,18 @@ The proposal's Document 0 sequences GEMM → quant → numerical-rigor → mmap,
 actually matters is **layouts before the math that consumes them**, and **seams before the
 primitives that ride on them** (so downstream can adopt incrementally):
 
-1. **Seams first (DOCUMENT-4).** Pointer APIs, tie-breaking, and provider protocols are
-   additive, low-risk, and immediately unblock `VectorIndex`/`VectorAccelerate` — they stop
-   bypassing Core. Ship these early in `0.3.0`.
-2. **GEMM batch-distance (DOCUMENT-2).** Pure CPU, reuses existing optimized storage, highest
-   throughput ROI, no new public types beyond an entry point.
-3. **Block quant (DOCUMENT-3) — gated.** Only proceed once a consumer (EmbedKit storage or
-   VectorIndex codes) commits; otherwise it is an unexercised format.
+1. **Seams first (DOCUMENT-4) — ✅ done in `0.3.0`.** Pointer APIs, tie-breaking (`TieBreaker`),
+   the provider protocol (`BatchKernelProvider`), the zero-copy buffer contract
+   (`UnifiedVectorBuffer`/`PageAlignedBuffer`), and the frozen `SoALayout` contract shipped first
+   — they were additive, low-risk, and immediately unblocked `VectorIndex`/`VectorAccelerate` so
+   they stop bypassing Core.
+2. **GEMM batch-distance (DOCUMENT-2) — ✅ done in `0.3.0`.** Pure CPU (`cblas_sgemm`→AMX),
+   reused the existing optimized storage, highest throughput ROI; landed as `MatrixDistance`
+   with no new public types beyond the entry point (and transparent routing via
+   `BatchOperations.Configuration.enableMatrixRouting`).
+3. **Block quant (DOCUMENT-3) — still gated (deferred, not built in `0.3.0`).** Will only
+   proceed once a consumer (EmbedKit storage or VectorIndex codes) commits; otherwise it is an
+   unexercised format.
 
 This inverts the proposal's "GEMM first" because the seams are what the ecosystem is blocked on
 *today*, and they cost the least.

--- a/Docs/future_roadmap.md
+++ b/Docs/future_roadmap.md
@@ -2,6 +2,12 @@
 
 **Scope:** High-performance CPU-bound vector mathematics via `vDSP` and `simd`.
 
+> **Note (2026-06-07):** This document predates the **"hold the line, sharpen the seams"**
+> strategy adopted for 0.3.0. Some primitives it lists as "missing" (FP16, scalar INT8) already
+> ship in Core. The authoritative 0.3.0 record of work is
+> `Docs/beta-evolution-4/be4-master.md` (+ `CHANGELOG`); findings below are kept for historical
+> context and annotated inline where superseded.
+
 ## Context
 `VectorCore` is the fallback and low-latency engine for this stack. Because Apple Silicon CPUs have incredibly wide and fast SIMD registers (NEON), CPU execution is the optimal path for single-query searches, streaming data, and small micro-batches. It must be brutally fast and allocation-free.
 
@@ -13,10 +19,17 @@
     *   Implement Swift 6 `~Copyable` (noncopyable) structs for internal scratch/vector storage to guarantee deterministic memory ownership transfer without ARC.
     *   Audit all asynchronous boundaries to ensure strict `Sendable` compliance.
 
-## Finding 2: Missing Low-Precision & Quantization Primitives
+## Finding 2: Low-Precision & Quantization Primitives — *mostly shipped; re-scoped for 0.3.0*
+
+> **Status update (2026-06-07):** FP16 and **scalar INT8** are no longer "missing" — both already
+> ship in Core (FP16 mixed precision via `MixedPrecisionKernels`; scalar INT8 via
+> `QuantizationSchemes`). They are struck from the task list below. The remaining quant asks are
+> re-scoped per the 0.3.0 "hold the line, sharpen the seams" decision.
+
 *   **The Problem:** Standardizing entirely on 32-bit floating point (`Float32`) halves potential memory bandwidth. State-of-the-art vector workloads maximize cache locality by scaling down to `Float16` or Scalar Quantization (`Int8`), shrinking downstream RAG caches by up to 4x.
 *   **The Solution:** Hardware-optimized precision types.
 *   **Agent Implementation Tasks:** 
-    *   Add native `Float16` support utilizing Apple's `vDSP` half-precision conversion and dot-product functions (`vDSP_dotpr_f16`).
-    *   **Scalar Quantization:** Add functions to compress `Float32` bounds to `Int8` via min/max scaling, and perform dot products using integer arithmetic.
-    *   **Binary Vectors:** Implement a struct for `[UInt64]` bit-packed vectors and compute Hamming distance using the ultra-fast CPU instruction `nonzeroBitCount` (popcount) via `simd_popcount`.
+    *   ~~Add native `Float16` support utilizing Apple's `vDSP` half-precision conversion and dot-product functions (`vDSP_dotpr_f16`).~~ ✅ **Already ships in Core** (`MixedPrecisionKernels`).
+    *   ~~**Scalar Quantization:** Add functions to compress `Float32` bounds to `Int8` via min/max scaling, and perform dot products using integer arithmetic.~~ ✅ **Already ships in Core** (`QuantizationSchemes`, scalar INT8).
+    *   **Block-wise quantization (`Q8_0`):** the still-open quant gap (per-block scale, not whole-vector). **DEFERRED** for 0.3.0 — specced but **consumer-gated**; will land only once a consumer (EmbedKit storage / VectorIndex codes) commits. See `Docs/beta-evolution-4/DOCUMENT-3_Spec_Block_Quantization.md`.
+    *   **Binary Vectors (`[UInt64]` bit-packed + Hamming/Jaccard via popcount):** **REDIRECTED to VectorAccelerate** — GPU versions already exist there and there is no committed CPU consumer, so Core does not ship a packed binary type.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Note: Kernel helpers, storage backends, and buffer pools are internal implementa
 
 ## ⚡️ GPU Acceleration
 
-VectorCore is CPU-only and contains no GPU/Metal code. If you need GPU acceleration, use the separate VectorAccelerate package, which implements GPU-backed compute while integrating seamlessly with VectorCore types and protocols.
+VectorCore ships **no GPU/Metal code** — it stays CPU-only. What it provides (as of 0.3.0) is the *seam* for GPU acceleration: a zero-copy buffer contract (`UnifiedVectorBuffer` / `PageAlignedBuffer`, and opt-in page-aligned `SoA`) whose memory is valid for `MTLDevice.makeBuffer(bytesNoCopy:)`, plus a `BatchKernelProvider` hook so an installed GPU provider transparently services `Operations.findNearest` / `findNearestBatch`. The GPU implementation lives in the separate VectorAccelerate package, which plugs into these seams. See [Package Boundaries](Docs/Package_Boundaries.md) and [SoA Layout Contract](Docs/SoA_Layout_Contract.md).
 
 ## 📦 Installation
 
@@ -35,7 +35,7 @@ Add VectorCore to your Swift Package Manager dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/gifton/VectorCore.git", from: "0.2.2")
+    .package(url: "https://github.com/gifton/VectorCore.git", from: "0.3.0")
 ]
 ```
 
@@ -230,6 +230,13 @@ let distances = await BatchOperations.pairwiseDistances(vectors)
 // Centroid and statistics
 let centroid: Vector<Dim512> = Operations.centroid(of: vectors)
 let stats = await BatchOperations.statistics(for: vectors)
+
+// Large batches auto-route through a CPU GEMM path (Accelerate cblas_sgemm →
+// AMX on Apple Silicon) above `matrixRoutingMinN` (default 256). For direct
+// control, MatrixDistance computes a full query×candidate matrix over the
+// optimized vector types (any UnifiedVectorBuffer):
+let dmat = MatrixDistance.euclideanSquaredMatrix(queries: queryVecs, candidates: dbVecs)
+// row-major: dmat[i * dbVecs.count + j] = ‖queryVecs[i] − dbVecs[j]‖²
 ```
 
 ### Provider Configuration
@@ -337,9 +344,10 @@ See [Swift Evolution SE-0337](https://github.com/apple/swift-evolution/blob/main
 ### API Documentation
 
 - **Vector Types**: `Vector<D>`, `DynamicVector`, `Vector{512,768,1536}Optimized`
-- **Operations**: `Operations` (primary API), `BatchOperations` (auto-parallelized batches)
+- **Operations**: `Operations` (primary API), `BatchOperations` (auto-parallelized batches), `MatrixDistance` (GEMM batch-distance matrices)
 - **Distance Metrics**: `EuclideanDistance`, `CosineDistance`, `ManhattanDistance`, `ChebyshevDistance`, `HammingDistance`, `MinkowskiDistance`, `DotProductDistance`
-- **Providers**: `SIMDProvider`, `ComputeProvider`, `BufferProvider` (plug-in architecture via `@TaskLocal`)
+- **Providers**: `SIMDProvider`, `ComputeProvider`, `BufferProvider`, `BatchKernelProvider` (transparent GPU dispatch) — plug-in architecture via `@TaskLocal`
+- **Buffers**: `UnifiedVectorBuffer` / `PageAlignedBuffer` (zero-copy GPU-bridge contract), `SoALayout` (frozen SoA layout descriptor)
 
 ## 🤝 Contributing
 

--- a/Sources/VectorCore/Operations/BatchOperations.swift
+++ b/Sources/VectorCore/Operations/BatchOperations.swift
@@ -65,6 +65,17 @@ public enum BatchOperations {
         /// Default batch size for iterative processing
         public var defaultBatchSize: Int = 1024
 
+        /// Route large pairwise distance matrices through the GEMM (`cblas_sgemm` /
+        /// AMX) path for optimized vector types + Euclidean/Cosine. The GEMM result
+        /// agrees with the per-pair kernels within the DOCUMENT-2 tolerance (~1e-3
+        /// rel) but is not bit-identical; disable to force the exact per-pair path.
+        public var enableMatrixRouting: Bool = true
+
+        /// Minimum N (per side) before pairwise routing switches to GEMM. Below this,
+        /// the per-pair kernels win; above it, the matrix multiply amortizes packing.
+        /// Calibratable via `MatrixDistanceBench`.
+        public var matrixRoutingMinN: Int = 256
+
         public init() {}
     }
 
@@ -205,6 +216,15 @@ public enum BatchOperations {
         metric: M = EuclideanDistance()
     ) async -> [[Float]] where V.Scalar == M.Scalar, M.Scalar == Float {
         let n = vectors.count
+        guard n > 0 else { return [] }
+
+        // GEMM fast path (DOCUMENT-2): for optimized types + Euclidean/Cosine above the
+        // crossover threshold, compute the whole N×N matrix with one cblas_sgemm (AMX).
+        let config = await _configuration.get()
+        if config.enableMatrixRouting, n >= config.matrixRoutingMinN,
+           let routed = gemmPairwise(vectors, metric: metric) {
+            return routed
+        }
 
         // Serial for small matrices
         if n < 100 {
@@ -213,6 +233,47 @@ public enum BatchOperations {
 
         // Parallel block-based computation
         return await computePairwiseParallel(vectors, metric: metric)
+    }
+
+    /// GEMM pairwise dispatch: returns the `[[Float]]` distance matrix when `vectors`
+    /// is a known optimized type and `metric` is Euclidean or Cosine; otherwise `nil`
+    /// (caller falls back to the per-pair path).
+    private static func gemmPairwise<V: VectorProtocol, M: DistanceMetric>(
+        _ vectors: [V], metric: M
+    ) -> [[Float]]? {
+        let isEuclid = metric is EuclideanDistance
+        let isCosine = metric is CosineDistance
+        guard isEuclid || isCosine else { return nil }
+
+        if let vs = vectors as? [Vector512Optimized] { return gemmPairwiseTyped(vs, euclid: isEuclid) }
+        if let vs = vectors as? [Vector768Optimized] { return gemmPairwiseTyped(vs, euclid: isEuclid) }
+        if let vs = vectors as? [Vector1536Optimized] { return gemmPairwiseTyped(vs, euclid: isEuclid) }
+        return nil
+    }
+
+    /// Compute the pairwise matrix via `MatrixDistance` and reshape to `[[Float]]`.
+    /// Euclidean returns true distances (the GEMM path yields squared, so we `sqrt`
+    /// the already-clamped values).
+    private static func gemmPairwiseTyped<O: UnifiedVectorBuffer>(
+        _ vs: [O], euclid: Bool
+    ) -> [[Float]] {
+        let n = vs.count
+        let flat = euclid
+            ? MatrixDistance.euclideanSquaredMatrix(queries: vs, candidates: vs)
+            : MatrixDistance.cosineDistanceMatrix(queries: vs, candidates: vs)
+        var rows = [[Float]]()
+        rows.reserveCapacity(n)
+        for i in 0..<n {
+            var row = [Float](repeating: 0, count: n)
+            let base = i * n
+            if euclid {
+                for j in 0..<n { let v = flat[base + j]; row[j] = v > 0 ? sqrt(v) : 0 }
+            } else {
+                for j in 0..<n { row[j] = flat[base + j] }
+            }
+            rows.append(row)
+        }
+        return rows
     }
 
     // MARK: - Convenience Operations

--- a/Sources/VectorCore/Operations/Kernels/MixedPrecisionKernels.swift
+++ b/Sources/VectorCore/Operations/Kernels/MixedPrecisionKernels.swift
@@ -497,12 +497,15 @@ public enum MixedPrecisionKernels {
             self.groupCount = groupCap
         }
 
-        /// Convenience initializer from vectors (for test compatibility)
+        /// Convenience initializer from vectors (for test compatibility).
+        ///
+        /// - Note: `SoAFP16` uses vector-grouping (groups of 4 vectors, dimension-first),
+        ///   not dimension-blocking; there is intentionally no `blockSize` parameter. (A
+        ///   prior no-op `blockSize:` was removed in 0.3.0.)
         /// - Parameters:
         ///   - vectors: Array of optimized vectors to convert
-        ///   - blockSize: Ignored (reserved for future chunking optimizations)
         /// - Throws: VectorError if vectors have incompatible dimensions
-        public init(vectors: [VectorType], blockSize: Int = 32) throws {
+        public init(vectors: [VectorType]) throws {
             // An empty vector array yields a valid empty SoA (vectorCount == 0); the
             // specialized builders below already handle that degenerate case without throwing.
             // Delegate to the specialized creation function for each supported dimension.

--- a/Sources/VectorCore/Operations/Kernels/TopKSelectionKernels.swift
+++ b/Sources/VectorCore/Operations/Kernels/TopKSelectionKernels.swift
@@ -13,10 +13,14 @@ internal struct TopKBuffer: Sendable {
     public var idxs: [Int]
     @usableFromInline var size: Int
     public let isMinHeap: Bool
+    /// Policy for resolving equal-value ties. Default `.smallerIndex` reproduces
+    /// the historical behavior (and matches the array/pointer selection paths).
+    @usableFromInline let tieBreaker: TieBreaker
 
-    public init(k: Int, isMinHeap: Bool) {
+    public init(k: Int, isMinHeap: Bool, tieBreaker: TieBreaker = .smallerIndex) {
         self.k = k
         self.isMinHeap = isMinHeap
+        self.tieBreaker = tieBreaker
         self.vals = Array(repeating: 0, count: k)
         self.idxs = Array(repeating: -1, count: k)
         self.size = 0
@@ -27,8 +31,16 @@ internal struct TopKBuffer: Sendable {
         if v1 != v2 {
             return isMinHeap ? (v1 < v2) : (v1 > v2)
         }
-        // Deterministic tiebreaker: prefer smaller index → larger index is worse
-        return i1 > i2
+        // Equal value → resolve by policy. "Worse" means evicted/ranked last.
+        switch tieBreaker {
+        case .smallerIndex, .insertionOrder:
+            // Prefer smaller index → larger index is worse.
+            // (For a linear index-ordered scan, insertion order == index order.)
+            return i1 > i2
+        case .smallerValue:
+            // No index preference; equal values are treated as equally good.
+            return false
+        }
     }
 
     @inlinable

--- a/Sources/VectorCore/Operations/MatrixDistance.swift
+++ b/Sources/VectorCore/Operations/MatrixDistance.swift
@@ -107,7 +107,7 @@ public enum MatrixDistance {
         var xNorm = [Float](repeating: 0, count: q)
         rowSumOfSquares(X, rows: q, d: d, into: &xNorm)
 
-        gemmCrossTerm(X: X, Y: prepared.packed, q: q, n: n, d: d, alpha: -2, into: &out)
+        gemmCrossTerm(X: X, Y: prepared.packed, n: n, d: d, alpha: -2, into: &out)
 
         let yNorm = prepared.norms
         out.withUnsafeMutableBufferPointer { ob in
@@ -162,7 +162,7 @@ public enum MatrixDistance {
         var X = packRows(queries, d: d)
         normalizeRows(&X, rows: q, d: d)
 
-        gemmCrossTerm(X: X, Y: prepared.packed, q: q, n: n, d: d, alpha: 1, into: &out)
+        gemmCrossTerm(X: X, Y: prepared.packed, n: n, d: d, alpha: 1, into: &out)
 
         out.withUnsafeMutableBufferPointer { ob in
             let o = ob.baseAddress!
@@ -227,9 +227,11 @@ public enum MatrixDistance {
     }
 
     /// `out (q × n) = alpha · X (q × d) · Y (n × d)ᵀ` via cblas_sgemm (AMX on Apple Silicon).
+    /// The row count `q` is derived from `X.count / d` (X is row-major `q × d`).
     private static func gemmCrossTerm(
-        X: [Float], Y: [Float], q: Int, n: Int, d: Int, alpha: Float, into out: inout [Float]
+        X: [Float], Y: [Float], n: Int, d: Int, alpha: Float, into out: inout [Float]
     ) {
+        let q = X.count / d
         X.withUnsafeBufferPointer { xb in
             Y.withUnsafeBufferPointer { yb in
                 out.withUnsafeMutableBufferPointer { ob in

--- a/Sources/VectorCore/Operations/MatrixDistance.swift
+++ b/Sources/VectorCore/Operations/MatrixDistance.swift
@@ -1,0 +1,188 @@
+// VectorCore: Matrix (GEMM) Batch Distance
+//
+// beta-evolution-4, DOCUMENT-2. CPU batch-distance via the identity
+//   ‖x − y‖² = ‖x‖² + ‖y‖² − 2⟨x, y⟩
+// computed with Accelerate's cblas_sgemm, which dispatches to the AMX coprocessor
+// on Apple Silicon. This is the high-throughput path for large query × candidate
+// matrices; the per-pair SIMD kernels (BatchKernels) remain the small-batch path.
+//
+// CPU-only. The GPU GEMM lives in VectorAccelerate.
+
+import Foundation
+import Accelerate
+
+/// GEMM-based batch distance over contiguous `Float32` vectors.
+///
+/// Packs queries (`q × d`) and candidates (`n × d`) into row-major matrices and
+/// computes the full `q × n` distance matrix with a single matrix multiply. Any
+/// `UnifiedVectorBuffer` works as input — the optimized `Vector*Optimized` types and
+/// `DynamicVector` all conform — so one implementation serves every dimension.
+///
+/// Results are written row-major: `out[i*n + j]` is the distance from `queries[i]`
+/// to `candidates[j]`. The `into:` forms are the hot path (caller owns `out`); the
+/// returning forms are convenience wrappers that allocate.
+public enum MatrixDistance {
+
+    // MARK: - Euclidean (squared)
+
+    /// Squared-Euclidean distance matrix via GEMM. `out[i*n + j] = ‖q_i − c_j‖²`,
+    /// clamped at 0 (the identity can round slightly negative when `q_i ≈ c_j`).
+    ///
+    /// - Precondition: `out.count == queries.count * candidates.count`, and all
+    ///   inputs share a dimension.
+    public static func euclideanSquaredMatrix<V: UnifiedVectorBuffer>(
+        queries: [V],
+        candidates: [V],
+        into out: inout [Float]
+    ) {
+        let q = queries.count
+        let n = candidates.count
+        guard q > 0, n > 0 else { return }
+        let d = queries[0].elementCount
+        precondition(candidates[0].elementCount == d,
+                     "queries and candidates must share a dimension (\(d) vs \(candidates[0].elementCount))")
+        precondition(out.count == q * n,
+                     "out must have q*n elements (got \(out.count), expected \(q * n))")
+
+        let X = packRows(queries, d: d)
+        let Y = packRows(candidates, d: d)
+
+        var xNorm = [Float](repeating: 0, count: q)
+        var yNorm = [Float](repeating: 0, count: n)
+        rowSumOfSquares(X, rows: q, d: d, into: &xNorm)
+        rowSumOfSquares(Y, rows: n, d: d, into: &yNorm)
+
+        // out = -2 · X · Yᵀ
+        gemmCrossTerm(X: X, Y: Y, q: q, n: n, d: d, alpha: -2, into: &out)
+
+        // out[i,j] += ‖x_i‖² + ‖y_j‖² ; clamp ≥ 0 (cancellation guard before any sqrt).
+        out.withUnsafeMutableBufferPointer { ob in
+            let o = ob.baseAddress!
+            for i in 0..<q {
+                let xi = xNorm[i]
+                let base = i * n
+                for j in 0..<n {
+                    let v = o[base + j] + xi + yNorm[j]
+                    o[base + j] = v < 0 ? 0 : v
+                }
+            }
+        }
+    }
+
+    /// Allocating convenience overload.
+    public static func euclideanSquaredMatrix<V: UnifiedVectorBuffer>(
+        queries: [V], candidates: [V]
+    ) -> [Float] {
+        var out = [Float](repeating: 0, count: queries.count * candidates.count)
+        euclideanSquaredMatrix(queries: queries, candidates: candidates, into: &out)
+        return out
+    }
+
+    // MARK: - Cosine distance (1 − cosine similarity)
+
+    /// Cosine *distance* matrix via GEMM on L2-normalized rows.
+    /// `out[i*n + j] = 1 − cos(q_i, c_j)`, clamped to `[0, 2]`.
+    public static func cosineDistanceMatrix<V: UnifiedVectorBuffer>(
+        queries: [V],
+        candidates: [V],
+        into out: inout [Float]
+    ) {
+        let q = queries.count
+        let n = candidates.count
+        guard q > 0, n > 0 else { return }
+        let d = queries[0].elementCount
+        precondition(candidates[0].elementCount == d,
+                     "queries and candidates must share a dimension (\(d) vs \(candidates[0].elementCount))")
+        precondition(out.count == q * n,
+                     "out must have q*n elements (got \(out.count), expected \(q * n))")
+
+        var X = packRows(queries, d: d)
+        var Y = packRows(candidates, d: d)
+        normalizeRows(&X, rows: q, d: d)
+        normalizeRows(&Y, rows: n, d: d)
+
+        // out = X · Yᵀ  (cosine similarities, since rows are unit-norm)
+        gemmCrossTerm(X: X, Y: Y, q: q, n: n, d: d, alpha: 1, into: &out)
+
+        // distance = 1 − similarity, clamped to [0, 2].
+        out.withUnsafeMutableBufferPointer { ob in
+            let o = ob.baseAddress!
+            for k in 0..<(q * n) {
+                let dist = 1 - o[k]
+                o[k] = dist < 0 ? 0 : (dist > 2 ? 2 : dist)
+            }
+        }
+    }
+
+    /// Allocating convenience overload.
+    public static func cosineDistanceMatrix<V: UnifiedVectorBuffer>(
+        queries: [V], candidates: [V]
+    ) -> [Float] {
+        var out = [Float](repeating: 0, count: queries.count * candidates.count)
+        cosineDistanceMatrix(queries: queries, candidates: candidates, into: &out)
+        return out
+    }
+
+    // MARK: - Private helpers
+
+    /// Pack vectors into a contiguous row-major `[rows × d]` Float buffer.
+    private static func packRows<V: UnifiedVectorBuffer>(_ vs: [V], d: Int) -> [Float] {
+        let stride = MemoryLayout<Float>.stride
+        var buf = [Float](repeating: 0, count: vs.count * d)
+        buf.withUnsafeMutableBytes { dst in
+            let dstBase = dst.baseAddress!
+            for (i, v) in vs.enumerated() {
+                v.withUnsafeContiguousBytes { src in
+                    memcpy(dstBase.advanced(by: i * d * stride), src.baseAddress!, d * stride)
+                }
+            }
+        }
+        return buf
+    }
+
+    /// Per-row sum of squares (‖row‖²) via vDSP.
+    private static func rowSumOfSquares(_ buf: [Float], rows: Int, d: Int, into norms: inout [Float]) {
+        buf.withUnsafeBufferPointer { bp in
+            let base = bp.baseAddress!
+            for i in 0..<rows {
+                var ss: Float = 0
+                vDSP_svesq(base + i * d, 1, &ss, vDSP_Length(d))
+                norms[i] = ss
+            }
+        }
+    }
+
+    /// L2-normalize each row in place (no-op for zero rows).
+    private static func normalizeRows(_ buf: inout [Float], rows: Int, d: Int) {
+        buf.withUnsafeMutableBufferPointer { bp in
+            let base = bp.baseAddress!
+            for i in 0..<rows {
+                var ss: Float = 0
+                vDSP_svesq(base + i * d, 1, &ss, vDSP_Length(d))
+                if ss > 0 {
+                    var inv = 1 / sqrtf(ss)
+                    vDSP_vsmul(base + i * d, 1, &inv, base + i * d, 1, vDSP_Length(d))
+                }
+            }
+        }
+    }
+
+    /// `out (q × n) = alpha · X (q × d) · Y (n × d)ᵀ` via cblas_sgemm (AMX on Apple Silicon).
+    private static func gemmCrossTerm(
+        X: [Float], Y: [Float], q: Int, n: Int, d: Int, alpha: Float, into out: inout [Float]
+    ) {
+        X.withUnsafeBufferPointer { xb in
+            Y.withUnsafeBufferPointer { yb in
+                out.withUnsafeMutableBufferPointer { ob in
+                    cblas_sgemm(
+                        CblasRowMajor, CblasNoTrans, CblasTrans,
+                        Int32(q), Int32(n), Int32(d),
+                        alpha, xb.baseAddress, Int32(d),
+                        yb.baseAddress, Int32(d),
+                        0, ob.baseAddress, Int32(n)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Sources/VectorCore/Operations/MatrixDistance.swift
+++ b/Sources/VectorCore/Operations/MatrixDistance.swift
@@ -21,7 +21,57 @@ import Accelerate
 /// Results are written row-major: `out[i*n + j]` is the distance from `queries[i]`
 /// to `candidates[j]`. The `into:` forms are the hot path (caller owns `out`); the
 /// returning forms are convenience wrappers that allocate.
+///
+/// For **repeated** search against a fixed candidate set, pack the candidates once
+/// with ``prepare(_:normalized:)`` and reuse the ``PreparedCandidates`` across many
+/// query batches — this avoids re-packing and re-norming the (large) candidate side
+/// on every call.
 public enum MatrixDistance {
+
+    // MARK: - Prepared (reusable) candidates
+
+    /// Candidates packed into a contiguous row-major matrix with their norms
+    /// precomputed, ready to be reused across many query batches.
+    ///
+    /// Build with ``MatrixDistance/prepare(_:normalized:)``. Use `normalized: false`
+    /// for Euclidean (stores raw rows + ‖·‖²) and `normalized: true` for Cosine
+    /// (stores unit-normalized rows).
+    public struct PreparedCandidates: Sendable {
+        @usableFromInline let packed: [Float]   // n × d, row-major
+        @usableFromInline let norms: [Float]    // ‖row‖² per candidate (empty when normalized)
+        @usableFromInline let n: Int
+        @usableFromInline let d: Int
+        @usableFromInline let normalized: Bool
+
+        @usableFromInline
+        init(packed: [Float], norms: [Float], n: Int, d: Int, normalized: Bool) {
+            self.packed = packed; self.norms = norms; self.n = n; self.d = d; self.normalized = normalized
+        }
+
+        /// Number of candidates.
+        public var count: Int { n }
+        /// Vector dimension.
+        public var dimension: Int { d }
+    }
+
+    /// Pack candidates once for reuse. `normalized: false` prepares for Euclidean
+    /// (raw rows + squared norms); `normalized: true` prepares for Cosine
+    /// (L2-normalized rows).
+    public static func prepare<V: UnifiedVectorBuffer>(
+        _ candidates: [V], normalized: Bool = false
+    ) -> PreparedCandidates {
+        let n = candidates.count
+        let d = n > 0 ? candidates[0].elementCount : 0
+        var packed = packRows(candidates, d: d)
+        if normalized {
+            normalizeRows(&packed, rows: n, d: d)
+            return PreparedCandidates(packed: packed, norms: [], n: n, d: d, normalized: true)
+        } else {
+            var norms = [Float](repeating: 0, count: n)
+            rowSumOfSquares(packed, rows: n, d: d, into: &norms)
+            return PreparedCandidates(packed: packed, norms: norms, n: n, d: d, normalized: false)
+        }
+    }
 
     // MARK: - Euclidean (squared)
 
@@ -35,27 +85,31 @@ public enum MatrixDistance {
         candidates: [V],
         into out: inout [Float]
     ) {
+        guard !queries.isEmpty, !candidates.isEmpty else { return }
+        euclideanSquaredMatrix(queries: queries, prepared: prepare(candidates, normalized: false), into: &out)
+    }
+
+    /// Squared-Euclidean distance matrix against pre-packed candidates (reusable path).
+    public static func euclideanSquaredMatrix<V: UnifiedVectorBuffer>(
+        queries: [V],
+        prepared: PreparedCandidates,
+        into out: inout [Float]
+    ) {
         let q = queries.count
-        let n = candidates.count
+        let n = prepared.n
         guard q > 0, n > 0 else { return }
+        precondition(!prepared.normalized, "PreparedCandidates for Euclidean must be built with normalized: false")
         let d = queries[0].elementCount
-        precondition(candidates[0].elementCount == d,
-                     "queries and candidates must share a dimension (\(d) vs \(candidates[0].elementCount))")
-        precondition(out.count == q * n,
-                     "out must have q*n elements (got \(out.count), expected \(q * n))")
+        precondition(prepared.d == d, "queries and candidates must share a dimension (\(d) vs \(prepared.d))")
+        precondition(out.count == q * n, "out must have q*n elements (got \(out.count), expected \(q * n))")
 
         let X = packRows(queries, d: d)
-        let Y = packRows(candidates, d: d)
-
         var xNorm = [Float](repeating: 0, count: q)
-        var yNorm = [Float](repeating: 0, count: n)
         rowSumOfSquares(X, rows: q, d: d, into: &xNorm)
-        rowSumOfSquares(Y, rows: n, d: d, into: &yNorm)
 
-        // out = -2 · X · Yᵀ
-        gemmCrossTerm(X: X, Y: Y, q: q, n: n, d: d, alpha: -2, into: &out)
+        gemmCrossTerm(X: X, Y: prepared.packed, q: q, n: n, d: d, alpha: -2, into: &out)
 
-        // out[i,j] += ‖x_i‖² + ‖y_j‖² ; clamp ≥ 0 (cancellation guard before any sqrt).
+        let yNorm = prepared.norms
         out.withUnsafeMutableBufferPointer { ob in
             let o = ob.baseAddress!
             for i in 0..<q {
@@ -87,24 +141,29 @@ public enum MatrixDistance {
         candidates: [V],
         into out: inout [Float]
     ) {
+        guard !queries.isEmpty, !candidates.isEmpty else { return }
+        cosineDistanceMatrix(queries: queries, prepared: prepare(candidates, normalized: true), into: &out)
+    }
+
+    /// Cosine distance matrix against pre-normalized candidates (reusable path).
+    public static func cosineDistanceMatrix<V: UnifiedVectorBuffer>(
+        queries: [V],
+        prepared: PreparedCandidates,
+        into out: inout [Float]
+    ) {
         let q = queries.count
-        let n = candidates.count
+        let n = prepared.n
         guard q > 0, n > 0 else { return }
+        precondition(prepared.normalized, "PreparedCandidates for Cosine must be built with normalized: true")
         let d = queries[0].elementCount
-        precondition(candidates[0].elementCount == d,
-                     "queries and candidates must share a dimension (\(d) vs \(candidates[0].elementCount))")
-        precondition(out.count == q * n,
-                     "out must have q*n elements (got \(out.count), expected \(q * n))")
+        precondition(prepared.d == d, "queries and candidates must share a dimension (\(d) vs \(prepared.d))")
+        precondition(out.count == q * n, "out must have q*n elements (got \(out.count), expected \(q * n))")
 
         var X = packRows(queries, d: d)
-        var Y = packRows(candidates, d: d)
         normalizeRows(&X, rows: q, d: d)
-        normalizeRows(&Y, rows: n, d: d)
 
-        // out = X · Yᵀ  (cosine similarities, since rows are unit-norm)
-        gemmCrossTerm(X: X, Y: Y, q: q, n: n, d: d, alpha: 1, into: &out)
+        gemmCrossTerm(X: X, Y: prepared.packed, q: q, n: n, d: d, alpha: 1, into: &out)
 
-        // distance = 1 − similarity, clamped to [0, 2].
         out.withUnsafeMutableBufferPointer { ob in
             let o = ob.baseAddress!
             for k in 0..<(q * n) {

--- a/Sources/VectorCore/Operations/Operations.swift
+++ b/Sources/VectorCore/Operations/Operations.swift
@@ -159,13 +159,12 @@ public enum Operations {
         guard qDim == vDim else {
             throw VectorError.dimensionMismatch(expected: vDim, actual: qDim)
         }
-        // R4 — transparent GPU dispatch: if a GPU kernel provider is installed, dispatch
-        // each query through it (its findNearest); this takes precedence over CPU GEMM.
+        // R4 — transparent GPU dispatch: an installed BatchKernelProvider services the
+        // whole batch (a conformer may encode all queries in one kernel; the default
+        // loops findNearest). Takes precedence over CPU GEMM.
         if let gpu = computeProvider as? any BatchKernelProvider {
-            return try await gpu.parallelExecute(items: 0..<queries.count) { i in
-                let pairs = try await gpu.findNearest(query: queries[i], candidates: vectors, k: k, metric: metric)
-                return pairs.map { NearestNeighborResult(index: $0.index, distance: $0.distance) }
-            }
+            let batched = try await gpu.findNearestBatch(queries: queries, candidates: vectors, k: k, metric: metric)
+            return batched.map { $0.map { NearestNeighborResult(index: $0.index, distance: $0.distance) } }
         }
         // GEMM fast path (DOCUMENT-2): for large multi-query k-NN over optimized types
         // + Euclidean/Cosine, one cblas_sgemm (AMX) yields the q×n matrix; each row is

--- a/Sources/VectorCore/Operations/Operations.swift
+++ b/Sources/VectorCore/Operations/Operations.swift
@@ -65,6 +65,13 @@ public enum Operations {
             throw VectorError.dimensionMismatch(expected: expectedDim, actual: v.scalarCount)
         }
 
+        // R4 — transparent GPU dispatch: an installed BatchKernelProvider supplies real
+        // batch kernels; delegate to it (precedence over the CPU fast paths below).
+        if let gpu = computeProvider as? any BatchKernelProvider {
+            let pairs = try await gpu.findNearest(query: query, candidates: vectors, k: k, metric: metric)
+            return pairs.map { NearestNeighborResult(index: $0.index, distance: $0.distance) }
+        }
+
         // Optimized Top‑K fast paths for Vector*Optimized + supported metrics
         if k < vectors.count { // only worth it when K < N
             // Euclidean distance Top‑K via squared kernels (monotonic → correct indices)
@@ -151,6 +158,13 @@ public enum Operations {
         // Queries dim must match vectors dim
         guard qDim == vDim else {
             throw VectorError.dimensionMismatch(expected: vDim, actual: qDim)
+        }
+        // R4 — transparent GPU dispatch: if a GPU kernel provider is installed, dispatch
+        // each query through it (its findNearest); this takes precedence over CPU GEMM.
+        if computeProvider as? any BatchKernelProvider != nil {
+            return try await computeProvider.parallelExecute(items: 0..<queries.count) { i in
+                try await findNearest(to: queries[i], in: vectors, k: k, metric: metric)
+            }
         }
         // GEMM fast path (DOCUMENT-2): for large multi-query k-NN over optimized types
         // + Euclidean/Cosine, one cblas_sgemm (AMX) yields the q×n matrix; each row is

--- a/Sources/VectorCore/Operations/Operations.swift
+++ b/Sources/VectorCore/Operations/Operations.swift
@@ -161,9 +161,10 @@ public enum Operations {
         }
         // R4 — transparent GPU dispatch: if a GPU kernel provider is installed, dispatch
         // each query through it (its findNearest); this takes precedence over CPU GEMM.
-        if computeProvider as? any BatchKernelProvider != nil {
-            return try await computeProvider.parallelExecute(items: 0..<queries.count) { i in
-                try await findNearest(to: queries[i], in: vectors, k: k, metric: metric)
+        if let gpu = computeProvider as? any BatchKernelProvider {
+            return try await gpu.parallelExecute(items: 0..<queries.count) { i in
+                let pairs = try await gpu.findNearest(query: queries[i], candidates: vectors, k: k, metric: metric)
+                return pairs.map { NearestNeighborResult(index: $0.index, distance: $0.distance) }
             }
         }
         // GEMM fast path (DOCUMENT-2): for large multi-query k-NN over optimized types

--- a/Sources/VectorCore/Operations/Operations.swift
+++ b/Sources/VectorCore/Operations/Operations.swift
@@ -152,6 +152,13 @@ public enum Operations {
         guard qDim == vDim else {
             throw VectorError.dimensionMismatch(expected: vDim, actual: qDim)
         }
+        // GEMM fast path (DOCUMENT-2): for large multi-query k-NN over optimized types
+        // + Euclidean/Cosine, one cblas_sgemm (AMX) yields the q×n matrix; each row is
+        // then reduced with the pointer Top-K (deterministic smaller-index tie-break).
+        if let routed = gemmFindNearestBatch(queries: queries, in: vectors, k: k, metric: metric) {
+            return routed
+        }
+
         return try await computeProvider.parallelExecute(items: 0..<queries.count) { i in
             try await findNearest(
                 to: queries[i],
@@ -160,6 +167,65 @@ public enum Operations {
                 metric: metric
             )
         }
+    }
+
+    /// GEMM-backed batch k-NN dispatch. Returns one Top-K list per query when
+    /// `queries`/`vectors` are a known optimized type and `metric` is Euclidean or
+    /// Cosine, above the crossover sizes; otherwise `nil` (caller uses the per-query path).
+    private static func gemmFindNearestBatch<V: VectorProtocol, M: DistanceMetric>(
+        queries: [V], in vectors: [V], k: Int, metric: M
+    ) -> [[NearestNeighborResult]]? {
+        // Crossover: GEMM amortizes only when both the query batch and the candidate
+        // set are large enough (mirrors DOCUMENT-2's Q_MIN≈8, N_MIN≈256).
+        guard queries.count >= 8, vectors.count >= 256 else { return nil }
+        let isEuclid = metric is EuclideanDistance
+        let isCosine = metric is CosineDistance
+        guard isEuclid || isCosine else { return nil }
+
+        if let qs = queries as? [Vector512Optimized], let cs = vectors as? [Vector512Optimized] {
+            return gemmBatchRun(qs, cs, k: k, euclid: isEuclid)
+        }
+        if let qs = queries as? [Vector768Optimized], let cs = vectors as? [Vector768Optimized] {
+            return gemmBatchRun(qs, cs, k: k, euclid: isEuclid)
+        }
+        if let qs = queries as? [Vector1536Optimized], let cs = vectors as? [Vector1536Optimized] {
+            return gemmBatchRun(qs, cs, k: k, euclid: isEuclid)
+        }
+        return nil
+    }
+
+    private static func gemmBatchRun<O: UnifiedVectorBuffer>(
+        _ qs: [O], _ cs: [O], k: Int, euclid: Bool
+    ) -> [[NearestNeighborResult]] {
+        let q = qs.count, n = cs.count
+        var flat = [Float](repeating: 0, count: q * n)
+        if euclid {
+            MatrixDistance.euclideanSquaredMatrix(queries: qs, candidates: cs, into: &flat)
+        } else {
+            MatrixDistance.cosineDistanceMatrix(queries: qs, candidates: cs, into: &flat)
+        }
+
+        let kk = min(k, n)
+        var out = [[NearestNeighborResult]]()
+        out.reserveCapacity(q)
+        flat.withUnsafeBufferPointer { fb in
+            let base = fb.baseAddress!
+            for i in 0..<q {
+                // Top-K over this query's row. For Euclidean the row holds *squared*
+                // distances; ordering is monotonic, so we select on squared then sqrt.
+                let sel = TopKSelection.select(k: kk, from: base + i * n, count: n,
+                                               ids: nil, tieBreaker: .smallerIndex)
+                var row = [NearestNeighborResult]()
+                row.reserveCapacity(sel.indices.count)
+                for t in 0..<sel.indices.count {
+                    let raw = sel.distances[t]
+                    let dist = euclid ? (raw > 0 ? raw.squareRoot() : 0) : raw
+                    row.append(NearestNeighborResult(index: Int(sel.indices[t]), distance: dist))
+                }
+                out.append(row)
+            }
+        }
+        return out
     }
 
     // MARK: - Optimized Top‑K helpers

--- a/Sources/VectorCore/Operations/TopKSelection.swift
+++ b/Sources/VectorCore/Operations/TopKSelection.swift
@@ -52,6 +52,28 @@ public struct TopKResult: Sendable, Equatable {
     }
 }
 
+// MARK: - Tie-Breaking Policy
+
+/// Policy for resolving ties when two candidates compare equal on distance/similarity.
+///
+/// Top-K results are ordered nearest-first; when two candidates are equal on value,
+/// the policy decides both *which* candidates survive at the k boundary and their
+/// relative order in the result.
+///
+/// - Note: For the array/pointer selection APIs a candidate's index equals its
+///   position in the input scan, so `.smallerIndex` and `.insertionOrder` produce
+///   identical, fully-deterministic output. `.smallerValue` applies no index
+///   tie-break (equal values keep value-only ordering).
+public enum TieBreaker: Sendable {
+    /// Prefer the candidate with the smaller index — fully deterministic. Default.
+    case smallerIndex
+    /// Preserve input encounter order among equal values (stable). For an
+    /// index-ordered scan this is identical to `.smallerIndex`.
+    case insertionOrder
+    /// Order by value only; do not break ties by index.
+    case smallerValue
+}
+
 // MARK: - Top-K Selection API
 
 /// Top-K selection algorithms for k-nearest neighbor search.
@@ -101,7 +123,11 @@ public enum TopKSelection {
     /// ## Algorithm Selection
     /// - For k < n/10: Uses max-heap to maintain k smallest (O(n log k))
     /// - For k >= n/10: Uses partial sort (O(n log n) but better constants)
-    public static func select(k: Int, from distances: [Float]) -> TopKResult {
+    public static func select(
+        k: Int,
+        from distances: [Float],
+        tieBreaker: TieBreaker = .smallerIndex
+    ) -> TopKResult {
         guard k > 0 else { return TopKResult() }
         guard !distances.isEmpty else { return TopKResult() }
 
@@ -113,9 +139,9 @@ public enum TopKSelection {
         // Use adaptive algorithm based on k/n ratio
         let selected: [(index: Int, distance: Float)]
         if actualK < distances.count / 10 {
-            selected = heapSelectSmallK(pairs, k: actualK)
+            selected = heapSelectSmallK(pairs, k: actualK, tieBreaker: tieBreaker)
         } else {
-            selected = sortSelectLargeK(pairs, k: actualK)
+            selected = sortSelectLargeK(pairs, k: actualK, tieBreaker: tieBreaker)
         }
 
         return TopKResult(
@@ -142,7 +168,8 @@ public enum TopKSelection {
         k: Int,
         from distances: UnsafePointer<Float>,
         count: Int,
-        ids: UnsafePointer<Int32>? = nil
+        ids: UnsafePointer<Int32>? = nil,
+        tieBreaker: TieBreaker = .smallerIndex
     ) -> (indices: [Int32], distances: [Float]) {
         guard k > 0, count > 0 else {
             return (indices: [], distances: [])
@@ -152,9 +179,9 @@ public enum TopKSelection {
         let actualK = min(k, count)
 
         if actualK < count / 10 {
-            return heapSelectPointer(distances: distances, count: count, k: actualK, ids: ids)
+            return heapSelectPointer(distances: distances, count: count, k: actualK, ids: ids, tieBreaker: tieBreaker)
         } else {
-            return sortSelectPointer(distances: distances, count: count, k: actualK, ids: ids)
+            return sortSelectPointer(distances: distances, count: count, k: actualK, ids: ids, tieBreaker: tieBreaker)
         }
     }
 
@@ -163,21 +190,22 @@ public enum TopKSelection {
         distances: UnsafePointer<Float>,
         count: Int,
         k: Int,
-        ids: UnsafePointer<Int32>?
+        ids: UnsafePointer<Int32>?,
+        tieBreaker: TieBreaker
     ) -> (indices: [Int32], distances: [Float]) {
-        var buffer = TopKBuffer(k: k, isMinHeap: false)
+        var buffer = TopKBuffer(k: k, isMinHeap: false, tieBreaker: tieBreaker)
 
         for i in 0..<count {
             buffer.pushIfBetter(val: distances[i], idx: i)
         }
 
-        // Extract and sort ascending by distance
+        // Extract and sort ascending by distance (ties resolved per policy)
         var pairs: [(Int, Float)] = []
         pairs.reserveCapacity(buffer.size)
         for i in 0..<buffer.size {
             pairs.append((buffer.idxs[i], buffer.vals[i]))
         }
-        pairs.sort { $0.1 < $1.1 }
+        pairs.sort { orderedAscending(($0.0, $0.1), ($1.0, $1.1), tieBreaker) }
 
         if let ids = ids {
             return (
@@ -197,10 +225,11 @@ public enum TopKSelection {
         distances: UnsafePointer<Float>,
         count: Int,
         k: Int,
-        ids: UnsafePointer<Int32>?
+        ids: UnsafePointer<Int32>?,
+        tieBreaker: TieBreaker
     ) -> (indices: [Int32], distances: [Float]) {
         var indexArray = Array(0..<count)
-        indexArray.sort { distances[$0] < distances[$1] }
+        indexArray.sort { orderedAscending(($0, distances[$0]), ($1, distances[$1]), tieBreaker) }
 
         let selected = indexArray.prefix(k)
         if let ids = ids {
@@ -228,7 +257,8 @@ public enum TopKSelection {
     public static func select<T>(
         k: Int,
         from elements: [T],
-        distance: (T) -> Float
+        distance: (T) -> Float,
+        tieBreaker: TieBreaker = .smallerIndex
     ) -> [T] {
         guard k > 0 && !elements.isEmpty else { return [] }
 
@@ -237,9 +267,9 @@ public enum TopKSelection {
 
         let selected: [(index: Int, distance: Float)]
         if actualK < elements.count / 10 {
-            selected = heapSelectSmallK(indexed, k: actualK)
+            selected = heapSelectSmallK(indexed, k: actualK, tieBreaker: tieBreaker)
         } else {
-            selected = sortSelectLargeK(indexed, k: actualK)
+            selected = sortSelectLargeK(indexed, k: actualK, tieBreaker: tieBreaker)
         }
 
         return selected.map { elements[$0.index] }
@@ -471,28 +501,53 @@ public enum TopKSelection {
 
     // MARK: - Private Helpers
 
-    /// Heap-based selection for small k (O(n log k))
+    /// Total order for nearest-first (ascending distance) results, ties resolved
+    /// per `tieBreaker`. Defines a strict weak ordering for `sort(by:)`.
+    @usableFromInline @inline(__always)
+    internal static func orderedAscending(
+        _ a: (Int, Float), _ b: (Int, Float), _ tieBreaker: TieBreaker
+    ) -> Bool {
+        if a.1 != b.1 { return a.1 < b.1 }
+        switch tieBreaker {
+        case .smallerIndex, .insertionOrder: return a.0 < b.0
+        case .smallerValue: return false
+        }
+    }
+
+    /// Heap-based selection for small k (O(n log k)), deterministic per `tieBreaker`.
+    ///
+    /// Routes through `TopKBuffer` (the same primitive the pointer/optimized paths
+    /// use) so that boundary membership and result order honor the tie policy — the
+    /// historical `KNearestHeap` broke ties only by value, leaving order undefined.
     @usableFromInline
     internal static func heapSelectSmallK(
         _ elements: [(index: Int, distance: Float)],
-        k: Int
+        k: Int,
+        tieBreaker: TieBreaker = .smallerIndex
     ) -> [(index: Int, distance: Float)] {
-        var heap = KNearestHeap(k: k)
-
+        var buffer = TopKBuffer(k: k, isMinHeap: false, tieBreaker: tieBreaker)
         for element in elements {
-            heap.insert(index: element.index, distance: element.distance)
+            buffer.pushIfBetter(val: element.distance, idx: element.index)
         }
-
-        return heap.getSorted()
+        var pairs: [(index: Int, distance: Float)] = []
+        pairs.reserveCapacity(buffer.size)
+        for i in 0..<buffer.size {
+            pairs.append((index: buffer.idxs[i], distance: buffer.vals[i]))
+        }
+        pairs.sort { orderedAscending(($0.index, $0.distance), ($1.index, $1.distance), tieBreaker) }
+        return pairs
     }
 
-    /// Sort-based selection for large k (better constants)
+    /// Sort-based selection for large k (better constants), deterministic per `tieBreaker`.
     @usableFromInline
     internal static func sortSelectLargeK(
         _ elements: [(index: Int, distance: Float)],
-        k: Int
+        k: Int,
+        tieBreaker: TieBreaker = .smallerIndex
     ) -> [(index: Int, distance: Float)] {
-        Array(elements.sorted { $0.distance < $1.distance }.prefix(k))
+        Array(elements.sorted {
+            orderedAscending(($0.index, $0.distance), ($1.index, $1.distance), tieBreaker)
+        }.prefix(k))
     }
 
     /// Extract sorted result from TopKBuffer (for distance minimization)
@@ -507,8 +562,9 @@ public enum TopKSelection {
             pairs.append((buffer.idxs[i], dist))
         }
 
-        // Sort by distance ascending
-        pairs.sort { $0.1 < $1.1 }
+        // Sort by distance ascending, ties resolved per the buffer's policy
+        // (sqrt is monotonic, so applying it before the comparison is order-preserving).
+        pairs.sort { orderedAscending(($0.0, $0.1), ($1.0, $1.1), buffer.tieBreaker) }
 
         return TopKResult(
             indices: pairs.map { $0.0 },
@@ -526,8 +582,14 @@ public enum TopKSelection {
             pairs.append((buffer.idxs[i], buffer.vals[i]))
         }
 
-        // Sort by similarity descending (highest first)
-        pairs.sort { $0.1 > $1.1 }
+        // Sort by similarity descending (highest first), ties resolved per policy.
+        pairs.sort { a, b in
+            if a.1 != b.1 { return a.1 > b.1 }
+            switch buffer.tieBreaker {
+            case .smallerIndex, .insertionOrder: return a.0 < b.0
+            case .smallerValue: return false
+            }
+        }
 
         return TopKResult(
             indices: pairs.map { $0.0 },

--- a/Sources/VectorCore/Platform/PlatformConfiguration.swift
+++ b/Sources/VectorCore/Platform/PlatformConfiguration.swift
@@ -75,6 +75,24 @@ internal enum PlatformConfiguration {
         Int(getpagesize())
     }
 
+    /// Rounds a byte count **up** to a whole multiple of ``pageSize``.
+    ///
+    /// This is the single source of truth for the page-rounding used by every
+    /// page-aligned allocation (e.g. ``SoA`` and `PageAlignedBuffer`) so the
+    /// length passed to `MTLDevice.makeBuffer(bytesNoCopy:)` — which on macOS
+    /// must be a page multiple — is computed identically everywhere, including
+    /// in `SoALayout.forType(_:count:)` where it is derived without allocating.
+    ///
+    /// - Parameter byteCount: A non-negative byte count.
+    /// - Returns: `byteCount` rounded up to the next multiple of ``pageSize``
+    ///   (`0` maps to `0`).
+    public static func roundUpToPage(_ byteCount: Int) -> Int {
+        precondition(byteCount >= 0, "byteCount must be non-negative, got \(byteCount)")
+        guard byteCount > 0 else { return 0 }
+        let page = pageSize
+        return ((byteCount + page - 1) / page) * page
+    }
+
     // MARK: - Platform Detection
 
     /// Whether running on Apple Silicon

--- a/Sources/VectorCore/Protocols/BatchKernelProvider.swift
+++ b/Sources/VectorCore/Protocols/BatchKernelProvider.swift
@@ -20,12 +20,35 @@ import Foundation
 ///   documented tolerance.
 public protocol BatchKernelProvider: ComputeProvider {
     /// Distance from `query` to each candidate, in candidate order.
+    ///
+    /// Provided for downstream consumers that want raw distances directly (e.g.
+    /// reranking). VectorCore's `Operations` k-NN entry points dispatch through
+    /// `findNearest` / `findNearestBatch`, not this method.
     func batchDistance<V: VectorProtocol>(
         query: V, candidates: [V], metric: any DistanceMetric
     ) async throws -> [Float] where V.Scalar == Float
 
-    /// Up to `k` nearest candidates, sorted ascending by distance.
+    /// Up to `k` nearest candidates for `query`, sorted ascending by distance.
     func findNearest<V: VectorProtocol>(
         query: V, candidates: [V], k: Int, metric: any DistanceMetric
     ) async throws -> [(index: Int, distance: Float)] where V.Scalar == Float
+
+    /// Up to `k` nearest candidates for each query. The default loops `findNearest`
+    /// per query; a conformer with a true batched kernel (one GPU dispatch for the
+    /// whole query set — the actual GPU win) should override this.
+    func findNearestBatch<V: VectorProtocol>(
+        queries: [V], candidates: [V], k: Int, metric: any DistanceMetric
+    ) async throws -> [[(index: Int, distance: Float)]] where V.Scalar == Float
+}
+
+public extension BatchKernelProvider {
+    /// Default: dispatch each query through `findNearest` using the provider's own
+    /// scheduler. Backward-compatible — conformers that don't override get this.
+    func findNearestBatch<V: VectorProtocol>(
+        queries: [V], candidates: [V], k: Int, metric: any DistanceMetric
+    ) async throws -> [[(index: Int, distance: Float)]] where V.Scalar == Float {
+        try await parallelExecute(items: 0..<queries.count) { i in
+            try await self.findNearest(query: queries[i], candidates: candidates, k: k, metric: metric)
+        }
+    }
 }

--- a/Sources/VectorCore/Protocols/BatchKernelProvider.swift
+++ b/Sources/VectorCore/Protocols/BatchKernelProvider.swift
@@ -1,0 +1,31 @@
+// VectorCore: Batch Kernel Provider Protocol
+//
+// beta-evolution-4, DOCUMENT-5 (R4). A ComputeProvider that can substitute real
+// batch kernels (e.g. Metal) for VectorCore's CPU kernels. `Operations` downcasts
+// the installed `computeProvider` to this protocol and, when present, delegates —
+// so GPU acceleration becomes transparent through VectorCore's own findNearest.
+//
+// VectorCore defines the protocol; the GPU-backed conformance lives in VectorAccelerate.
+
+import Foundation
+
+/// A `ComputeProvider` that supplies hardware batch kernels rather than only a
+/// scheduling strategy. Conformers compute the kernel themselves (CPU SIMD, Metal,
+/// etc.) instead of running an opaque closure.
+///
+/// Semantics a conformer must honor (see DOCUMENT-4 S4 conformance contract):
+/// - `batchDistance` returns one distance per candidate, in candidate order.
+/// - `findNearest` returns up to `k` `(index, distance)` pairs sorted ascending by
+///   distance, indexing into `candidates`; results match the CPU reference within a
+///   documented tolerance.
+public protocol BatchKernelProvider: ComputeProvider {
+    /// Distance from `query` to each candidate, in candidate order.
+    func batchDistance<V: VectorProtocol>(
+        query: V, candidates: [V], metric: any DistanceMetric
+    ) async throws -> [Float] where V.Scalar == Float
+
+    /// Up to `k` nearest candidates, sorted ascending by distance.
+    func findNearest<V: VectorProtocol>(
+        query: V, candidates: [V], k: Int, metric: any DistanceMetric
+    ) async throws -> [(index: Int, distance: Float)] where V.Scalar == Float
+}

--- a/Sources/VectorCore/Storage/SoA.swift
+++ b/Sources/VectorCore/Storage/SoA.swift
@@ -43,12 +43,20 @@ extension Vector1536Optimized: SoACompatible {
 
 /// Structure-of-Arrays (SoA) container for optimized batch scoring.
 ///
-/// Memory layout: lanes-major then candidate index.
-/// `buffer[lane * N + j]` stores SIMD4 for candidate j at lane `lane`.
+/// Memory layout: **lane-major, then candidate index.** `buffer[lane * count + j]`
+/// stores the `SIMD4<Float>` for candidate `j` at `lane` (each lane = 4 contiguous
+/// dimensions; `lanes = dimension / 4`). The candidate axis is never padded, so the
+/// stride between lanes is exactly `count` elements.
 ///
 /// This provides superior cache locality when processing multiple candidates
 /// with the same query vector, as all candidates' data for a given lane
 /// are stored contiguously in memory.
+///
+/// - Important: This layout is a **frozen, stable contract as of 0.3.0** — downstream
+///   GPU kernels index into a zero-copy `MTLBuffer` built from ``pageAlignedBytes``,
+///   so the formula, element type, and stride must not change silently. The contract is
+///   documented in `Docs/SoA_Layout_Contract.md` and exposed programmatically via
+///   ``layoutDescriptor`` (a ``SoALayout``); consumers should derive constants from there.
 public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     public let lanes: Int
     public let count: Int
@@ -86,14 +94,16 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     ) -> (buffer: UnsafeMutablePointer<SIMD4<Float>>, usedAlignedAlloc: Bool, allocatedBytes: Int) {
         let elemSize = MemoryLayout<SIMD4<Float>>.stride   // 16
         if pageAligned && capacity > 0 {
-            let page = PlatformConfiguration.pageSize
-            let logical = capacity * elemSize
-            let padded = ((logical + page - 1) / page) * page   // round up to a whole page
+            // Round the *whole* allocation up to a page so the length is valid for
+            // makeBuffer(bytesNoCopy:). pageSize is a multiple of elemSize (16), so the
+            // padded byte count divides evenly back into SIMD4<Float> slots.
+            let padded = PlatformConfiguration.roundUpToPage(capacity * elemSize)
             let paddedCapacity = padded / elemSize
             let ptr: UnsafeMutablePointer<SIMD4<Float>>
             do {
                 ptr = try AlignedMemory.allocateAligned(type: SIMD4<Float>.self,
-                                                        count: paddedCapacity, alignment: page)
+                                                        count: paddedCapacity,
+                                                        alignment: PlatformConfiguration.pageSize)
             } catch {
                 fatalError("SoA: page-aligned allocation of \(padded) bytes failed: \(error)")
             }
@@ -117,14 +127,19 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
         }
     }
 
-    /// Public initializer for test compatibility: creates SoA from vectors
+    /// Creates an SoA from an array of vectors.
     ///
     /// - Parameters:
-    ///   - vectors: Array of vectors to convert to SoA layout
-    ///   - blockSize: Ignored parameter for API compatibility (reserved for future chunking optimizations)
+    ///   - vectors: Array of vectors to convert to SoA layout.
     ///   - pageAligned: When true, allocates via posix_memalign with page-aligned base and
     ///     page-rounded length, making the region usable with MTLDevice.makeBuffer(bytesNoCopy:).
-    public init(vectors: [Vector], blockSize: Int = 32, pageAligned: Bool = false) {
+    ///
+    /// - Note: The frozen in-memory layout is documented in `Docs/SoA_Layout_Contract.md`
+    ///   and exposed programmatically via ``layoutDescriptor``. There is intentionally **no**
+    ///   `blockSize` parameter: the buffer is never padded along the candidate axis, so the
+    ///   lane stride is exactly `count` elements. (A prior `blockSize:` parameter was a no-op
+    ///   and was removed in 0.3.0 to avoid implying candidate-axis padding.)
+    public init(vectors: [Vector], pageAligned: Bool = false) {
         let count = vectors.count
         self.count = count
         self.lanes = Vector.lanes
@@ -221,6 +236,21 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
         guard usedAlignedAlloc, ownsBuffer else { return nil }
         ownsBuffer = false
         return (UnsafeMutableRawPointer(buffer), allocatedByteCount)
+    }
+
+    /// The frozen layout descriptor for this SoA — the authoritative, machine-readable
+    /// description of the in-memory layout (lane stride, logical vs. allocated byte counts,
+    /// and the element-index formula `lane * count + candidate`).
+    ///
+    /// Downstream GPU kernels (e.g. VectorAccelerate Metal shaders that index a zero-copy
+    /// `MTLBuffer` wrapping ``pageAlignedBytes``) should derive their indexing constants
+    /// from this single source of truth rather than hardcoding magic numbers — in
+    /// particular, take the candidate count `N` from ``SoALayout/count`` and **never**
+    /// reverse-engineer it from the page-rounded ``SoALayout/allocatedByteCount``.
+    ///
+    /// See `Docs/SoA_Layout_Contract.md` for the full frozen contract.
+    public var layoutDescriptor: SoALayout {
+        SoALayout(lanes: lanes, count: count, allocatedByteCount: allocatedByteCount)
     }
 
     /// Scoped read-only access to the raw SoA data (logical bytes = `count * lanes * 16`).

--- a/Sources/VectorCore/Storage/SoA.swift
+++ b/Sources/VectorCore/Storage/SoA.swift
@@ -64,6 +64,10 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     /// makeBuffer(bytesNoCopy:)); otherwise bufferCapacity * sizeof(SIMD4<Float>).
     private let allocatedByteCount: Int
 
+    /// Whether this object still owns (and will free) the buffer. Becomes `false`
+    /// after `consumeAllocation()` transfers ownership to the caller.
+    private var ownsBuffer = true
+
     private init(count: Int, pageAligned: Bool = false) {
         self.count = count
         self.lanes = Vector.lanes
@@ -103,6 +107,7 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     }
 
     deinit {
+        guard ownsBuffer else { return }   // ownership transferred via consumeAllocation()
         if usedAlignedAlloc {
             // posix_memalign memory MUST be freed with free(), never .deallocate().
             AlignedMemory.deallocate(buffer)
@@ -198,8 +203,24 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     ///   The memory is freed on `SoA` deinit, so hold a strong reference to the `SoA`
     ///   for the buffer's lifetime (or arrange a deallocator handshake).
     public var pageAlignedBytes: (base: UnsafeRawPointer, byteCount: Int)? {
-        guard usedAlignedAlloc else { return nil }
+        guard usedAlignedAlloc, ownsBuffer else { return nil }
         return (UnsafeRawPointer(buffer), allocatedByteCount)
+    }
+
+    /// Transfer ownership of the page-aligned allocation to the caller — for handing
+    /// the buffer to a Metal `bytesNoCopy` deallocator without a double free. Returns
+    /// the page-aligned base + page-rounded length, or `nil` if this SoA is not
+    /// page-aligned (only the `posix_memalign` buffer can be handed to `free()`).
+    ///
+    /// After this call the `SoA` no longer frees the buffer on `deinit`, and
+    /// `pageAlignedBytes` returns `nil`; the caller becomes responsible for freeing the
+    /// base (via `AlignedMemory.deallocate(_:)` / `free`). Mirrors
+    /// `PageAlignedBuffer.consumeAllocation()`. Do not use the `SoA` for CPU compute
+    /// after consuming.
+    public func consumeAllocation() -> (base: UnsafeMutableRawPointer, byteCount: Int)? {
+        guard usedAlignedAlloc, ownsBuffer else { return nil }
+        ownsBuffer = false
+        return (UnsafeMutableRawPointer(buffer), allocatedByteCount)
     }
 
     /// Scoped read-only access to the raw SoA data (logical bytes = `count * lanes * 16`).

--- a/Sources/VectorCore/Storage/SoA.swift
+++ b/Sources/VectorCore/Storage/SoA.swift
@@ -57,9 +57,8 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     @usableFromInline internal let buffer: UnsafeMutablePointer<SIMD4<Float>>
     private let bufferCapacity: Int
 
-    /// True when `buffer` was allocated via AlignedMemory (posix_memalign) and so must
-    /// be freed with free(); false for the default Swift allocation.
-    private let ownsViaAlignedMemory: Bool
+    /// True when the buffer was allocated via AlignedMemory (posix_memalign) and so must be freed with free(); false for the default Swift allocation.
+    private let usedAlignedAlloc: Bool
 
     /// Total allocated bytes. Page-rounded when page-aligned (the length to pass to
     /// makeBuffer(bytesNoCopy:)); otherwise bufferCapacity * sizeof(SIMD4<Float>).
@@ -71,7 +70,7 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
         self.bufferCapacity = self.lanes * self.count
         let alloc = SoA.allocateBuffer(capacity: self.bufferCapacity, pageAligned: pageAligned)
         self.buffer = alloc.buffer
-        self.ownsViaAlignedMemory = alloc.ownsViaAligned
+        self.usedAlignedAlloc = alloc.usedAlignedAlloc
         self.allocatedByteCount = alloc.allocatedBytes
     }
 
@@ -80,7 +79,7 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     /// for MTLDevice.makeBuffer(bytesNoCopy:); otherwise the default 16-byte allocation.
     private static func allocateBuffer(
         capacity: Int, pageAligned: Bool
-    ) -> (buffer: UnsafeMutablePointer<SIMD4<Float>>, ownsViaAligned: Bool, allocatedBytes: Int) {
+    ) -> (buffer: UnsafeMutablePointer<SIMD4<Float>>, usedAlignedAlloc: Bool, allocatedBytes: Int) {
         let elemSize = MemoryLayout<SIMD4<Float>>.stride   // 16
         if pageAligned && capacity > 0 {
             let page = PlatformConfiguration.pageSize
@@ -104,7 +103,7 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     }
 
     deinit {
-        if ownsViaAlignedMemory {
+        if usedAlignedAlloc {
             // posix_memalign memory MUST be freed with free(), never .deallocate().
             AlignedMemory.deallocate(buffer)
         } else {
@@ -127,7 +126,7 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
         self.bufferCapacity = self.lanes * self.count
         let alloc = SoA.allocateBuffer(capacity: self.bufferCapacity, pageAligned: pageAligned)
         self.buffer = alloc.buffer
-        self.ownsViaAlignedMemory = alloc.ownsViaAligned
+        self.usedAlignedAlloc = alloc.usedAlignedAlloc
         self.allocatedByteCount = alloc.allocatedBytes
 
         // Populate the SoA structure from vectors
@@ -199,14 +198,15 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     ///   The memory is freed on `SoA` deinit, so hold a strong reference to the `SoA`
     ///   for the buffer's lifetime (or arrange a deallocator handshake).
     public var pageAlignedBytes: (base: UnsafeRawPointer, byteCount: Int)? {
-        guard ownsViaAlignedMemory else { return nil }
+        guard usedAlignedAlloc else { return nil }
         return (UnsafeRawPointer(buffer), allocatedByteCount)
     }
 
     /// Scoped read-only access to the raw SoA data (logical bytes = `count * lanes * 16`).
     /// The pointer is valid only for the duration of `body`.
-    public func withUnsafeRawBuffer<R>(_ body: (UnsafeRawPointer, Int) throws -> R) rethrows -> R {
-        try body(UnsafeRawPointer(buffer), bufferCapacity * MemoryLayout<SIMD4<Float>>.stride)
+    public func withUnsafeRawBuffer<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        let byteCount = bufferCapacity * MemoryLayout<SIMD4<Float>>.stride
+        return try body(UnsafeRawBufferPointer(start: UnsafeRawPointer(buffer), count: byteCount))
     }
 
     /// Memory footprint in bytes

--- a/Sources/VectorCore/Storage/SoA.swift
+++ b/Sources/VectorCore/Storage/SoA.swift
@@ -57,27 +57,60 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     @usableFromInline internal let buffer: UnsafeMutablePointer<SIMD4<Float>>
     private let bufferCapacity: Int
 
-    private init(count: Int) {
+    /// True when `buffer` was allocated via AlignedMemory (posix_memalign) and so must
+    /// be freed with free(); false for the default Swift allocation.
+    private let ownsViaAlignedMemory: Bool
+
+    /// Total allocated bytes. Page-rounded when page-aligned (the length to pass to
+    /// makeBuffer(bytesNoCopy:)); otherwise bufferCapacity * sizeof(SIMD4<Float>).
+    private let allocatedByteCount: Int
+
+    private init(count: Int, pageAligned: Bool = false) {
         self.count = count
         self.lanes = Vector.lanes
         self.bufferCapacity = self.lanes * self.count
+        let alloc = SoA.allocateBuffer(capacity: self.bufferCapacity, pageAligned: pageAligned)
+        self.buffer = alloc.buffer
+        self.ownsViaAlignedMemory = alloc.ownsViaAligned
+        self.allocatedByteCount = alloc.allocatedBytes
+    }
 
-        if bufferCapacity > 0 {
-            // Allocate memory with proper alignment for SIMD4<Float> (16 bytes)
-            self.buffer = UnsafeMutablePointer<SIMD4<Float>>.allocate(capacity: bufferCapacity)
-            // Initialize to zero
-            self.buffer.initialize(repeating: .zero, count: bufferCapacity)
+    /// Allocate (and zero) the SoA buffer. When `pageAligned` and non-empty, uses
+    /// AlignedMemory (page-aligned base + page-rounded length) so the region is valid
+    /// for MTLDevice.makeBuffer(bytesNoCopy:); otherwise the default 16-byte allocation.
+    private static func allocateBuffer(
+        capacity: Int, pageAligned: Bool
+    ) -> (buffer: UnsafeMutablePointer<SIMD4<Float>>, ownsViaAligned: Bool, allocatedBytes: Int) {
+        let elemSize = MemoryLayout<SIMD4<Float>>.stride   // 16
+        if pageAligned && capacity > 0 {
+            let page = PlatformConfiguration.pageSize
+            let logical = capacity * elemSize
+            let padded = ((logical + page - 1) / page) * page   // round up to a whole page
+            let paddedCapacity = padded / elemSize
+            let ptr: UnsafeMutablePointer<SIMD4<Float>>
+            do {
+                ptr = try AlignedMemory.allocateAligned(type: SIMD4<Float>.self,
+                                                        count: paddedCapacity, alignment: page)
+            } catch {
+                fatalError("SoA: page-aligned allocation of \(padded) bytes failed: \(error)")
+            }
+            ptr.initialize(repeating: .zero, count: paddedCapacity)   // zero logical + padding
+            return (ptr, true, padded)
         } else {
-            // Handle empty case
-            self.buffer = UnsafeMutablePointer<SIMD4<Float>>.allocate(capacity: 0)
+            let ptr = UnsafeMutablePointer<SIMD4<Float>>.allocate(capacity: max(0, capacity))
+            if capacity > 0 { ptr.initialize(repeating: .zero, count: capacity) }
+            return (ptr, false, max(0, capacity) * elemSize)
         }
     }
 
     deinit {
-        if bufferCapacity > 0 {
-            buffer.deinitialize(count: bufferCapacity)
+        if ownsViaAlignedMemory {
+            // posix_memalign memory MUST be freed with free(), never .deallocate().
+            AlignedMemory.deallocate(buffer)
+        } else {
+            if bufferCapacity > 0 { buffer.deinitialize(count: bufferCapacity) }
+            buffer.deallocate()
         }
-        buffer.deallocate()
     }
 
     /// Public initializer for test compatibility: creates SoA from vectors
@@ -85,32 +118,26 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     /// - Parameters:
     ///   - vectors: Array of vectors to convert to SoA layout
     ///   - blockSize: Ignored parameter for API compatibility (reserved for future chunking optimizations)
-    public init(vectors: [Vector], blockSize: Int = 32) {
+    ///   - pageAligned: When true, allocates via posix_memalign with page-aligned base and
+    ///     page-rounded length, making the region usable with MTLDevice.makeBuffer(bytesNoCopy:).
+    public init(vectors: [Vector], blockSize: Int = 32, pageAligned: Bool = false) {
         let count = vectors.count
         self.count = count
         self.lanes = Vector.lanes
         self.bufferCapacity = self.lanes * self.count
-
-        if bufferCapacity > 0 {
-            self.buffer = UnsafeMutablePointer<SIMD4<Float>>.allocate(capacity: bufferCapacity)
-            self.buffer.initialize(repeating: .zero, count: bufferCapacity)
-        } else {
-            self.buffer = UnsafeMutablePointer<SIMD4<Float>>.allocate(capacity: 0)
-        }
+        let alloc = SoA.allocateBuffer(capacity: self.bufferCapacity, pageAligned: pageAligned)
+        self.buffer = alloc.buffer
+        self.ownsViaAlignedMemory = alloc.ownsViaAligned
+        self.allocatedByteCount = alloc.allocatedBytes
 
         // Populate the SoA structure from vectors
         guard count > 0 else { return }
-
         let lanes = Vector.lanes
         let bufferPtr = self.buffer
-
         for j in 0..<count {
-            let vector = vectors[j]
-            let vectorStorage = vector.storage
-
+            let vectorStorage = vectors[j].storage
             for i in 0..<lanes {
-                let destinationIndex = i * count + j
-                bufferPtr[destinationIndex] = vectorStorage[i]
+                bufferPtr[i * count + j] = vectorStorage[i]
             }
         }
     }
@@ -119,9 +146,15 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     ///
     /// Transforms the memory layout from [Candidate][Lane] to [Lane][Candidate]
     /// for optimal cache performance during batch scoring operations.
-    public static func build(from candidates: [Vector]) -> SoA<Vector> {
+    ///
+    /// - Parameters:
+    ///   - candidates: Source vectors in AoS layout.
+    ///   - pageAligned: When true, allocates via posix_memalign with page-aligned base and
+    ///     page-rounded length, enabling zero-copy GPU import via
+    ///     `MTLDevice.makeBuffer(bytesNoCopy:)`. Access the pointer pair via `pageAlignedBytes`.
+    public static func build(from candidates: [Vector], pageAligned: Bool = false) -> SoA<Vector> {
         let N = candidates.count
-        let soa = SoA<Vector>(count: N)
+        let soa = SoA<Vector>(count: N, pageAligned: pageAligned)
 
         guard N > 0 else { return soa }
 
@@ -156,6 +189,24 @@ public final class SoA<Vector: SoACompatible>: @unchecked Sendable {
     public func lanePointer(_ lane: Int) -> UnsafePointer<SIMD4<Float>> {
         assert(lane >= 0 && lane < self.lanes, "Lane index \(lane) out of bounds [0..<\(lanes)]")
         return UnsafePointer(buffer + (lane * count))
+    }
+
+    /// Page-aligned base pointer + page-rounded byte length for zero-copy GPU import
+    /// via `MTLDevice.makeBuffer(bytesNoCopy:)`, or `nil` if this SoA was not built
+    /// page-aligned (`build(from:pageAligned: true)` / `init(..., pageAligned: true)`).
+    ///
+    /// - Important: The `SoA` MUST outlive any `MTLBuffer` created from this pointer.
+    ///   The memory is freed on `SoA` deinit, so hold a strong reference to the `SoA`
+    ///   for the buffer's lifetime (or arrange a deallocator handshake).
+    public var pageAlignedBytes: (base: UnsafeRawPointer, byteCount: Int)? {
+        guard ownsViaAlignedMemory else { return nil }
+        return (UnsafeRawPointer(buffer), allocatedByteCount)
+    }
+
+    /// Scoped read-only access to the raw SoA data (logical bytes = `count * lanes * 16`).
+    /// The pointer is valid only for the duration of `body`.
+    public func withUnsafeRawBuffer<R>(_ body: (UnsafeRawPointer, Int) throws -> R) rethrows -> R {
+        try body(UnsafeRawPointer(buffer), bufferCapacity * MemoryLayout<SIMD4<Float>>.stride)
     }
 
     /// Memory footprint in bytes

--- a/Sources/VectorCore/Storage/SoALayout.swift
+++ b/Sources/VectorCore/Storage/SoALayout.swift
@@ -1,0 +1,125 @@
+//
+//  SoALayout.swift
+//  VectorCore
+//
+//  The frozen, machine-readable description of the SoA memory layout — the single
+//  source of truth that downstream GPU kernels derive their indexing constants from,
+//  instead of hardcoding magic numbers that silently break if the layout changes.
+//
+//  See Docs/SoA_Layout_Contract.md for the full human-readable contract.
+//
+
+import Foundation
+import simd
+
+/// Frozen description of the ``SoA`` in-memory layout.
+///
+/// `SoA` stores candidate vectors **lane-major, then candidate index**: the element for
+/// (lane `ℓ`, candidate `j`) lives at `buffer[ℓ * count + j]`, where each element is a
+/// `SIMD4<Float>` packing four contiguous dimensions. This descriptor exposes that layout
+/// as data so a consumer — most importantly a VectorAccelerate Metal shader indexing a
+/// zero-copy `MTLBuffer` built from ``SoA/pageAlignedBytes`` — derives its constants from
+/// one authoritative place rather than re-deriving (and risking drift from) the formula.
+///
+/// The layout is **stable as of VectorCore 0.3.0**. Any change to the formula, the element
+/// type, or the stride is a breaking change to this contract; see `Docs/SoA_Layout_Contract.md`.
+///
+/// ### Worked example (512-dim, N candidates)
+/// `lanes = 128`, `elementStrideBytes = 16`, `laneStrideBytes = N * 16`,
+/// `logicalByteCount = 128 * N * 16`. Candidate `j`'s lane `ℓ` is at element index
+/// `ℓ * N + j` — equivalently byte offset `(ℓ * N + j) * 16`.
+public struct SoALayout: Sendable, Equatable {
+
+    /// Number of `SIMD4<Float>` lanes per vector, `= dimension / 4`.
+    ///
+    /// Always exact: every ``SoACompatible`` dimension (384, 512, 768, 1536) is divisible
+    /// by 4, so there are **no partial / tail lanes** — every lane is a full `SIMD4<Float>`.
+    public let lanes: Int
+
+    /// Number of candidate vectors stored — the true `N`.
+    ///
+    /// This is **not padded**: it is exactly the stride, in elements, between one lane and
+    /// the next. There is no candidate-axis block padding regardless of how the `SoA` was
+    /// built. (The page-aligned allocation rounds the *whole buffer's* length up to a page;
+    /// see ``allocatedByteCount`` — that rounding never changes this value or the stride.)
+    public let count: Int
+
+    /// Total bytes the allocation occupies.
+    ///
+    /// For a page-aligned `SoA` this is ``logicalByteCount`` rounded **up** to a whole page
+    /// (the length to pass to `MTLDevice.makeBuffer(bytesNoCopy:)`); for a non-page-aligned
+    /// `SoA` it equals ``logicalByteCount``. Always `>= logicalByteCount`; the trailing
+    /// `allocatedByteCount - logicalByteCount` bytes are zero-filled slack.
+    ///
+    /// - Important: **Do not derive ``count`` from this value.** It is page-rounded and
+    ///   larger than the logical data; the valid indexed region is `[0, lanes * count)`
+    ///   elements only.
+    public let allocatedByteCount: Int
+
+    /// Size of one packed element (`SIMD4<Float>`) in bytes — `16`.
+    @inlinable
+    public static var elementStrideBytes: Int { MemoryLayout<SIMD4<Float>>.stride }
+
+    /// Stride between consecutive lanes, in bytes: `count * elementStrideBytes`.
+    ///
+    /// A consumer steps from lane `ℓ` to lane `ℓ + 1` by exactly this many bytes.
+    @inlinable
+    public var laneStrideBytes: Int { count * Self.elementStrideBytes }
+
+    /// Bytes occupied by the logical data: `lanes * count * elementStrideBytes`.
+    ///
+    /// The valid indexed region is exactly `[0, lanes * count)` elements / `[0, logicalByteCount)`
+    /// bytes. Bytes in `[logicalByteCount, allocatedByteCount)` are zero-filled padding.
+    @inlinable
+    public var logicalByteCount: Int { lanes * count * Self.elementStrideBytes }
+
+    /// Total number of logical `SIMD4<Float>` elements: `lanes * count`.
+    @inlinable
+    public var elementCount: Int { lanes * count }
+
+    /// Creates a descriptor from its stored fields. Prefer ``forType(_:count:pageAligned:)``
+    /// to derive a layout for a vector type, or ``SoA/layoutDescriptor`` for a live instance.
+    @inlinable
+    public init(lanes: Int, count: Int, allocatedByteCount: Int) {
+        self.lanes = lanes
+        self.count = count
+        self.allocatedByteCount = allocatedByteCount
+    }
+
+    /// The frozen index formula: returns the `SIMD4<Float>`-element offset of the element
+    /// for `(lane, candidate)`, i.e. `lane * count + candidate`.
+    ///
+    /// Multiply by ``elementStrideBytes`` for a byte offset. Bounds-checked in debug builds.
+    @inlinable
+    public func elementIndex(lane: Int, candidate: Int) -> Int {
+        precondition(lane >= 0 && lane < lanes, "lane \(lane) out of range [0, \(lanes))")
+        precondition(candidate >= 0 && candidate < count, "candidate \(candidate) out of range [0, \(count))")
+        return lane * count + candidate
+    }
+
+    /// Derives the layout for a ``SoACompatible`` vector type and candidate count **without
+    /// allocating** — for a consumer that needs to size a buffer or precompute shader
+    /// constants ahead of receiving the pointer.
+    ///
+    /// - Parameters:
+    ///   - type: The fixed-dimension optimized vector type (e.g. `Vector768Optimized`).
+    ///   - count: The number of candidates `N`.
+    ///   - pageAligned: Pass `true` to match a `SoA` built with `pageAligned: true` —
+    ///     ``allocatedByteCount`` is then page-rounded to the `makeBuffer(bytesNoCopy:)`
+    ///     length. Defaults to `false` (the exact logical size), matching the `pageAligned`
+    ///     default on `SoA.build`/`init` so page-alignment is **opt-in everywhere**. A GPU
+    ///     consumer sizing a zero-copy buffer must pass `true` (just as it calls
+    ///     `build(from:pageAligned: true)`).
+    /// - Returns: A descriptor whose ``allocatedByteCount`` matches what the corresponding
+    ///   `SoA` reports for the same `pageAligned` value.
+    public static func forType<V: SoACompatible>(
+        _ type: V.Type, count: Int, pageAligned: Bool = false
+    ) -> SoALayout {
+        let lanes = V.lanes
+        let logical = lanes * count * elementStrideBytes
+        let allocated = (pageAligned && count > 0)
+            ? PlatformConfiguration.roundUpToPage(logical)
+            : logical
+        return SoALayout(lanes: lanes, count: count, allocatedByteCount: allocated)
+    }
+}

--- a/Sources/VectorCore/Storage/UnifiedVectorBuffer.swift
+++ b/Sources/VectorCore/Storage/UnifiedVectorBuffer.swift
@@ -1,0 +1,232 @@
+// VectorCore: Unified Vector Buffer — the zero-copy contract
+//
+// beta-evolution-4, DOCUMENT-4 (S5). Provides the CPU-only memory contract that
+// lets downstream packages read VectorCore vectors — or hand them to the GPU via
+// `MTLDevice.makeBuffer(bytesNoCopy:)` — without copying. VectorCore guarantees
+// alignment and contiguity; it imports no GPU framework. The Metal side (and the
+// ownership handoff it implies) lives entirely in VectorAccelerate.
+//
+// See: Docs/Memory_Alignment.md, Docs/beta-evolution-4/DOCUMENT-4_Spec_Ecosystem_Seams.md
+
+import Foundation
+
+// MARK: - Read contract
+
+/// A contiguous, alignment-guaranteed read view over a vector's `Float32` elements.
+///
+/// This is the zero-copy *contract* between VectorCore and downstream packages
+/// (VectorAccelerate, EmbedKit). A conforming value exposes its elements as a
+/// contiguous, aligned byte region that a consumer can read without copying.
+///
+/// The protocol describes only *reading*. The base address yielded by
+/// ``withUnsafeContiguousBytes(_:)`` is guaranteed aligned to ``alignment`` bytes,
+/// but is **not** necessarily page-aligned — only ``PageAlignedBuffer`` guarantees
+/// the page alignment that `makeBuffer(bytesNoCopy:)` requires. Consumers that need
+/// the GPU-import path must check ``alignment`` (or use ``PageAlignedBuffer``
+/// directly); the rest can read any conforming vector uniformly.
+public protocol UnifiedVectorBuffer {
+    /// Number of logical `Float32` elements in the vector.
+    var elementCount: Int { get }
+
+    /// Guaranteed alignment, in bytes, of the base address yielded by
+    /// ``withUnsafeContiguousBytes(_:)``. Always a power of two ≥ `MemoryLayout<Float>.alignment`.
+    var alignment: Int { get }
+
+    /// Invoke `body` with a contiguous raw view of the logical element bytes
+    /// (`elementCount * MemoryLayout<Float>.stride`).
+    ///
+    /// - Important: The pointer is valid only for the duration of `body`; do not
+    ///   escape it. For ``PageAlignedBuffer`` the base address is page-aligned and
+    ///   stable for the object's lifetime, but this scoped accessor is still the
+    ///   correct way to *read*.
+    func withUnsafeContiguousBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
+}
+
+public extension UnifiedVectorBuffer {
+    /// Logical size of the vector's elements, in bytes (`elementCount * stride`).
+    ///
+    /// For ``PageAlignedBuffer`` this is the *logical* size; the *allocated* size
+    /// (rounded up to a page multiple, the length for `bytesNoCopy`) is
+    /// ``PageAlignedBuffer/allocatedByteCount``.
+    var byteCount: Int { elementCount * MemoryLayout<Float>.stride }
+}
+
+// MARK: - Page-aligned allocation (bytesNoCopy-ready)
+
+/// A page-aligned `Float32` buffer suitable for zero-copy GPU import via
+/// `MTLDevice.makeBuffer(bytesNoCopy:length:options:deallocator:)`.
+///
+/// `makeBuffer(bytesNoCopy:)` requires, on macOS, that **both** the base address and
+/// the length be multiples of the OS page size. This type satisfies both: it
+/// allocates page-aligned memory (via the package's `posix_memalign`-backed
+/// allocator) and rounds the byte length up to a whole page, zero-filling the
+/// padding so the GPU never reads uninitialized memory.
+///
+/// ## Ownership and zero-copy handoff
+///
+/// For a true zero-copy handoff, the `MTLBuffer` outlives this object and frees the
+/// memory through Metal's `bytesNoCopy` deallocator. To avoid a double free, call
+/// ``consumeAllocation()`` to transfer ownership: after that, this object no longer
+/// frees on `deinit`, and the caller (the Metal deallocator) becomes responsible for
+/// `free()`. If you instead keep this object alive for the buffer's lifetime, pass a
+/// no-op deallocator on the Metal side and let `deinit` free as usual.
+///
+/// VectorCore performs none of the Metal calls; it only provides the page-aligned
+/// memory and the ownership primitive.
+public final class PageAlignedBuffer: UnifiedVectorBuffer, @unchecked Sendable {
+
+    /// Number of logical `Float32` elements.
+    public let elementCount: Int
+
+    /// The OS page size used for alignment (captured at construction).
+    public let pageSize: Int
+
+    /// Total allocated size in bytes, rounded up to a multiple of ``pageSize``.
+    /// This is the `length` to pass to `makeBuffer(bytesNoCopy:length:)`.
+    public let allocatedByteCount: Int
+
+    /// Whether this object still owns (and will free) the allocation. Becomes
+    /// `false` after ``consumeAllocation()`` transfers ownership to the caller.
+    public private(set) var ownsAllocation: Bool
+
+    /// Float-bound base pointer. Non-nil while owned; the raw allocation is freed on
+    /// `deinit` unless ownership was transferred.
+    @usableFromInline internal var fptr: UnsafeMutablePointer<Float>?
+
+    /// `bytesNoCopy` requires page alignment.
+    public var alignment: Int { pageSize }
+
+    /// Page-aligned base address of the allocation (the `bytesNoCopy` pointer).
+    ///
+    /// - Precondition: ownership has not been transferred via ``consumeAllocation()``.
+    public var baseAddress: UnsafeMutableRawPointer {
+        precondition(ownsAllocation, "PageAlignedBuffer: allocation was consumed")
+        return UnsafeMutableRawPointer(fptr!)
+    }
+
+    /// Allocate a zero-initialized, page-aligned buffer for `elementCount` floats.
+    ///
+    /// - Parameter elementCount: Number of `Float32` elements (must be > 0).
+    /// - Complexity: O(allocatedByteCount) for the zero-fill.
+    public init(elementCount: Int) {
+        precondition(elementCount > 0, "PageAlignedBuffer: elementCount must be positive")
+        let page = PlatformConfiguration.pageSize
+        let logical = elementCount * MemoryLayout<Float>.stride
+        // Round the byte length up to a whole page (the makeBuffer(bytesNoCopy:) rule).
+        let padded = ((logical + page - 1) / page) * page
+        let floatCapacity = padded / MemoryLayout<Float>.stride
+
+        let ptr: UnsafeMutablePointer<Float>
+        do {
+            // pageSize is a power of two ≥ minimumAlignment, so it is a valid
+            // posix_memalign alignment. Reusing AlignedMemory keeps allocation and
+            // deallocation (free) consistent with the rest of the package.
+            ptr = try AlignedMemory.allocateAligned(type: Float.self, count: floatCapacity, alignment: page)
+        } catch {
+            fatalError("PageAlignedBuffer: page-aligned allocation of \(padded) bytes failed: \(error)")
+        }
+        // Zero logical + padding so the GPU never imports uninitialized bytes.
+        ptr.initialize(repeating: 0, count: floatCapacity)
+
+        self.elementCount = elementCount
+        self.pageSize = page
+        self.allocatedByteCount = padded
+        self.fptr = ptr
+        self.ownsAllocation = true
+    }
+
+    /// Allocate a page-aligned buffer and copy `source` into it once.
+    ///
+    /// The canonical EmbedKit use: write a freshly produced embedding into
+    /// page-aligned memory a single time, then hand the pointer downstream.
+    public convenience init(copying source: [Float]) {
+        self.init(elementCount: source.count)
+        source.withUnsafeBufferPointer { src in
+            fptr!.update(from: src.baseAddress!, count: src.count)
+        }
+    }
+
+    deinit {
+        if ownsAllocation, let p = fptr {
+            AlignedMemory.deallocate(p)
+        }
+    }
+
+    public func withUnsafeContiguousBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        precondition(ownsAllocation, "PageAlignedBuffer: allocation was consumed")
+        // Expose only the logical bytes; the page padding is implementation detail.
+        return try body(UnsafeRawBufferPointer(start: fptr!, count: byteCount))
+    }
+
+    /// Mutable access to the logical `Float32` elements (e.g. to write an embedding).
+    public func withUnsafeMutableBufferPointer<R>(_ body: (UnsafeMutableBufferPointer<Float>) throws -> R) rethrows -> R {
+        precondition(ownsAllocation, "PageAlignedBuffer: allocation was consumed")
+        return try body(UnsafeMutableBufferPointer(start: fptr!, count: elementCount))
+    }
+
+    /// Transfer ownership of the page-aligned allocation to the caller.
+    ///
+    /// After this call, ``ownsAllocation`` is `false`, this object will **not** free
+    /// the memory on `deinit`, and further access to ``baseAddress`` /
+    /// `withUnsafe*` traps. The caller — typically a Metal `bytesNoCopy` deallocator —
+    /// must eventually `free()` the returned base (e.g. via
+    /// ``AlignedMemory/deallocate(_:)-(UnsafeMutableRawPointer)``).
+    ///
+    /// - Returns: The page-aligned base address and the page-rounded byte length.
+    public func consumeAllocation() -> (baseAddress: UnsafeMutableRawPointer, allocatedByteCount: Int) {
+        precondition(ownsAllocation, "PageAlignedBuffer: allocation already consumed")
+        ownsAllocation = false
+        return (UnsafeMutableRawPointer(fptr!), allocatedByteCount)
+    }
+}
+
+// MARK: - Conformances for VectorCore vector types (read contract)
+//
+// The optimized types back their storage with `ContiguousArray<SIMD4<Float>>`, whose
+// element region is 16-byte aligned — enough for the read contract, but not the page
+// alignment `bytesNoCopy` needs. Consumers that require the GPU-import path must copy
+// into a `PageAlignedBuffer` (e.g. via `PageAlignedBuffer(copying:)`).
+
+extension Vector512Optimized: UnifiedVectorBuffer {
+    public var elementCount: Int { 512 }
+    public var alignment: Int { MemoryLayout<SIMD4<Float>>.alignment }
+    public func withUnsafeContiguousBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        try storage.withUnsafeBytes(body)
+    }
+}
+
+extension Vector768Optimized: UnifiedVectorBuffer {
+    public var elementCount: Int { 768 }
+    public var alignment: Int { MemoryLayout<SIMD4<Float>>.alignment }
+    public func withUnsafeContiguousBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        try storage.withUnsafeBytes(body)
+    }
+}
+
+extension Vector1536Optimized: UnifiedVectorBuffer {
+    public var elementCount: Int { 1536 }
+    public var alignment: Int { MemoryLayout<SIMD4<Float>>.alignment }
+    public func withUnsafeContiguousBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        try storage.withUnsafeBytes(body)
+    }
+}
+
+extension Vector384Optimized: UnifiedVectorBuffer {
+    public var elementCount: Int { 384 }
+    public var alignment: Int { MemoryLayout<SIMD4<Float>>.alignment }
+    public func withUnsafeContiguousBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        try storage.withUnsafeBytes(body)
+    }
+}
+
+extension DynamicVector: UnifiedVectorBuffer {
+    public var elementCount: Int { scalarCount }
+    // HybridStorage may store small vectors inline; only Float alignment is
+    // guaranteed across the inline and heap paths.
+    public var alignment: Int { MemoryLayout<Float>.alignment }
+    public func withUnsafeContiguousBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        try withUnsafeBufferPointer { buffer in
+            try body(UnsafeRawBufferPointer(buffer))
+        }
+    }
+}

--- a/Tests/ComprehensiveTests/BatchGEMMRoutingTests.swift
+++ b/Tests/ComprehensiveTests/BatchGEMMRoutingTests.swift
@@ -1,0 +1,119 @@
+//
+//  BatchGEMMRoutingTests.swift
+//  VectorCore
+//
+//  Verifies BatchOperations.pairwiseDistances routes large matrices through the
+//  GEMM (cblas_sgemm/AMX) path (beta-evolution-4, DOCUMENT-2 routing) and that the
+//  routed results match the per-pair kernels, while non-routable inputs fall back.
+//
+//  Suite is .serialized because one test toggles the process-global routing config.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+@Suite("GEMM routing in BatchOperations", .serialized)
+struct BatchGEMMRoutingTests {
+
+    private struct RNG {
+        var state: UInt64
+        mutating func next() -> Float {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            return Float(state >> 40) / Float(1 << 23) - 1
+        }
+    }
+
+    private func vecs512(_ count: Int, seed: UInt64) -> [Vector512Optimized] {
+        var rng = RNG(state: seed)
+        return (0..<count).map { _ in try! Vector512Optimized((0..<512).map { _ in rng.next() }) }
+    }
+
+    // N ≥ matrixRoutingMinN (256) so the GEMM path is taken.
+    private let N = 300
+
+    @Test("Routed Euclidean pairwise matches the direct kernel")
+    func euclideanRoutedMatchesKernel() async {
+        let vs = vecs512(N, seed: 0xE1)
+        let m = await BatchOperations.pairwiseDistances(vs)            // routes via GEMM
+        #expect(m.count == N && m[0].count == N)
+        // Diagonal ≈ 0. The GEMM identity ‖x‖²+‖x‖²−2‖x‖² cannot reach exactly 0 for
+        // a self-pair (catastrophic cancellation leaves ~ε·‖x‖²); the clamp keeps it
+        // non-negative, and sqrt of that residual is ~0.01 at these magnitudes. This is
+        // the documented DOCUMENT-2 §4 behavior, negligible for ranking.
+        for i in stride(from: 0, to: N, by: 37) {
+            #expect(m[i][i] >= 0 && m[i][i] < 0.05, "self-distance residual too large: \(m[i][i])")
+        }
+        // Spot-check rows against the direct SIMD kernel (sqrt of squared).
+        for i in 0..<5 {
+            for j in 0..<N {
+                let ref = (EuclideanKernels.squared512(vs[i], vs[j])).squareRoot()
+                #expect(abs(m[i][j] - ref) <= 0.05 + 1e-3 * ref, "i=\(i) j=\(j) got=\(m[i][j]) ref=\(ref)")
+            }
+        }
+    }
+
+    @Test("Routed Cosine pairwise matches double-precision reference")
+    func cosineRoutedMatchesReference() async {
+        let vs = vecs512(N, seed: 0xC0)
+        let m = await BatchOperations.pairwiseDistances(vs, metric: CosineDistance())
+        for i in 0..<4 {
+            let a = vs[i].toArray()
+            for j in 0..<N {
+                let b = vs[j].toArray()
+                var dot = 0.0, na = 0.0, nb = 0.0
+                for k in 0..<512 { dot += Double(a[k]) * Double(b[k]); na += Double(a[k]*a[k]); nb += Double(b[k]*b[k]) }
+                let ref = Float(1.0 - dot / (sqrt(na) * sqrt(nb)))
+                #expect(abs(m[i][j] - ref) <= 2e-3, "i=\(i) j=\(j) got=\(m[i][j]) ref=\(ref)")
+            }
+        }
+    }
+
+    @Test("Non-routable metric (Manhattan) falls back to the per-pair path")
+    func manhattanFallsBack() async {
+        let vs = vecs512(N, seed: 0x3A)
+        let m = await BatchOperations.pairwiseDistances(vs, metric: ManhattanDistance())
+        let metric = ManhattanDistance()
+        for i in 0..<3 {
+            for j in stride(from: 0, to: N, by: 23) {
+                let ref = metric.distance(vs[i], vs[j])
+                #expect(abs(m[i][j] - ref) <= 1e-3, "manhattan not exact at i=\(i) j=\(j)")
+            }
+        }
+    }
+
+    @Test("DynamicVector does not route (concrete-type gate) and stays correct")
+    func dynamicDoesNotRoute() async {
+        let vs = (0..<N).map { k in DynamicVector((0..<64).map { Float((($0 + k) % 13) - 6) }) }
+        let m = await BatchOperations.pairwiseDistances(vs)
+        for i in 0..<3 {
+            let a = vs[i].toArray()
+            for j in stride(from: 0, to: N, by: 29) {
+                let b = vs[j].toArray()
+                var ss = 0.0
+                for k in 0..<64 { let d = Double(a[k] - b[k]); ss += d * d }
+                let ref = Float(ss.squareRoot())
+                #expect(abs(m[i][j] - ref) <= 1e-2 + 1e-3 * ref)
+            }
+        }
+    }
+
+    @Test("Routing ON and OFF agree within tolerance")
+    func routingToggleConsistent() async {
+        let vs = vecs512(N, seed: 0x7B)
+
+        await BatchOperations.updateConfiguration { $0.enableMatrixRouting = false }
+        let exact = await BatchOperations.pairwiseDistances(vs)        // per-pair kernels
+        await BatchOperations.updateConfiguration { $0.enableMatrixRouting = true }
+        let gemm = await BatchOperations.pairwiseDistances(vs)         // GEMM
+
+        for i in stride(from: 0, to: N, by: 31) {
+            for j in stride(from: 0, to: N, by: 31) {
+                #expect(abs(exact[i][j] - gemm[i][j]) <= 0.05 + 1e-3 * exact[i][j],
+                        "routed vs exact diverge at i=\(i) j=\(j): \(gemm[i][j]) vs \(exact[i][j])")
+            }
+        }
+        // Leave the global default as shipped (routing enabled).
+        await BatchOperations.updateConfiguration { $0.enableMatrixRouting = true }
+    }
+}

--- a/Tests/ComprehensiveTests/BatchKNNGEMMTests.swift
+++ b/Tests/ComprehensiveTests/BatchKNNGEMMTests.swift
@@ -1,0 +1,78 @@
+//
+//  BatchKNNGEMMTests.swift
+//  VectorCore
+//
+//  Verifies Operations.findNearestBatch routes large multi-query k-NN through the
+//  GEMM matrix + per-row Top-K path (beta-evolution-4, DOCUMENT-2), matching the
+//  per-query reference, and falls back below the crossover sizes.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+@Suite("GEMM batch k-NN (findNearestBatch routing)")
+struct BatchKNNGEMMTests {
+
+    private struct RNG {
+        var state: UInt64
+        mutating func next() -> Float {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            return Float(state >> 40) / Float(1 << 23) - 1
+        }
+    }
+    private func vecs512(_ count: Int, seed: UInt64) -> [Vector512Optimized] {
+        var rng = RNG(state: seed)
+        return (0..<count).map { _ in try! Vector512Optimized((0..<512).map { _ in rng.next() }) }
+    }
+
+    @Test("Routed Euclidean batch k-NN matches the per-query reference")
+    func euclideanBatchMatchesPerQuery() async throws {
+        let qs = vecs512(16, seed: 0xB1)          // q ≥ 8
+        let cs = vecs512(300, seed: 0xB2)         // n ≥ 256 → GEMM routes
+        let k = 10
+        let batch = try await Operations.findNearestBatch(queries: qs, in: cs, k: k)
+        #expect(batch.count == 16)
+        for i in 0..<16 {
+            let ref = try await Operations.findNearest(to: qs[i], in: cs, k: k)
+            #expect(batch[i].count == k)
+            // Nearest neighbour index is robust; compare it exactly.
+            #expect(batch[i][0].index == ref[0].index, "query \(i): nearest index differs")
+            // Positional distances agree within tolerance (robust to rare boundary swaps,
+            // whose distances are near-equal by construction).
+            for t in 0..<k {
+                #expect(abs(batch[i][t].distance - ref[t].distance) <= 0.05 + 1e-3 * ref[t].distance,
+                        "query \(i) rank \(t): \(batch[i][t].distance) vs \(ref[t].distance)")
+            }
+        }
+    }
+
+    @Test("Routed Cosine batch k-NN matches the per-query reference")
+    func cosineBatchMatchesPerQuery() async throws {
+        let qs = vecs512(12, seed: 0xC1)
+        let cs = vecs512(280, seed: 0xC2)
+        let k = 8
+        let batch = try await Operations.findNearestBatch(queries: qs, in: cs, k: k, metric: CosineDistance())
+        for i in 0..<12 {
+            let ref = try await Operations.findNearest(to: qs[i], in: cs, k: k, metric: CosineDistance())
+            #expect(batch[i].count == k)
+            #expect(batch[i][0].index == ref[0].index, "query \(i): nearest index differs")
+            for t in 0..<k {
+                #expect(abs(batch[i][t].distance - ref[t].distance) <= 2e-3,
+                        "query \(i) rank \(t): \(batch[i][t].distance) vs \(ref[t].distance)")
+            }
+        }
+    }
+
+    @Test("Small batch (q < crossover) falls back and stays correct")
+    func smallBatchFallsBack() async throws {
+        let qs = vecs512(4, seed: 0xD1)           // q < 8 → no GEMM routing
+        let cs = vecs512(300, seed: 0xD2)
+        let k = 5
+        let batch = try await Operations.findNearestBatch(queries: qs, in: cs, k: k)
+        for i in 0..<4 {
+            let ref = try await Operations.findNearest(to: qs[i], in: cs, k: k)
+            #expect(batch[i].map { $0.index } == ref.map { $0.index })
+        }
+    }
+}

--- a/Tests/ComprehensiveTests/BatchKernelProviderTests.swift
+++ b/Tests/ComprehensiveTests/BatchKernelProviderTests.swift
@@ -62,7 +62,10 @@ struct BatchKernelProviderTests {
             try await Operations.findNearestBatch(queries: qs, in: cs, k: 3)
         }
         #expect(result.count == 5)
-        for row in result { #expect(row.first?.index == 999) }
+        for row in result {
+            #expect(row.count == 1)            // the mock returns exactly one result
+            #expect(row.first?.index == 999)
+        }
     }
 
     @Test("Default provider uses the CPU path (no sentinel)")
@@ -71,6 +74,6 @@ struct BatchKernelProviderTests {
         let cs = (0..<10).map { k in try! Vector512Optimized((0..<512).map { Float($0 + k) }) }
         let result = try await Operations.findNearest(to: q, in: cs, k: 3)
         #expect(result.count == 3)
-        #expect(result[0].index != 999)        // real CPU result, not the sentinel
+        #expect(result[0].index == 0)          // identical vector at index 0 ⇒ nearest; and not the 999 sentinel
     }
 }

--- a/Tests/ComprehensiveTests/BatchKernelProviderTests.swift
+++ b/Tests/ComprehensiveTests/BatchKernelProviderTests.swift
@@ -31,6 +31,32 @@ private struct MockGPUProvider: BatchKernelProvider {
     }
 }
 
+/// A provider that returns `k` results from `findNearest` (to verify k-passthrough)
+/// and OVERRIDES `findNearestBatch` with a distinct sentinel (to verify the batch
+/// override path is used, not the default per-query loop).
+private struct MockBatchGPUProvider: BatchKernelProvider {
+    let device: ComputeDevice = .cpu
+    var maxConcurrency: Int { 1 }
+    var deviceInfo: ComputeDeviceInfo {
+        ComputeDeviceInfo(name: "mock-batch-gpu", availableMemory: nil, maxThreads: 1, preferredChunkSize: 1)
+    }
+    func execute<T: Sendable>(_ work: @Sendable @escaping () async throws -> T) async throws -> T {
+        try await work()
+    }
+    func batchDistance<V: VectorProtocol>(query: V, candidates: [V], metric: any DistanceMetric)
+        async throws -> [Float] where V.Scalar == Float {
+        Array(repeating: Float(-1), count: candidates.count)
+    }
+    func findNearest<V: VectorProtocol>(query: V, candidates: [V], k: Int, metric: any DistanceMetric)
+        async throws -> [(index: Int, distance: Float)] where V.Scalar == Float {
+        (0..<Swift.min(k, candidates.count)).map { (index: 100 + $0, distance: Float(-$0)) }
+    }
+    func findNearestBatch<V: VectorProtocol>(queries: [V], candidates: [V], k: Int, metric: any DistanceMetric)
+        async throws -> [[(index: Int, distance: Float)]] where V.Scalar == Float {
+        queries.map { _ in [(index: 777, distance: Float(-7))] }   // batch-override sentinel
+    }
+}
+
 @Suite("BatchKernelProvider GPU dispatch (R4)")
 struct BatchKernelProviderTests {
 
@@ -39,6 +65,29 @@ struct BatchKernelProviderTests {
         let p: any ComputeProvider = MockGPUProvider()
         let mapped = try await p.parallelExecute(items: 0..<4) { $0 * 2 }
         #expect(mapped == [0, 2, 4, 6])   // inherits the ComputeProvider default
+    }
+
+    @Test("findNearest passes through all k provider results")
+    func findNearestKPassthrough() async throws {
+        let q = try Vector512Optimized(Array(repeating: 1, count: 512))
+        let cs = (0..<10).map { _ in try! Vector512Optimized(Array(repeating: 0, count: 512)) }
+        let result = try await Operations.$computeProvider.withValue(MockBatchGPUProvider()) {
+            try await Operations.findNearest(to: q, in: cs, k: 3)
+        }
+        #expect(result.map { $0.index } == [100, 101, 102])   // all k results flow through
+    }
+
+    @Test("findNearestBatch uses the provider's batch override (not the default loop)")
+    func findNearestBatchUsesOverride() async throws {
+        let qs = (0..<4).map { _ in try! Vector512Optimized(Array(repeating: 1, count: 512)) }
+        let cs = (0..<300).map { _ in try! Vector512Optimized(Array(repeating: 0, count: 512)) }
+        let result = try await Operations.$computeProvider.withValue(MockBatchGPUProvider()) {
+            try await Operations.findNearestBatch(queries: qs, in: cs, k: 3)
+        }
+        #expect(result.count == 4)
+        for row in result {
+            #expect(row.first?.index == 777)   // batch-override sentinel, not 100+rank from the loop
+        }
     }
 
     @Test("Operations.findNearest delegates to an installed BatchKernelProvider")

--- a/Tests/ComprehensiveTests/BatchKernelProviderTests.swift
+++ b/Tests/ComprehensiveTests/BatchKernelProviderTests.swift
@@ -1,0 +1,43 @@
+//
+//  BatchKernelProviderTests.swift
+//  VectorCore
+//
+//  R4: a ComputeProvider sub-protocol that supplies real batch kernels, so an
+//  installed GPU provider transparently services Operations.findNearest.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+/// A mock GPU provider that returns an impossible-from-CPU sentinel, so tests can
+/// detect that dispatch was delegated to it.
+private struct MockGPUProvider: BatchKernelProvider {
+    let device: ComputeDevice = .cpu
+    var maxConcurrency: Int { 1 }
+    var deviceInfo: ComputeDeviceInfo {
+        ComputeDeviceInfo(name: "mock-gpu", availableMemory: nil, maxThreads: 1, preferredChunkSize: 1)
+    }
+    func execute<T: Sendable>(_ work: @Sendable @escaping () async throws -> T) async throws -> T {
+        try await work()
+    }
+    func batchDistance<V: VectorProtocol>(query: V, candidates: [V], metric: any DistanceMetric)
+        async throws -> [Float] where V.Scalar == Float {
+        Array(repeating: Float(-1), count: candidates.count)
+    }
+    func findNearest<V: VectorProtocol>(query: V, candidates: [V], k: Int, metric: any DistanceMetric)
+        async throws -> [(index: Int, distance: Float)] where V.Scalar == Float {
+        [(index: 999, distance: -42)]   // impossible from the CPU path
+    }
+}
+
+@Suite("BatchKernelProvider GPU dispatch (R4)")
+struct BatchKernelProviderTests {
+
+    @Test("A BatchKernelProvider is usable as a ComputeProvider")
+    func conformsToComputeProvider() async throws {
+        let p: any ComputeProvider = MockGPUProvider()
+        let mapped = try await p.parallelExecute(items: 0..<4) { $0 * 2 }
+        #expect(mapped == [0, 2, 4, 6])   // inherits the ComputeProvider default
+    }
+}

--- a/Tests/ComprehensiveTests/BatchKernelProviderTests.swift
+++ b/Tests/ComprehensiveTests/BatchKernelProviderTests.swift
@@ -40,4 +40,37 @@ struct BatchKernelProviderTests {
         let mapped = try await p.parallelExecute(items: 0..<4) { $0 * 2 }
         #expect(mapped == [0, 2, 4, 6])   // inherits the ComputeProvider default
     }
+
+    @Test("Operations.findNearest delegates to an installed BatchKernelProvider")
+    func findNearestDelegates() async throws {
+        let q = try Vector512Optimized(Array(repeating: 1, count: 512))
+        let cs = (0..<10).map { _ in try! Vector512Optimized(Array(repeating: 0, count: 512)) }
+        let result = try await Operations.$computeProvider.withValue(MockGPUProvider()) {
+            try await Operations.findNearest(to: q, in: cs, k: 3)
+        }
+        #expect(result.count == 1)
+        #expect(result[0].index == 999)        // the sentinel ⇒ delegation happened
+        #expect(result[0].distance == -42)
+    }
+
+    @Test("findNearestBatch delegates per query (GPU precedence over CPU GEMM)")
+    func findNearestBatchDelegates() async throws {
+        // n = 300 ≥ 256 would normally hit the CPU GEMM path; the GPU provider must win.
+        let qs = (0..<5).map { _ in try! Vector512Optimized(Array(repeating: 1, count: 512)) }
+        let cs = (0..<300).map { _ in try! Vector512Optimized(Array(repeating: 0, count: 512)) }
+        let result = try await Operations.$computeProvider.withValue(MockGPUProvider()) {
+            try await Operations.findNearestBatch(queries: qs, in: cs, k: 3)
+        }
+        #expect(result.count == 5)
+        for row in result { #expect(row.first?.index == 999) }
+    }
+
+    @Test("Default provider uses the CPU path (no sentinel)")
+    func defaultUsesCPU() async throws {
+        let q = try Vector512Optimized((0..<512).map { Float($0) })
+        let cs = (0..<10).map { k in try! Vector512Optimized((0..<512).map { Float($0 + k) }) }
+        let result = try await Operations.findNearest(to: q, in: cs, k: 3)
+        #expect(result.count == 3)
+        #expect(result[0].index != 999)        // real CPU result, not the sentinel
+    }
 }

--- a/Tests/ComprehensiveTests/MatrixDistanceTests.swift
+++ b/Tests/ComprehensiveTests/MatrixDistanceTests.swift
@@ -1,0 +1,135 @@
+//
+//  MatrixDistanceTests.swift
+//  VectorCore
+//
+//  Parity + numerical-contract tests for the GEMM batch-distance path
+//  (beta-evolution-4, DOCUMENT-2). Asserts the GEMM identity agrees with the
+//  direct SIMD kernels, and that the cancellation clamp prevents negative/NaN.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+@Suite("MatrixDistance (GEMM batch-distance)")
+struct MatrixDistanceTests {
+
+    /// Deterministic pseudo-random Float in [-1, 1] (SplitMix64-based; no global RNG).
+    private struct RNG {
+        var state: UInt64
+        mutating func next() -> Float {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            let bits = (state >> 40)               // 24 high bits
+            return Float(bits) / Float(1 << 23) - 1 // → [-1, 1)
+        }
+    }
+
+    private func makeVecs512(_ count: Int, seed: UInt64) -> [Vector512Optimized] {
+        var rng = RNG(state: seed)
+        return (0..<count).map { _ in
+            try! Vector512Optimized((0..<512).map { _ in rng.next() })
+        }
+    }
+
+    /// Double-precision ground-truth cosine distance.
+    private func cosineRef(_ a: Vector512Optimized, _ b: Vector512Optimized) -> Float {
+        let av = a.toArray(), bv = b.toArray()
+        var dot = 0.0, na = 0.0, nb = 0.0
+        for k in 0..<512 {
+            dot += Double(av[k]) * Double(bv[k])
+            na += Double(av[k]) * Double(av[k])
+            nb += Double(bv[k]) * Double(bv[k])
+        }
+        return Float(1.0 - dot / (sqrt(na) * sqrt(nb)))
+    }
+
+    @Test("Euclidean GEMM matches the direct SIMD kernel")
+    func euclideanParity512() {
+        let qs = makeVecs512(4, seed: 0x1234)
+        let cs = makeVecs512(10, seed: 0x9ABC)
+        let out = MatrixDistance.euclideanSquaredMatrix(queries: qs, candidates: cs)
+        #expect(out.count == 4 * 10)
+        for i in 0..<4 {
+            for j in 0..<10 {
+                let ref = EuclideanKernels.squared512(qs[i], cs[j])
+                let got = out[i * 10 + j]
+                // Generous absolute + relative band; GEMM vs direct agree to ~1e-4 rel here.
+                #expect(abs(got - ref) <= 1e-2 + 1e-3 * abs(ref),
+                        "euclid mismatch i=\(i) j=\(j) got=\(got) ref=\(ref)")
+            }
+        }
+    }
+
+    @Test("Identical query/candidate clamps to zero (no negative, no NaN)")
+    func euclideanIdentityClamp() {
+        let v = makeVecs512(1, seed: 0x7777)
+        let out = MatrixDistance.euclideanSquaredMatrix(queries: v, candidates: v)
+        #expect(out.count == 1)
+        #expect(out[0] >= 0, "must be clamped non-negative")
+        #expect(out[0].isFinite, "must not be NaN/Inf")
+        #expect(out[0] < 1e-1, "self-distance ≈ 0")
+    }
+
+    @Test("Cosine GEMM matches double-precision ground truth")
+    func cosineParity512() {
+        let qs = makeVecs512(3, seed: 0x55)
+        let cs = makeVecs512(8, seed: 0xAA)
+        let out = MatrixDistance.cosineDistanceMatrix(queries: qs, candidates: cs)
+        for i in 0..<3 {
+            for j in 0..<8 {
+                let ref = cosineRef(qs[i], cs[j])
+                let got = out[i * 8 + j]
+                #expect(abs(got - ref) <= 2e-3, "cosine mismatch i=\(i) j=\(j) got=\(got) ref=\(ref)")
+            }
+        }
+    }
+
+    @Test("Self-cosine-distance is ~0")
+    func cosineSelf() {
+        let v = makeVecs512(1, seed: 0x42)
+        let out = MatrixDistance.cosineDistanceMatrix(queries: v, candidates: v)
+        #expect(out[0] >= 0)
+        #expect(out[0] < 1e-3)
+    }
+
+    @Test("Works for 768 and 1536 dimensions")
+    func otherDims() {
+        let q7 = (0..<2).map { _ in try! Vector768Optimized((0..<768).map { Float(($0 % 7) - 3) }) }
+        let c7 = (0..<3).map { k in try! Vector768Optimized((0..<768).map { Float((($0 + k) % 5) - 2) }) }
+        let o7 = MatrixDistance.euclideanSquaredMatrix(queries: q7, candidates: c7)
+        #expect(o7.count == 6)
+        for i in 0..<2 {
+            for j in 0..<3 {
+                let ref = EuclideanKernels.squared768(q7[i], c7[j])
+                #expect(abs(o7[i * 3 + j] - ref) <= 1e-1 + 1e-3 * abs(ref))
+            }
+        }
+        // 1536 self-distance smoke (must clamp to ~0)
+        let q15 = [try! Vector1536Optimized((0..<1536).map { Float(($0 % 11) - 5) })]
+        let o15 = MatrixDistance.euclideanSquaredMatrix(queries: q15, candidates: q15)
+        #expect(o15[0] >= 0 && o15[0] < 1e-1)
+    }
+
+    @Test("Empty inputs are a no-op")
+    func emptyInputs() {
+        let cs = makeVecs512(3, seed: 0x9)
+        var out = [Float]()
+        MatrixDistance.euclideanSquaredMatrix(queries: [], candidates: cs, into: &out)
+        #expect(out.isEmpty)
+    }
+
+    @Test("DynamicVector works through the same generic path")
+    func dynamicVectorPath() {
+        let qs = [DynamicVector((0..<64).map { Float($0 % 5) })]
+        let cs = (0..<3).map { k in DynamicVector((0..<64).map { Float(($0 + k) % 5) }) }
+        let out = MatrixDistance.euclideanSquaredMatrix(queries: qs, candidates: cs)
+        #expect(out.count == 3)
+        for j in 0..<3 {
+            // direct reference
+            var ref = 0.0
+            let a = qs[0].toArray(), b = cs[j].toArray()
+            for k in 0..<64 { let d = Double(a[k] - b[k]); ref += d * d }
+            #expect(abs(Double(out[j]) - ref) <= 1e-2 + 1e-3 * abs(ref))
+        }
+    }
+}

--- a/Tests/ComprehensiveTests/MatrixDistanceTests.swift
+++ b/Tests/ComprehensiveTests/MatrixDistanceTests.swift
@@ -132,4 +132,43 @@ struct MatrixDistanceTests {
             #expect(abs(Double(out[j]) - ref) <= 1e-2 + 1e-3 * abs(ref))
         }
     }
+
+    // MARK: - Prepared (reusable) candidates
+
+    @Test("Prepared Euclidean matches the one-shot path exactly")
+    func preparedEuclidParity() {
+        let qs = makeVecs512(5, seed: 0x11)
+        let cs = makeVecs512(12, seed: 0x22)
+        let oneShot = MatrixDistance.euclideanSquaredMatrix(queries: qs, candidates: cs)
+        let prep = MatrixDistance.prepare(cs, normalized: false)
+        var prepared = [Float](repeating: 0, count: 5 * 12)
+        MatrixDistance.euclideanSquaredMatrix(queries: qs, prepared: prep, into: &prepared)
+        // Same packing/norms/GEMM → bit-identical.
+        #expect(prepared == oneShot)
+        #expect(prep.count == 12 && prep.dimension == 512)
+    }
+
+    @Test("Prepared Cosine matches the one-shot path exactly")
+    func preparedCosineParity() {
+        let qs = makeVecs512(4, seed: 0x33)
+        let cs = makeVecs512(9, seed: 0x44)
+        let oneShot = MatrixDistance.cosineDistanceMatrix(queries: qs, candidates: cs)
+        let prep = MatrixDistance.prepare(cs, normalized: true)
+        var prepared = [Float](repeating: 0, count: 4 * 9)
+        MatrixDistance.cosineDistanceMatrix(queries: qs, prepared: prep, into: &prepared)
+        #expect(prepared == oneShot)
+    }
+
+    @Test("One PreparedCandidates serves multiple query batches")
+    func preparedReuse() {
+        let cs = makeVecs512(20, seed: 0x55)
+        let prep = MatrixDistance.prepare(cs, normalized: false)
+        for seed in [UInt64(0x60), 0x61, 0x62] {
+            let qs = makeVecs512(3, seed: seed)
+            var got = [Float](repeating: 0, count: 3 * 20)
+            MatrixDistance.euclideanSquaredMatrix(queries: qs, prepared: prep, into: &got)
+            let ref = MatrixDistance.euclideanSquaredMatrix(queries: qs, candidates: cs)
+            #expect(got == ref, "reuse batch seed \(seed) diverged")
+        }
+    }
 }

--- a/Tests/ComprehensiveTests/MixedPrecisionKernelTests.swift
+++ b/Tests/ComprehensiveTests/MixedPrecisionKernelTests.swift
@@ -1392,7 +1392,7 @@ struct MixedPrecisionKernelTests {
                 return try! Vector512Optimized(values)
             }
 
-            let soa512 = try SoAFP16(vectors: vectors512, blockSize: 64)
+            let soa512 = try SoAFP16(vectors: vectors512)
             #expect(soa512.dimension == 512)
             #expect(soa512.vectorCount == 10)
             // Note: blockSize parameter is accepted but ignored (reserved for future use)
@@ -1414,7 +1414,7 @@ struct MixedPrecisionKernelTests {
                 return try! Vector768Optimized(values)
             }
 
-            let soa768 = try SoAFP16(vectors: vectors768, blockSize: 128)
+            let soa768 = try SoAFP16(vectors: vectors768)
             #expect(soa768.dimension == 768)
             #expect(soa768.vectorCount == 5)
 
@@ -1424,12 +1424,12 @@ struct MixedPrecisionKernelTests {
                 return try! Vector1536Optimized(values)
             }
 
-            let soa1536 = try SoAFP16(vectors: vectors1536, blockSize: 256)
+            let soa1536 = try SoAFP16(vectors: vectors1536)
             #expect(soa1536.dimension == 1536)
             #expect(soa1536.vectorCount == 3)
 
             // Test empty vector handling - should create empty SoA without throwing
-            let emptySOA = try SoAFP16<Vector512Optimized>(vectors: [], blockSize: 64)
+            let emptySOA = try SoAFP16<Vector512Optimized>(vectors: [])
             #expect(emptySOA.vectorCount == 0)
             #expect(emptySOA.dimension == 512)
 
@@ -1437,7 +1437,7 @@ struct MixedPrecisionKernelTests {
             var mismatchedVectors = vectors512
             mismatchedVectors.append(try Vector512Optimized(Array(repeating: Float(1.0), count: 512)))
             // This should work as all have same dimension
-            let soaMismatched = try SoAFP16(vectors: mismatchedVectors, blockSize: 64)
+            let soaMismatched = try SoAFP16(vectors: mismatchedVectors)
             #expect(soaMismatched.vectorCount == 11)
         }
 
@@ -1454,7 +1454,7 @@ struct MixedPrecisionKernelTests {
                 return try! Vector512Optimized(values)
             }
 
-            let soa = try SoAFP16(vectors: vectors, blockSize: 64)
+            let soa = try SoAFP16(vectors: vectors)
 
             // Verify SoA metadata
             #expect(soa.vectorCount == vectorCount)
@@ -1536,7 +1536,7 @@ struct MixedPrecisionKernelTests {
                 return try! Vector768Optimized(values)
             }
 
-            let soa = try SoAFP16(vectors: testVectors, blockSize: 96)
+            let soa = try SoAFP16(vectors: testVectors)
 
             // Test extracting individual vectors
             for i in 0..<vectorCount {
@@ -1580,7 +1580,7 @@ struct MixedPrecisionKernelTests {
 
             // Test round-trip: original → SoA → extracted
             let simpleVector = try Vector768Optimized(Array(repeating: Float(3.14159), count: 768))
-            let soaSimple = try SoAFP16(vectors: [simpleVector], blockSize: 64)
+            let soaSimple = try SoAFP16(vectors: [simpleVector])
             let extractedSimple = try soaSimple.getVector(at: 0)
 
             for i in 0..<768 {
@@ -1607,7 +1607,7 @@ struct MixedPrecisionKernelTests {
 
             // Note: blockSize parameter is accepted but currently unused (reserved for future optimizations)
             // The implementation uses a fixed group size of 4 vectors
-            let soa = try SoAFP16(vectors: vectors, blockSize: 64)
+            let soa = try SoAFP16(vectors: vectors)
 
             // Verify storage efficiency: SoA should use groups of 4 vectors
             let expectedGroups = (vectorCount + 3) / 4
@@ -1682,7 +1682,7 @@ struct MixedPrecisionKernelTests {
             }
 
             // Create SoA layout
-            let soaCandidates = try SoAFP16(vectors: candidates, blockSize: 64)
+            let soaCandidates = try SoAFP16(vectors: candidates)
 
             // Test SoA batch Euclidean distance
             let soaResults = UnsafeMutableBufferPointer<Float>.allocate(capacity: vectorCount)
@@ -1728,25 +1728,6 @@ struct MixedPrecisionKernelTests {
             let reference = sqrt(query.euclideanDistanceSquared(to: candidates[0]))
             let soaFirst = soaResults[0]
             #expect(abs(soaFirst - reference) / reference < 0.01)
-
-            // Test with different block sizes
-            let blockSizes = [32, 128]
-            for blockSize in blockSizes {
-                let soaAlt = try SoAFP16(vectors: candidates, blockSize: blockSize)
-                let altResults = UnsafeMutableBufferPointer<Float>.allocate(capacity: vectorCount)
-                defer { altResults.deallocate() }
-
-                MixedPrecisionKernels.batchEuclideanSoA(
-                    query: queryFP16,
-                    candidates: soaAlt,
-                    results: altResults
-                )
-
-                // Results should be consistent regardless of block size
-                for i in 0..<vectorCount {
-                    #expect(abs(altResults[i] - soaResults[i]) < 0.001)
-                }
-            }
         }
 
         @Test("Batch dot product SoA processing")
@@ -1783,7 +1764,7 @@ struct MixedPrecisionKernelTests {
             }
 
             // Test SoA batch dot product
-            let soaCandidates = try SoAFP16(vectors: candidates, blockSize: 96)
+            let soaCandidates = try SoAFP16(vectors: candidates)
             let dotResults = UnsafeMutableBufferPointer<Float>.allocate(capacity: vectorCount)
             defer { dotResults.deallocate() }
 
@@ -1822,215 +1803,8 @@ struct MixedPrecisionKernelTests {
                 let error = abs(soaDot - refDot)
                 #expect(error < 0.01, "Index \(i): SoA=\(soaDot), ref=\(refDot), error=\(error)")
             }
-
-            // Test with various block sizes
-            let blockSizes = [48, 192, 384]
-            for blockSize in blockSizes {
-                let soaAlt = try SoAFP16(vectors: candidates, blockSize: blockSize)
-                let altDotResults = UnsafeMutableBufferPointer<Float>.allocate(capacity: vectorCount)
-                defer { altDotResults.deallocate() }
-
-                MixedPrecisionKernels.batchDotProductSoA(
-                    query: normalizedQuery,
-                    candidates: soaAlt,
-                    results: altDotResults
-                )
-
-                // Results should be consistent across block sizes
-                for i in 0..<vectorCount {
-                    #expect(abs(altDotResults[i] - dotResults[i]) < 0.001,
-                           "Block size \(blockSize), index \(i): inconsistent results")
-                }
-            }
         }
 
-        // TODO: Restore when SoAFP16 implements dimensional blocking
-        // Currently commented because SoAFP16 uses vector-grouping (groups of 4 vectors)
-        // not dimension-blocking. The blockSize parameter is reserved but unused.
-        // To restore this test, SoAFP16 would need:
-        // 1. Store blockSize as a property
-        // 2. Add blocksPerVector computed property
-        // 3. Add blockPointer(blockIndex:) method
-        // See: https://github.com/anthropics/claude-code/issues/XXX
-        /*
-        @Test("SoA block processing correctness")
-        func testSoABlockProcessingCorrectness() async throws {
-            // Create small test case for detailed verification
-            let vectorCount = 5
-            let dimension = 100  // Not divisible by common block sizes
-            let blockSize = 32
-
-            // Create vectors with predictable patterns
-            var vectors: [Vector512Optimized] = []
-            for i in 0..<vectorCount {
-                var values = Array(repeating: Float(0), count: 512)
-                for j in 0..<dimension {
-                    values[j] = Float(i * 1000 + j)  // Unique value per element
-                }
-                vectors.append(try Vector512Optimized(values))
-            }
-
-            let soa = try SoAFP16(vectors: vectors, blockSize: blockSize)
-
-            // Test individual block processing
-            let blocksPerVector = (dimension + blockSize - 1) / blockSize
-            #expect(blocksPerVector == 4)  // ceil(100/32) = 4
-
-            // Verify dimension/vector indexing within blocks
-            for blockIdx in 0..<blocksPerVector {
-                let blockStart = blockIdx * blockSize
-                let blockEnd = min(blockStart + blockSize, dimension)
-                let blockPtr = soa.blockPointer(blockIndex: blockIdx)
-
-                // Manually verify some values
-                for dimOffset in 0..<min(3, blockEnd - blockStart) {
-                    for vecIdx in 0..<min(2, vectorCount) {
-                        let elementIdx = dimOffset * vectorCount + vecIdx
-                        let simd4Idx = elementIdx / 4
-                        let laneIdx = elementIdx % 4
-
-                        let fp16Value = blockPtr[simd4Idx][laneIdx]
-                        let fp32Value = Float(fp16Value)
-
-                        let expectedValue = Float(vecIdx * 1000 + blockStart + dimOffset)
-                        let error = abs(fp32Value - expectedValue)
-
-                        #expect(error < 1.0,
-                               "Block \(blockIdx), dim \(dimOffset), vec \(vecIdx): expected \(expectedValue), got \(fp32Value)")
-                    }
-                }
-            }
-
-            // Test padding handling in last block
-            let lastBlockIdx = blocksPerVector - 1
-            let lastBlockStart = lastBlockIdx * blockSize
-            let remainingDims = dimension - lastBlockStart
-            #expect(remainingDims == 4)  // 100 - 96 = 4
-
-            // Elements beyond dimension should be padded with zeros
-            _ = soa.blockPointer(blockIndex: lastBlockIdx)
-            let totalElementsInBlock = blockSize * vectorCount
-            let actualElementsInBlock = remainingDims * vectorCount
-            let paddingElements = totalElementsInBlock - actualElementsInBlock
-
-            // Check that padding exists
-            #expect(paddingElements > 0)
-
-            // Verify extracted vectors match original (despite padding)
-            for i in 0..<vectorCount {
-                let extracted = try soa.getVector(at: i)
-                for j in 0..<dimension {
-                    let original = vectors[i][j]
-                    let recovered = extracted[j]
-                    #expect(abs(original - recovered) < 1.0)
-                }
-                // Elements beyond dimension should be zero
-                for j in dimension..<512 {
-                    #expect(extracted[j] == 0.0)
-                }
-            }
-        }
-        */
-
-        // TODO: Restore when SoAFP16 implements dimensional blocking
-        // Currently commented because SoAFP16 uses vector-grouping (groups of 4 vectors)
-        // not dimension-blocking. The blockSize parameter is reserved but unused.
-        // See note above testSoABlockProcessingCorrectness for requirements.
-        /*
-        @Test("SoA memory layout optimization")
-        func testSoAMemoryLayoutOptimization() async throws {
-            // Create large dataset to test memory patterns
-            let vectorCount = 50
-            let dimension = 512
-            let blockSize = 128  // Optimized for cache line size
-
-            let vectors: [Vector512Optimized] = (0..<vectorCount).map { i in
-                let values = (0..<dimension).map { j in
-                    Float(sin(Double(i * j) * 0.0001))
-                }
-                return try! Vector512Optimized(values)
-            }
-
-            let soa = try SoAFP16(vectors: vectors, blockSize: blockSize)
-
-            // Test memory access patterns
-            // Sequential access within blocks should be efficient
-            var sequentialSum: Float = 0
-            for blockIdx in 0..<soa.blocksPerVector {
-                let blockPtr = soa.blockPointer(blockIndex: blockIdx)
-                let blockStart = blockIdx * blockSize
-                let blockEnd = min(blockStart + blockSize, dimension)
-                let elementsInBlock = (blockEnd - blockStart) * vectorCount
-                let simd4Groups = (elementsInBlock + 3) / 4
-
-                // Sequential SIMD4 access
-                for simd4Idx in 0..<simd4Groups {
-                    let simd4 = blockPtr[simd4Idx]
-                    for lane in 0..<4 {
-                        sequentialSum += Float(simd4[lane])
-                    }
-                }
-            }
-
-            #expect(sequentialSum != 0, "Should have processed values")
-
-            // Verify sequential access within blocks
-            // Each block stores dimensions contiguously for all vectors
-            // This means accessing all vectors for a dimension range is efficient
-            let testBlockIdx = 2
-            let testBlockStart = testBlockIdx * blockSize
-            let testBlockEnd = min(testBlockStart + blockSize, dimension)
-
-            // Simulate efficient access pattern
-            var blockValues: [Float] = []
-            let testBlockPtr = soa.blockPointer(blockIndex: testBlockIdx)
-
-            for dimOffset in 0..<(testBlockEnd - testBlockStart) {
-                for vecIdx in 0..<vectorCount {
-                    let elementIdx = dimOffset * vectorCount + vecIdx
-                    let simd4Idx = elementIdx / 4
-                    let laneIdx = elementIdx % 4
-
-                    blockValues.append(Float(testBlockPtr[simd4Idx][laneIdx]))
-                }
-            }
-
-            // Values should be accessed sequentially
-            #expect(blockValues.count == (testBlockEnd - testBlockStart) * vectorCount)
-
-            // Test that block size aligns with cache lines
-            // Modern CPUs have 64-byte cache lines
-            let cacheLineSize = 64
-            let fp16Size = MemoryLayout<Float16>.size
-            _ = cacheLineSize / fp16Size  // 32 elements per cache line
-
-            // Ideal block size should be multiple of cache line
-            let idealBlockElements = blockSize * vectorCount
-            let cacheLinesPerBlock = (idealBlockElements * fp16Size) / cacheLineSize
-
-            // Verify reasonable cache alignment
-            #expect(cacheLinesPerBlock > 0)
-
-            // Test prefetching benefits by accessing predictable pattern
-            let query = vectors[0]  // Use first vector as query
-            let prefetchResults = UnsafeMutableBufferPointer<Float>.allocate(capacity: vectorCount)
-            defer { prefetchResults.deallocate() }
-
-            // This access pattern benefits from prefetching
-            // Convert query to FP16 for mixed precision computation
-            let queryFP16 = MixedPrecisionKernels.Vector512FP16(from: query)
-            MixedPrecisionKernels.batchEuclideanSoA(
-                query: queryFP16,
-                candidates: soa,
-                results: prefetchResults
-            )
-
-            // Verify all results computed
-            for i in 0..<vectorCount {
-                #expect(prefetchResults[i] >= 0, "Distance should be non-negative")
-            }
-        }
-        */
     }
 
     // MARK: - Numerical Stability Tests
@@ -3083,39 +2857,8 @@ struct MixedPrecisionKernelTests {
 
             let query = vectors[0]
 
-            // Test different block sizes for cache efficiency
-            let blockSizes = [32, 64, 128, 256]
-            var timings: [Int: Double] = [:]
-
-            for blockSize in blockSizes {
-                let soa = try SoAFP16(vectors: vectors, blockSize: blockSize)
-                let results = UnsafeMutableBufferPointer<Float>.allocate(capacity: vectorCount)
-                defer { results.deallocate() }
-
-                let start = CFAbsoluteTimeGetCurrent()
-                // Convert query to FP16 for mixed precision computation
-                let queryFP16 = MixedPrecisionKernels.Vector512FP16(from: query)
-                for _ in 0..<10 {  // Multiple iterations to measure
-                    MixedPrecisionKernels.batchEuclideanSoA(
-                        query: queryFP16,
-                        candidates: soa,
-                        results: results
-                    )
-                }
-                let elapsed = CFAbsoluteTimeGetCurrent() - start
-                timings[blockSize] = elapsed
-            }
-
-            // Smaller block sizes should generally be faster for this size
-            // (better cache locality)
-            if let time32 = timings[32], let time256 = timings[256] {
-                // Smaller blocks might be faster, but not necessarily
-                // Just verify both complete successfully
-                #expect(time32 > 0 && time256 > 0, "Both block sizes should work")
-            }
-
             // Compare SoA with regular layout
-            let soaOpt = try SoAFP16(vectors: vectors, blockSize: 64)
+            let soaOpt = try SoAFP16(vectors: vectors)
             let regularFP16 = MixedPrecisionKernels.convertToFP16_512(vectors)
 
             let soaResults = UnsafeMutableBufferPointer<Float>.allocate(capacity: vectorCount)
@@ -3791,7 +3534,7 @@ struct MixedPrecisionKernelTests {
             }
 
             // Test with SoA layout for better memory efficiency
-            let soaDataset = try SoAFP16(vectors: Array(largeDataset.prefix(100)), blockSize: 64)
+            let soaDataset = try SoAFP16(vectors: Array(largeDataset.prefix(100)))
             let soaOutput = UnsafeMutableBufferPointer<Float>.allocate(capacity: 100)
             defer { soaOutput.deallocate() }
 
@@ -3850,7 +3593,7 @@ struct MixedPrecisionKernelTests {
 
             // Test with empty SoA: empty input yields a valid empty SoA (no throw),
             // consistent with the graceful empty-handling above and testSoAFP16Initialization.
-            let emptySoA = try SoAFP16<Vector512Optimized>(vectors: [], blockSize: 64)
+            let emptySoA = try SoAFP16<Vector512Optimized>(vectors: [])
             #expect(emptySoA.vectorCount == 0, "Empty vectors should yield an empty SoA")
             #expect(emptySoA.dimension == 512)
 
@@ -3903,7 +3646,7 @@ struct MixedPrecisionKernelTests {
             #expect(abs(output[0] - expectedCosine) < 0.01)
 
             // Test SoA with single vector
-            let soaSingle = try SoAFP16(vectors: [singleCandidate], blockSize: 64)
+            let soaSingle = try SoAFP16(vectors: [singleCandidate])
             #expect(soaSingle.vectorCount == 1)
 
             // Convert query to FP16 for mixed precision computation
@@ -4162,7 +3905,7 @@ struct MixedPrecisionKernelTests {
             // 1536-dimensional SoA batch operations not yet implemented
             // TODO: Add SoA batch support for 1536-dimensional vectors
             /*
-            let soaCandidates = try SoAFP16(vectors: candidates, blockSize: 128)
+            let soaCandidates = try SoAFP16(vectors: candidates)
             let soaBuffer = UnsafeMutableBufferPointer<Float>.allocate(capacity: candidateCount)
             defer { soaBuffer.deallocate() }
 
@@ -4293,7 +4036,7 @@ struct MixedPrecisionKernelTests {
             #expect(batchFP16.count == batchSize)
 
             // Test SoA layout (good for ANE)
-            let soaBatch = try SoAFP16(vectors: batch, blockSize: 64)
+            let soaBatch = try SoAFP16(vectors: batch)
             #expect(soaBatch.vectorCount == batchSize)
             #expect(soaBatch.dimension == dimension)
 
@@ -4389,7 +4132,7 @@ struct MixedPrecisionKernelTests {
             #expect(alignedTime < 0.01, "Aligned access should be fast")
 
             // Test SoA alignment
-            let soaVectors = try SoAFP16(vectors: alignedVectors, blockSize: 64)
+            let soaVectors = try SoAFP16(vectors: alignedVectors)
 
             // Note: blocksPerVector and blockPointer are internal implementation details
             // not exposed in the public API

--- a/Tests/ComprehensiveTests/PointerSeamRegressionTests.swift
+++ b/Tests/ComprehensiveTests/PointerSeamRegressionTests.swift
@@ -1,0 +1,169 @@
+//
+//  PointerSeamRegressionTests.swift
+//  VectorCore
+//
+//  Regression locks for the pointer-level seams VectorIndex depends on
+//  (beta-evolution-4, DOCUMENT-4 S1 + S2). These APIs already shipped in 0.2.2;
+//  these tests pin the exact behavior so downstream hot paths can rely on it.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+// MARK: - S1: Pointer-level Top-K selection
+
+@Suite("S1 pointer Top-K (regression lock)")
+struct PointerTopKRegressionTests {
+
+    /// Convenience: run the pointer-based select over a Swift array.
+    private func ptrSelect(
+        _ distances: [Float], k: Int, ids: [Int32]? = nil,
+        tieBreaker: TieBreaker = .smallerIndex
+    ) -> (indices: [Int32], distances: [Float]) {
+        distances.withUnsafeBufferPointer { db in
+            if let ids {
+                return ids.withUnsafeBufferPointer { ib in
+                    TopKSelection.select(k: k, from: db.baseAddress!, count: db.count,
+                                         ids: ib.baseAddress!, tieBreaker: tieBreaker)
+                }
+            }
+            return TopKSelection.select(k: k, from: db.baseAddress!, count: db.count,
+                                        ids: nil, tieBreaker: tieBreaker)
+        }
+    }
+
+    @Test("Pointer select matches the array select (distinct distances)")
+    func parityWithArraySelect() {
+        let distances: [Float] = [9, 3, 7, 1, 5, 8, 2, 6, 4, 0]
+        let arr = TopKSelection.select(k: 4, from: distances)
+        let ptr = ptrSelect(distances, k: 4)
+        #expect(ptr.indices.map { Int($0) } == arr.indices)
+        #expect(ptr.distances == arr.distances)
+        #expect(ptr.indices == [9, 3, 6, 1].map(Int32.init))   // values 0,1,2,3
+    }
+
+    @Test("ids buffer remaps result indices")
+    func idsRemap() {
+        let distances: [Float] = [5, 1, 4, 2, 3]
+        let ids: [Int32] = [1000, 1001, 1002, 1003, 1004]
+        let r = ptrSelect(distances, k: 3, ids: ids)
+        // smallest distances are at positions 1,3,4 → remapped to 1001,1003,1004
+        #expect(r.indices == [1001, 1003, 1004])
+        #expect(r.distances == [1, 2, 3])
+    }
+
+    @Test("Results are sorted ascending by distance")
+    func sortedAscending() {
+        let distances: [Float] = (0..<200).map { Float(($0 * 37) % 200) }
+        let r = ptrSelect(distances, k: 25)
+        #expect(r.distances == r.distances.sorted())
+        #expect(r.indices.count == 25)
+    }
+
+    @Test("k greater than count returns count results")
+    func kExceedsCount() {
+        let distances: [Float] = [3, 1, 2]
+        let r = ptrSelect(distances, k: 10)
+        #expect(r.indices.count == 3)
+        #expect(r.distances == [1, 2, 3])
+    }
+
+    @Test("Empty input and non-positive k return empty")
+    func emptyAndZeroK() {
+        #expect(ptrSelect([], k: 5).indices.isEmpty)
+        #expect(ptrSelect([1, 2, 3], k: 0).indices.isEmpty)
+    }
+
+    @Test("Heap path (small k) and sort path (large k) agree with the array reference")
+    func bothPathsCorrect() {
+        // n = 1000: k = 10 (< n/10 → heap path) and k = 600 (>= n/10 → sort path)
+        let distances: [Float] = (0..<1000).map { Float(($0 * 911) % 1000) }
+        for k in [10, 600] {
+            let arr = TopKSelection.select(k: k, from: distances)
+            let ptr = ptrSelect(distances, k: k)
+            #expect(ptr.indices.map { Int($0) } == arr.indices, "mismatch at k=\(k)")
+            #expect(ptr.distances == arr.distances, "distance mismatch at k=\(k)")
+        }
+    }
+}
+
+// MARK: - S2: In-place raw-buffer normalize
+
+@Suite("S2 in-place normalize (regression lock)")
+struct NormalizeUncheckedRegressionTests {
+
+    /// L2 norm computed in Double for measurement accuracy.
+    private func l2(_ v: [Float]) -> Double {
+        sqrt(v.reduce(0.0) { $0 + Double($1) * Double($1) })
+    }
+
+    /// Allocate a 16-byte-aligned Float buffer initialized from `values`.
+    /// `normalizeUnchecked` uses aligned SIMD4 loads, so callers must supply
+    /// aligned memory — this mirrors VectorIndex's real usage.
+    private func withAlignedCopy(_ values: [Float], _ body: (UnsafeMutablePointer<Float>, Int) -> Void) {
+        let p = try! AlignedMemory.allocateAligned(count: values.count, alignment: 64)
+        values.withUnsafeBufferPointer { p.update(from: $0.baseAddress!, count: $0.count) }
+        defer { AlignedMemory.deallocate(p) }
+        body(p, values.count)
+    }
+
+    @Test("Normalizes an aligned buffer to unit L2 norm")
+    func unitNorm() {
+        let values = (0..<512).map { Float(sin(Double($0) * 0.3)) + 1.5 }
+        withAlignedCopy(values) { p, n in
+            NormalizeKernels.normalizeUnchecked(p, dimension: n)
+            let out = Array(UnsafeBufferPointer(start: p, count: n))
+            #expect(abs(l2(out) - 1.0) < 1e-4)
+        }
+    }
+
+    @Test("Preserves direction (parity with typed normalizedUnchecked)")
+    func parityWithTyped() {
+        let values = (0..<512).map { Float(cos(Double($0) * 0.17)) + 0.5 }
+        let typed = try! Vector512Optimized(values).normalizedUnchecked().toArray()
+        withAlignedCopy(values) { p, n in
+            NormalizeKernels.normalizeUnchecked(p, dimension: n)
+            let ptr = Array(UnsafeBufferPointer(start: p, count: n))
+            #expect(abs(l2(typed) - 1.0) < 1e-4)
+            #expect(abs(l2(ptr) - 1.0) < 1e-4)
+            // Same direction ⇒ dot of two unit vectors ≈ 1.
+            let dot = zip(typed, ptr).reduce(0.0) { $0 + Double($1.0) * Double($1.1) }
+            #expect(abs(dot - 1.0) < 1e-4)
+        }
+    }
+
+    @Test("Handles dimensions that are not a multiple of 4 (SIMD tail)")
+    func nonMultipleOf4() {
+        for dim in [300, 301, 303] {
+            let values = (0..<dim).map { Float($0 % 17) + 1 }   // all nonzero
+            withAlignedCopy(values) { p, n in
+                NormalizeKernels.normalizeUnchecked(p, dimension: n)
+                let out = Array(UnsafeBufferPointer(start: p, count: n))
+                #expect(abs(l2(out) - 1.0) < 1e-4, "dim \(dim) not unit norm")
+            }
+        }
+    }
+
+    @Test("Large magnitudes do not overflow")
+    func largeMagnitudeNoOverflow() {
+        let values = (0..<512).map { Float(Double($0 + 1) * 1e17) }   // up to ~5e19
+        withAlignedCopy(values) { p, n in
+            NormalizeKernels.normalizeUnchecked(p, dimension: n)
+            let out = Array(UnsafeBufferPointer(start: p, count: n))
+            #expect(out.allSatisfy { $0.isFinite })
+            #expect(abs(l2(out) - 1.0) < 1e-4)
+        }
+    }
+
+    @Test("Subnormal-dominated vectors never produce NaN/Inf")
+    func subnormalNoPoison() {
+        let values = (0..<512).map { Float(Double($0 + 1) * 1e-41) }   // subnormal range
+        withAlignedCopy(values) { p, n in
+            NormalizeKernels.normalizeUnchecked(p, dimension: n)
+            let out = Array(UnsafeBufferPointer(start: p, count: n))
+            // Contract: leave unchanged rather than poison with Inf/NaN.
+            #expect(out.allSatisfy { $0.isFinite })
+        }
+    }
+}

--- a/Tests/ComprehensiveTests/ProviderConformanceTests.swift
+++ b/Tests/ComprehensiveTests/ProviderConformanceTests.swift
@@ -1,0 +1,240 @@
+//
+//  ProviderConformanceTests.swift
+//  VectorCore
+//
+//  Executable conformance suite for the provider protocols (beta-evolution-4,
+//  DOCUMENT-4 S4). Encodes the semantic laws from
+//  DOCUMENT-4_S4_Provider_Conformance.md and runs them against Core's conformers
+//  (CPUComputeProvider, SwiftBufferPool) and minimal mocks. Downstream packages
+//  (VectorAccelerate) should mirror these checkers against their own conformers.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+// MARK: - Helpers
+
+private enum ProbeError: Error { case boom }
+
+/// Actor that records how many times each index was visited (for completeness laws).
+private actor IndexCounter {
+    private var counts: [Int]
+    init(_ n: Int) { counts = Array(repeating: 0, count: n) }
+    func inc(_ i: Int) { counts[i] += 1 }
+    func snapshot() -> [Int] { counts }
+}
+
+// MARK: - ComputeProvider conformance checker (laws C1–C8)
+
+private func checkComputeProvider(_ p: any ComputeProvider, _ label: String) async throws {
+    // C7 — metadata sanity
+    #expect(p.maxConcurrency >= 1, "\(label): maxConcurrency")
+    #expect(p.deviceInfo.maxThreads >= 1, "\(label): maxThreads")
+    #expect(p.deviceInfo.preferredChunkSize >= 1, "\(label): preferredChunkSize")
+
+    // C1 — execute fidelity
+    let e = try await p.execute { 42 }
+    #expect(e == 42, "\(label): execute returns work result")
+
+    // C8 — error propagation
+    var executeThrew = false
+    do { _ = try await p.execute { throw ProbeError.boom } } catch { executeThrew = true }
+    #expect(executeThrew, "\(label): execute propagates errors")
+
+    let n = 1000
+
+    // C2 — parallelExecute order & completeness
+    let mapped = try await p.parallelExecute(items: 0..<n) { $0 * 2 }
+    #expect(mapped.count == n, "\(label): parallelExecute length")
+    #expect(mapped == (0..<n).map { $0 * 2 }, "\(label): parallelExecute preserves index order")
+
+    // C6 — empty range
+    let emptyMap = try await p.parallelExecute(items: 0..<0) { $0 }
+    #expect(emptyMap.isEmpty, "\(label): parallelExecute empty → []")
+
+    // C3 — parallelForEach completeness (exactly once per item)
+    let counter = IndexCounter(n)
+    try await p.parallelForEach(items: 0..<n) { await counter.inc($0) }
+    let visits = await counter.snapshot()
+    #expect(visits.allSatisfy { $0 == 1 }, "\(label): parallelForEach visits each item exactly once")
+
+    // C4/C5 — parallelReduce partition with identity initial (0 is identity for +)
+    let sum = try await p.parallelReduce(
+        items: 0..<n, initial: 0,
+        { range in range.reduce(0, +) },
+        { $0 + $1 }
+    )
+    #expect(sum == (0..<n).reduce(0, +), "\(label): parallelReduce sums via partition")
+
+    // C6 — reduce over empty range → initial
+    let reduceEmpty = try await p.parallelReduce(
+        items: 0..<0, initial: 7,
+        { _ in 999 },
+        { $0 + $1 }
+    )
+    #expect(reduceEmpty == 7, "\(label): parallelReduce empty → initial")
+}
+
+// MARK: - BufferProvider conformance checker (laws B1–B7)
+
+private func checkBufferProvider(_ p: any BufferProvider, _ label: String) async throws {
+    // B2 — alignment is a power of two ≥ 1
+    #expect(p.alignment >= 1, "\(label): alignment ≥ 1")
+    #expect(p.alignment.nonzeroBitCount == 1, "\(label): alignment is a power of two")
+
+    let size = 1024
+    let h1 = try await p.acquire(size: size)
+
+    // B1 — size
+    #expect(h1.size >= size, "\(label): acquired size ≥ requested")
+    // B2 — pointer aligned
+    #expect(Int(bitPattern: h1.pointer) % p.alignment == 0, "\(label): pointer aligned")
+
+    // B3 — writability (first `size` bytes round-trip)
+    let bytes = h1.pointer.assumingMemoryBound(to: UInt8.self)
+    for i in 0..<size { bytes[i] = UInt8(truncatingIfNeeded: i) }
+    var roundTripOK = true
+    for i in 0..<size where bytes[i] != UInt8(truncatingIfNeeded: i) { roundTripOK = false; break }
+    #expect(roundTripOK, "\(label): buffer is writable and reads back")
+
+    // B4 — two simultaneously-active buffers do not alias
+    let h2 = try await p.acquire(size: size)
+    #expect(h2.id != h1.id, "\(label): distinct handle ids")
+    #expect(h2.pointer != h1.pointer, "\(label): active buffers do not alias")
+    await p.release(h2)
+    await p.release(h1)
+
+    // B7 — statistics sanity
+    let stats = await p.statistics()
+    #expect(stats.totalAllocations >= 1, "\(label): recorded an allocation")
+    #expect(stats.hitRate >= 0 && stats.hitRate <= 1, "\(label): hitRate ∈ [0,1]")
+
+    // B6 — clear keeps active handles valid
+    let h3 = try await p.acquire(size: size)
+    await p.clear()
+    let live = h3.pointer.assumingMemoryBound(to: UInt8.self)
+    live[0] = 7
+    #expect(live[0] == 7, "\(label): active handle survives clear()")
+    await p.release(h3)
+}
+
+// MARK: - Mocks
+
+/// Minimal ComputeProvider implementing only `execute`; inherits parallel* defaults.
+/// Verifies that the protocol's default implementations are themselves conformant.
+private struct MockComputeProvider: ComputeProvider {
+    let device: ComputeDevice = .cpu
+    var maxConcurrency: Int { 4 }
+    var deviceInfo: ComputeDeviceInfo {
+        ComputeDeviceInfo(name: "mock", availableMemory: nil, maxThreads: 4, preferredChunkSize: 256)
+    }
+    func execute<T: Sendable>(_ work: @Sendable @escaping () async throws -> T) async throws -> T {
+        try await work()
+    }
+}
+
+/// Minimal BufferProvider backed by per-acquire aligned allocations.
+private actor MockBufferProvider: BufferProvider {
+    nonisolated let alignment: Int = 64
+    private var active: [UUID: UnsafeMutableRawPointer] = [:]
+    private var allocations = 0
+
+    func acquire(size: Int) async throws -> BufferHandle {
+        let raw = try AlignedMemory.allocateAligned(type: UInt8.self, count: max(1, size), alignment: alignment)
+        let ptr = UnsafeMutableRawPointer(raw)
+        let handle = BufferHandle(size: size, pointer: ptr)
+        active[handle.id] = ptr
+        allocations += 1
+        return handle
+    }
+    func release(_ handle: BufferHandle) async {
+        if let ptr = active.removeValue(forKey: handle.id) { AlignedMemory.deallocate(ptr) }
+    }
+    func statistics() async -> BufferStatistics {
+        BufferStatistics(totalAllocations: allocations, reusedBuffers: 0, currentUsageBytes: 0, peakUsageBytes: 0)
+    }
+    func clear() async { /* nothing pooled; active buffers intentionally retained (B6) */ }
+}
+
+private enum MockAccelError: Error { case unsupported }
+
+/// Minimal AccelerationProvider (a PAT) for A1/A3/A4 + type preservation.
+private struct MockAccelerator: AccelerationProvider {
+    struct Config: Sendable { let supported: Set<AcceleratedOperation> }
+    let supported: Set<AcceleratedOperation>
+    init(configuration: Config) async throws { self.supported = configuration.supported }
+    func isSupported(for operation: AcceleratedOperation) -> Bool { supported.contains(operation) }
+    func accelerate<T>(_ operation: AcceleratedOperation, input: T) async throws -> T {
+        guard supported.contains(operation) else { throw MockAccelError.unsupported }
+        return input
+    }
+}
+
+// MARK: - Tests
+
+@Suite("Provider conformance")
+struct ProviderConformanceTests {
+
+    @Test("CPUComputeProvider .sequential conforms")
+    func cpuSequential() async throws {
+        try await checkComputeProvider(CPUComputeProvider.sequential, "cpu.sequential")
+    }
+
+    @Test("CPUComputeProvider .parallel conforms")
+    func cpuParallel() async throws {
+        try await checkComputeProvider(CPUComputeProvider.parallel, "cpu.parallel")
+    }
+
+    @Test("CPUComputeProvider .automatic (parallel path) conforms")
+    func cpuAutomatic() async throws {
+        // Threshold 1 forces the parallel branch for n ≥ 1, exercising chunked execution.
+        try await checkComputeProvider(
+            CPUComputeProvider(mode: .automatic, parallelizationThreshold: 1), "cpu.automatic")
+    }
+
+    @Test("ComputeProvider default implementations conform")
+    func defaultsConform() async throws {
+        try await checkComputeProvider(MockComputeProvider(), "mock-defaults")
+    }
+
+    @Test("parallelReduce is mode-invariant for an identity initial (C5)")
+    func reduceIdentityInvariant() async throws {
+        let n = 500
+        let seq = try await CPUComputeProvider.sequential.parallelReduce(
+            items: 0..<n, initial: 0, { $0.reduce(0, +) }, { $0 + $1 })
+        let par = try await CPUComputeProvider.parallel.parallelReduce(
+            items: 0..<n, initial: 0, { $0.reduce(0, +) }, { $0 + $1 })
+        #expect(seq == par)
+        #expect(seq == (0..<n).reduce(0, +))
+    }
+
+    @Test("SwiftBufferPool conforms")
+    func swiftBufferPool() async throws {
+        try await checkBufferProvider(SwiftBufferPool(), "swift-pool")
+    }
+
+    @Test("MockBufferProvider conforms")
+    func mockBufferPool() async throws {
+        try await checkBufferProvider(MockBufferProvider(), "mock-pool")
+    }
+
+    @Test("AccelerationProvider laws A1/A3/A4 + type preservation")
+    func accelerationProvider() async throws {
+        let p = try await MockAccelerator(configuration: .init(supported: [.distanceComputation]))
+
+        // A1 — isSupported deterministic
+        #expect(p.isSupported(for: .distanceComputation))
+        #expect(p.isSupported(for: .distanceComputation))
+        #expect(!p.isSupported(for: .matrixMultiplication))
+
+        // Type preservation for a supported op
+        let out: [Float] = try await p.accelerate(.distanceComputation, input: [1, 2, 3])
+        #expect(out == [1, 2, 3])
+
+        // A3 — unsupported throws
+        var threw = false
+        do { _ = try await p.accelerate(.matrixMultiplication, input: [Float]()) } catch { threw = true }
+        #expect(threw, "unsupported operation must throw, not silently mis-compute")
+    }
+}

--- a/Tests/ComprehensiveTests/SoALayoutContractTests.swift
+++ b/Tests/ComprehensiveTests/SoALayoutContractTests.swift
@@ -1,0 +1,169 @@
+//
+//  SoALayoutContractTests.swift
+//  VectorCore
+//
+//  Locks the frozen SoA memory-layout contract (Docs/SoA_Layout_Contract.md) that
+//  VectorAccelerate's zero-copy Metal kernels couple to:
+//    1. SoALayout descriptor fields + the `lane * count + candidate` index formula.
+//    2. A golden parity fixture — known vectors → page-aligned SoA → analytic distances —
+//       so a downstream GPU shader can be validated against our CPU kernel's intent.
+//
+//  If a change breaks these tests, it is a BREAKING CHANGE to the published layout
+//  contract, not a routine refactor. Update the contract doc and notify consumers.
+//
+
+import Testing
+import Foundation
+import simd
+@testable import VectorCore
+
+@Suite("SoA Layout Contract — descriptor")
+struct SoALayoutDescriptorTests {
+
+    @Test("lanes = dimension / 4 for every SoACompatible type (no tail lanes)")
+    func lanesAreDimensionOverFour() {
+        #expect(Vector384Optimized.lanes == 384 / 4)
+        #expect(Vector512Optimized.lanes == 512 / 4)
+        #expect(Vector768Optimized.lanes == 768 / 4)
+        #expect(Vector1536Optimized.lanes == 1536 / 4)
+        // Every dimension is divisible by 4 ⇒ lanes are exact, no partial lane.
+        #expect(384 % 4 == 0 && 512 % 4 == 0 && 768 % 4 == 0 && 1536 % 4 == 0)
+    }
+
+    @Test("element stride is 16 bytes (SIMD4<Float>)")
+    func elementStrideIs16() {
+        #expect(SoALayout.elementStrideBytes == 16)
+        #expect(SoALayout.elementStrideBytes == MemoryLayout<SIMD4<Float>>.stride)
+    }
+
+    @Test("derived byte counts follow the frozen formulas")
+    func derivedByteCounts() {
+        // 768-dim, N = 10: lanes = 192.
+        let layout = SoALayout(lanes: 192, count: 10,
+                               allocatedByteCount: PlatformConfiguration.roundUpToPage(192 * 10 * 16))
+        #expect(layout.lanes == 192)
+        #expect(layout.count == 10)
+        #expect(layout.elementCount == 192 * 10)
+        #expect(layout.laneStrideBytes == 10 * 16)          // count * elementStride
+        #expect(layout.logicalByteCount == 192 * 10 * 16)   // lanes * count * elementStride
+        #expect(layout.allocatedByteCount >= layout.logicalByteCount)
+        #expect(layout.allocatedByteCount % PlatformConfiguration.pageSize == 0)
+    }
+
+    @Test("elementIndex is lane * count + candidate")
+    func elementIndexFormula() {
+        let layout = SoALayout(lanes: 128, count: 5, allocatedByteCount: 0)
+        #expect(layout.elementIndex(lane: 0, candidate: 0) == 0)
+        #expect(layout.elementIndex(lane: 0, candidate: 4) == 4)
+        #expect(layout.elementIndex(lane: 1, candidate: 0) == 5)   // next lane starts at +count
+        #expect(layout.elementIndex(lane: 3, candidate: 2) == 3 * 5 + 2)
+        #expect(layout.elementIndex(lane: 127, candidate: 4) == 127 * 5 + 4)
+    }
+
+    @Test("forType derives the same layout the live SoA reports (page-aligned)")
+    func forTypeMatchesInstancePageAligned() throws {
+        let candidates = try (0..<7).map { k in
+            try Vector768Optimized(Array(repeating: Float(k), count: 768))
+        }
+        let soa = SoA<Vector768Optimized>.build(from: candidates, pageAligned: true)
+        let derived = SoALayout.forType(Vector768Optimized.self, count: 7, pageAligned: true)
+        #expect(derived == soa.layoutDescriptor)
+        #expect(derived.allocatedByteCount == soa.pageAlignedBytes?.byteCount)
+    }
+
+    @Test("forType matches the live SoA for the non-page-aligned path")
+    func forTypeMatchesInstancePlain() throws {
+        let candidates = try (0..<7).map { k in
+            try Vector512Optimized(Array(repeating: Float(k), count: 512))
+        }
+        let soa = SoA<Vector512Optimized>.build(from: candidates, pageAligned: false)
+        let derived = SoALayout.forType(Vector512Optimized.self, count: 7, pageAligned: false)
+        #expect(derived == soa.layoutDescriptor)
+        // Non-page-aligned: allocated == logical, and no zero-copy pointer is offered.
+        #expect(derived.allocatedByteCount == derived.logicalByteCount)
+        #expect(soa.pageAlignedBytes == nil)
+    }
+
+    @Test("allocatedByteCount is page-rounded slack, never a source for count")
+    func allocatedIsSlackNotCount() throws {
+        // N = 5 @ 512-dim ⇒ logical = 128*5*16 = 10240 B; rounds up to a whole page.
+        let candidates = try (0..<5).map { _ in
+            try Vector512Optimized(Array(repeating: Float(1), count: 512))
+        }
+        let soa = SoA<Vector512Optimized>.build(from: candidates, pageAligned: true)
+        let d = soa.layoutDescriptor
+        #expect(d.logicalByteCount == 10240)
+        #expect(d.allocatedByteCount == PlatformConfiguration.roundUpToPage(10240))
+        #expect(d.allocatedByteCount > d.logicalByteCount)   // there IS trailing slack
+        // Reconstructing N from the padded byte count would be WRONG — prove it differs.
+        let wrongN = d.allocatedByteCount / (d.lanes * SoALayout.elementStrideBytes)
+        #expect(wrongN != d.count)   // padded bytes ⇒ inflated N; consumers must use `count`
+    }
+}
+
+@Suite("SoA Layout Contract — golden parity fixture")
+struct SoALayoutParityFixtureTests {
+
+    // Fixture construction (portable, reproducible by any consumer):
+    //   query     q = [1, 1, …, 1]            (512 dims)
+    //   candidate c_k = [1+k, 1+k, …, 1+k]    (512 dims), k = 0 … N-1
+    // Then (q − c_k) = [−k, …] over 512 dims, so the Euclidean SQUARED distance is
+    //   ‖q − c_k‖² = 512 · k².
+    private static let N = 5
+    private static let dim = 512
+    private static func makeQuery() throws -> Vector512Optimized {
+        try Vector512Optimized(Array(repeating: Float(1), count: dim))
+    }
+    private static func makeCandidates() throws -> [Vector512Optimized] {
+        try (0..<N).map { k in try Vector512Optimized(Array(repeating: Float(1 + k), count: dim)) }
+    }
+    /// Expected Euclidean SQUARED distances: 512 · k² = [0, 512, 2048, 4608, 8192].
+    private static let expectedSquared: [Float] = (0..<N).map { Float(dim) * Float($0 * $0) }
+
+    @Test("page-aligned SoA buffer holds candidate j at elementIndex(lane, j)")
+    func rawBufferMatchesIndexFormula() throws {
+        let soa = SoA<Vector512Optimized>.build(from: try Self.makeCandidates(), pageAligned: true)
+        let layout = soa.layoutDescriptor
+
+        soa.withUnsafeRawBuffer { raw in
+            let elems = raw.bindMemory(to: SIMD4<Float>.self)
+            // Candidate j is all (1+j); every lane should read back that constant SIMD4.
+            for j in 0..<Self.N {
+                let expected = SIMD4<Float>(repeating: Float(1 + j))
+                for lane in [0, 1, layout.lanes / 2, layout.lanes - 1] {
+                    let idx = layout.elementIndex(lane: lane, candidate: j)
+                    #expect(elems[idx] == expected)
+                }
+            }
+        }
+    }
+
+    @Test("CPU SoA kernel produces the analytic golden distances")
+    func cpuKernelMatchesGolden() throws {
+        let query = try Self.makeQuery()
+        let soa = SoA<Vector512Optimized>.build(from: try Self.makeCandidates(), pageAligned: true)
+
+        var out = [Float](repeating: .nan, count: Self.N)
+        out.withUnsafeMutableBufferPointer { buf in
+            BatchKernels_SoA.euclid2_512(query: query, soa: soa, out: buf)
+        }
+
+        for k in 0..<Self.N {
+            #expect(abs(out[k] - Self.expectedSquared[k]) < 1e-3,
+                    "k=\(k): kernel \(out[k]) vs golden \(Self.expectedSquared[k])")
+        }
+    }
+
+    @Test("descriptor for the fixture matches the documented golden values")
+    func descriptorGoldenValues() throws {
+        let soa = SoA<Vector512Optimized>.build(from: try Self.makeCandidates(), pageAligned: true)
+        let d = soa.layoutDescriptor
+        // These exact values appear in Docs/SoA_Layout_Contract.md §Golden fixture.
+        #expect(d.lanes == 128)
+        #expect(d.count == 5)
+        #expect(d.laneStrideBytes == 80)        // 5 * 16
+        #expect(d.logicalByteCount == 10240)    // 128 * 5 * 16
+        #expect(d.elementIndex(lane: 1, candidate: 0) == 5)
+        #expect(d.elementIndex(lane: 127, candidate: 4) == 639)
+    }
+}

--- a/Tests/ComprehensiveTests/SoAPageAlignTests.swift
+++ b/Tests/ComprehensiveTests/SoAPageAlignTests.swift
@@ -46,12 +46,30 @@ struct SoAPageAlignTests {
         }
     }
 
-    @Test("withUnsafeRawBuffer exposes the logical data length")
+    @Test("withUnsafeRawBuffer exposes the logical data length (both paths)")
     func rawBufferLength() {
-        let soa = SoA512.build(from: makeCandidates(10), pageAligned: true)
-        soa.withUnsafeRawBuffer { base, byteCount in
-            #expect(byteCount == 10 * 128 * 16)
-            #expect(Int(bitPattern: base) % 16 == 0)
+        for aligned in [true, false] {
+            let soa = SoA512.build(from: makeCandidates(10), pageAligned: aligned)
+            soa.withUnsafeRawBuffer { raw in
+                #expect(raw.count == 10 * 128 * 16)
+                #expect(Int(bitPattern: raw.baseAddress!) % 16 == 0)
+            }
+        }
+    }
+
+    @Test("Already-page-multiple capacity rounds to itself")
+    func exactPageMultiple() {
+        let page = PlatformConfiguration.pageSize
+        // count chosen so logical bytes == one page on the running arch.
+        let count = page / (128 * 16)            // 512-dim: 16384/2048 = 8 on a 16KB page
+        guard count > 0 else { return }          // skip on archs with a tiny page size
+        let soa = SoA512.build(from: makeCandidates(count), pageAligned: true)
+        if let (base, byteCount) = soa.pageAlignedBytes {
+            #expect(Int(bitPattern: base) % page == 0)
+            #expect(byteCount % page == 0)
+            #expect(byteCount == count * 128 * 16)   // already a multiple → no extra padding
+        } else {
+            Issue.record("expected page-aligned bytes")
         }
     }
 

--- a/Tests/ComprehensiveTests/SoAPageAlignTests.swift
+++ b/Tests/ComprehensiveTests/SoAPageAlignTests.swift
@@ -1,0 +1,63 @@
+//
+//  SoAPageAlignTests.swift
+//  VectorCore
+//
+//  R1/R2: opt-in page-aligned SoA buffer + public bytesNoCopy-ready accessor.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+@Suite("SoA page alignment (R1/R2)")
+struct SoAPageAlignTests {
+    private func makeCandidates(_ n: Int) -> [Vector512Optimized] {
+        (0..<n).map { k in try! Vector512Optimized((0..<512).map { Float(($0 + k) % 13) }) }
+    }
+
+    @Test("Page-aligned SoA exposes a page-aligned, page-length pointer")
+    func pageAlignedExposesBytes() {
+        let page = PlatformConfiguration.pageSize
+        let soa = SoA512.build(from: makeCandidates(300), pageAligned: true)
+        let bytes = soa.pageAlignedBytes
+        #expect(bytes != nil)
+        if let (base, byteCount) = bytes {
+            #expect(Int(bitPattern: base) % page == 0, "base must be page-aligned")
+            #expect(byteCount % page == 0, "length must be a page multiple")
+            #expect(byteCount >= 300 * 128 * 16)   // count * lanes * sizeof(SIMD4<Float>)
+        }
+    }
+
+    @Test("Non-page-aligned SoA returns nil for pageAlignedBytes")
+    func defaultReturnsNil() {
+        let soa = SoA512.build(from: makeCandidates(300))   // pageAligned defaults false
+        #expect(soa.pageAlignedBytes == nil)
+    }
+
+    @Test("Page alignment preserves the SoA data layout")
+    func dataIntegrity() {
+        let candidates = makeCandidates(64)
+        let aligned = SoA512.build(from: candidates, pageAligned: true)
+        let plain = SoA512.build(from: candidates, pageAligned: false)
+        for lane in 0..<aligned.lanes {
+            let a = aligned.lanePointer(lane)
+            let p = plain.lanePointer(lane)
+            for j in 0..<64 { #expect(a[j] == p[j], "lane \(lane) candidate \(j)") }
+        }
+    }
+
+    @Test("withUnsafeRawBuffer exposes the logical data length")
+    func rawBufferLength() {
+        let soa = SoA512.build(from: makeCandidates(10), pageAligned: true)
+        soa.withUnsafeRawBuffer { base, byteCount in
+            #expect(byteCount == 10 * 128 * 16)
+            #expect(Int(bitPattern: base) % 16 == 0)
+        }
+    }
+
+    @Test("Empty page-aligned SoA has no bytesNoCopy pointer")
+    func emptyAligned() {
+        let soa = SoA512.build(from: [], pageAligned: true)
+        #expect(soa.pageAlignedBytes == nil)
+    }
+}

--- a/Tests/ComprehensiveTests/SoAPageAlignTests.swift
+++ b/Tests/ComprehensiveTests/SoAPageAlignTests.swift
@@ -78,4 +78,26 @@ struct SoAPageAlignTests {
         let soa = SoA512.build(from: [], pageAligned: true)
         #expect(soa.pageAlignedBytes == nil)
     }
+
+    @Test("consumeAllocation transfers ownership of the page-aligned buffer")
+    func consumeTransfersOwnership() {
+        let soa = SoA512.build(from: makeCandidates(128), pageAligned: true)
+        let before = soa.pageAlignedBytes
+        #expect(before != nil)
+        let consumed = soa.consumeAllocation()
+        #expect(consumed != nil)
+        if let (base, byteCount) = consumed, let (beforeBase, beforeCount) = before {
+            #expect(UnsafeRawPointer(base) == beforeBase)   // same pointer identity
+            #expect(byteCount == beforeCount)
+            #expect(soa.pageAlignedBytes == nil)            // ownership relinquished
+            // Caller now owns the memory; SoA deinit must NOT double-free.
+            AlignedMemory.deallocate(base)
+        }
+    }
+
+    @Test("consumeAllocation returns nil for a non-page-aligned SoA")
+    func consumeNonAlignedNil() {
+        let soa = SoA512.build(from: makeCandidates(128))   // default 16-byte
+        #expect(soa.consumeAllocation() == nil)
+    }
 }

--- a/Tests/ComprehensiveTests/TopKTieBreakingTests.swift
+++ b/Tests/ComprehensiveTests/TopKTieBreakingTests.swift
@@ -1,0 +1,92 @@
+//
+//  TopKTieBreakingTests.swift
+//  VectorCore
+//
+//  Tests for configurable, deterministic Top-K tie-breaking
+//  (beta-evolution-4, DOCUMENT-4 S3). Verifies that equal-distance ties are
+//  resolved deterministically (default: smallerIndex) and consistently across
+//  the array, pointer, large-k, and optimized selection paths.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+@Suite("Top-K tie-breaking determinism")
+struct TopKTieBreakingTests {
+
+    // MARK: - Default policy
+
+    @Test("All-equal distances select the smallest indices, in order")
+    func arrayAllEqual() {
+        let distances = [Float](repeating: 1.0, count: 10)
+        let r = TopKSelection.select(k: 3, from: distances)
+        #expect(r.indices == [0, 1, 2])
+    }
+
+    @Test("Default tie-break equals explicit .smallerIndex")
+    func defaultEqualsSmallerIndex() {
+        let distances: [Float] = [5, 1, 1, 1, 2, 1]
+        let a = TopKSelection.select(k: 3, from: distances)
+        let b = TopKSelection.select(k: 3, from: distances, tieBreaker: .smallerIndex)
+        #expect(a.indices == b.indices)
+        #expect(a.distances == b.distances)
+    }
+
+    // MARK: - Boundary ties (which elements survive the cut)
+
+    @Test("smallerIndex keeps the lowest indices among ties at the k boundary (large-k path)")
+    func boundaryTiesLargeK() {
+        // index 0 is the unique minimum; the remaining six tie at 2.0.
+        // n=7, k=4 → k >= n/10 → large-k (sort) path.
+        let distances: [Float] = [0.0, 2, 2, 2, 2, 2, 2]
+        let r = TopKSelection.select(k: 4, from: distances, tieBreaker: .smallerIndex)
+        #expect(r.indices == [0, 1, 2, 3])
+    }
+
+    @Test("smallerIndex is deterministic on the small-k heap path")
+    func smallKHeapDeterministic() {
+        // n=1000, k=50 → k < n/10 → heap path. All equal → indices 0..<50.
+        let distances = [Float](repeating: 1.0, count: 1000)
+        let r1 = TopKSelection.select(k: 50, from: distances, tieBreaker: .smallerIndex)
+        let r2 = TopKSelection.select(k: 50, from: distances, tieBreaker: .smallerIndex)
+        #expect(r1.indices == r2.indices)
+        #expect(r1.indices == Array(0..<50))
+    }
+
+    // MARK: - Cross-path consistency
+
+    @Test("Pointer path agrees with array path under ties")
+    func pointerMatchesArray() {
+        // Minima (value 1) sit at odd indices; expect the three smallest such indices.
+        let distances: [Float] = [2, 1, 2, 1, 2, 1, 2, 1, 2, 1]
+        let arr = TopKSelection.select(k: 3, from: distances, tieBreaker: .smallerIndex)
+        let ptr = distances.withUnsafeBufferPointer { buf in
+            TopKSelection.select(k: 3, from: buf.baseAddress!, count: buf.count,
+                                 ids: nil, tieBreaker: .smallerIndex)
+        }
+        #expect(ptr.indices.map { Int($0) } == arr.indices)
+        #expect(arr.indices == [1, 3, 5])
+    }
+
+    // MARK: - Optimized kernel path ordering
+
+    @Test("Optimized nearestEuclidean512 orders identical candidates by smaller index")
+    func optimizedDeterministicTies() {
+        let q = try! Vector512Optimized([Float](repeating: 0, count: 512))
+        let c = try! Vector512Optimized([Float](repeating: 1, count: 512))
+        let candidates = Array(repeating: c, count: 8)  // all identical → equal distance
+        let r = TopKSelection.nearestEuclidean512(k: 3, query: q, candidates: candidates)
+        #expect(r.indices == [0, 1, 2])
+    }
+
+    // MARK: - Non-tie correctness is preserved
+
+    @Test("Distinct distances are unaffected by the tie-breaker")
+    func distinctUnaffected() {
+        let distances: [Float] = [9, 3, 7, 1, 5]
+        let r = TopKSelection.select(k: 3, from: distances, tieBreaker: .smallerIndex)
+        #expect(r.indices == [3, 1, 4])           // values 1, 3, 5
+        #expect(r.distances == [1, 3, 5])
+    }
+}

--- a/Tests/ComprehensiveTests/UnifiedVectorBufferTests.swift
+++ b/Tests/ComprehensiveTests/UnifiedVectorBufferTests.swift
@@ -1,0 +1,161 @@
+//
+//  UnifiedVectorBufferTests.swift
+//  VectorCore
+//
+//  Tests for the zero-copy buffer contract (beta-evolution-4, DOCUMENT-4 S5):
+//  UnifiedVectorBuffer protocol + PageAlignedBuffer page-aligned allocation path
+//  for MTLDevice.makeBuffer(bytesNoCopy:) interop.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+@Suite("UnifiedVectorBuffer / PageAlignedBuffer")
+struct UnifiedVectorBufferTests {
+
+    // MARK: - Page alignment contract (the makeBuffer(bytesNoCopy:) requirement)
+
+    @Test("Base address and length satisfy the bytesNoCopy contract")
+    func pageAlignmentContract() {
+        let page = PlatformConfiguration.pageSize
+        // 512 floats = 2048 bytes — far smaller than a page, must round up.
+        let buf = PageAlignedBuffer(elementCount: 512)
+
+        buf.withUnsafeContiguousBytes { raw in
+            let addr = Int(bitPattern: raw.baseAddress!)
+            #expect(addr % page == 0, "base address must be page-aligned")
+        }
+        #expect(Int(bitPattern: buf.baseAddress) % page == 0)
+        #expect(buf.allocatedByteCount % page == 0, "allocated length must be a page multiple")
+        #expect(buf.allocatedByteCount >= 512 * MemoryLayout<Float>.stride)
+        #expect(buf.alignment == page)
+        #expect(buf.elementCount == 512)
+        #expect(buf.byteCount == 512 * MemoryLayout<Float>.stride)
+    }
+
+    @Test("Logical length and padded length round correctly across page boundaries")
+    func lengthRounding() {
+        let page = PlatformConfiguration.pageSize
+        func padded(_ floats: Int) -> Int {
+            let logical = floats * MemoryLayout<Float>.stride
+            return ((logical + page - 1) / page) * page
+        }
+        // Sub-page, multi-page, and exact-page cases.
+        for floats in [1, 512, 4096, 5000, 8192] {
+            let buf = PageAlignedBuffer(elementCount: floats)
+            #expect(buf.allocatedByteCount == padded(floats))
+            #expect(buf.allocatedByteCount % page == 0)
+            #expect(buf.allocatedByteCount >= floats * MemoryLayout<Float>.stride)
+        }
+        // 4096 floats == exactly one 16KB page on Apple Silicon → no extra padding.
+        if page == 16384 {
+            #expect(PageAlignedBuffer(elementCount: 4096).allocatedByteCount == 16384)
+        }
+    }
+
+    // MARK: - Zero initialization (padding must be zero for GPU reads)
+
+    @Test("Buffer is zero-initialized including padding")
+    func zeroInitialized() {
+        let buf = PageAlignedBuffer(elementCount: 100)
+        // Logical region zero.
+        buf.withUnsafeContiguousBytes { raw in
+            for i in 0..<100 {
+                let v = raw.load(fromByteOffset: i * MemoryLayout<Float>.stride, as: Float.self)
+                #expect(v == 0)
+            }
+        }
+        // Padding region (beyond logical, up to allocatedByteCount) also zero.
+        let logical = 100 * MemoryLayout<Float>.stride
+        let rawBase = UnsafeRawBufferPointer(start: buf.baseAddress, count: buf.allocatedByteCount)
+        for off in stride(from: logical, to: buf.allocatedByteCount, by: MemoryLayout<Float>.stride) {
+            #expect(rawBase.load(fromByteOffset: off, as: Float.self) == 0)
+        }
+    }
+
+    // MARK: - Mutate / read round-trip
+
+    @Test("Mutable write is visible through the read contract")
+    func mutateReadRoundTrip() {
+        let buf = PageAlignedBuffer(elementCount: 256)
+        buf.withUnsafeMutableBufferPointer { ptr in
+            for i in 0..<256 { ptr[i] = Float(i) * 0.5 }
+        }
+        buf.withUnsafeContiguousBytes { raw in
+            #expect(raw.count == 256 * MemoryLayout<Float>.stride)
+            for i in 0..<256 {
+                let v = raw.load(fromByteOffset: i * MemoryLayout<Float>.stride, as: Float.self)
+                #expect(v == Float(i) * 0.5)
+            }
+        }
+    }
+
+    @Test("init(copying:) preserves values and count")
+    func copyingInit() {
+        let source = (0..<384).map { Float($0) * 1.25 }
+        let buf = PageAlignedBuffer(copying: source)
+        #expect(buf.elementCount == 384)
+        buf.withUnsafeContiguousBytes { raw in
+            for i in 0..<384 {
+                let v = raw.load(fromByteOffset: i * MemoryLayout<Float>.stride, as: Float.self)
+                #expect(v == source[i])
+            }
+        }
+    }
+
+    // MARK: - Ownership transfer (relinquish for Metal bytesNoCopy deallocator)
+
+    @Test("consumeAllocation transfers ownership and preserves pointer identity")
+    func consumeAllocation() {
+        let buf = PageAlignedBuffer(elementCount: 128)
+        #expect(buf.ownsAllocation == true)
+        let before = buf.baseAddress
+
+        let (base, length) = buf.consumeAllocation()
+        #expect(buf.ownsAllocation == false, "buffer must relinquish ownership")
+        #expect(base == before, "pointer identity preserved across transfer")
+        #expect(length == buf.allocatedByteCount)
+
+        // Caller is now responsible for freeing — deinit must NOT double-free.
+        AlignedMemory.deallocate(base)
+        // buf deinits here without freeing (verified by absence of double-free crash).
+    }
+
+    // MARK: - Conformance of optimized vector types (read contract, not page-aligned)
+
+    @Test("Vector512Optimized conforms to the read contract")
+    func optimizedConformance() {
+        let values = (0..<512).map { Float($0) * 0.01 }
+        let v = try! Vector512Optimized(values)
+        let u: any UnifiedVectorBuffer = v
+
+        #expect(u.elementCount == 512)
+        #expect(u.alignment >= 16, "SIMD4 storage is at least 16-byte aligned")
+        u.withUnsafeContiguousBytes { raw in
+            #expect(raw.count == 512 * MemoryLayout<Float>.stride)
+            let addr = Int(bitPattern: raw.baseAddress!)
+            #expect(addr % u.alignment == 0)
+            for i in 0..<512 {
+                let got = raw.load(fromByteOffset: i * MemoryLayout<Float>.stride, as: Float.self)
+                #expect(abs(got - values[i]) < 1e-6)
+            }
+        }
+    }
+
+    @Test("DynamicVector conforms to the read contract")
+    func dynamicConformance() {
+        let values = (0..<300).map { Float($0) * 0.1 }
+        let v = DynamicVector(values)
+        let u: any UnifiedVectorBuffer = v
+
+        #expect(u.elementCount == 300)
+        u.withUnsafeContiguousBytes { raw in
+            #expect(raw.count == 300 * MemoryLayout<Float>.stride)
+            for i in 0..<300 {
+                let got = raw.load(fromByteOffset: i * MemoryLayout<Float>.stride, as: Float.self)
+                #expect(abs(got - values[i]) < 1e-6)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Implements the **beta-evolution-4** review of an external "grow VectorCore into a SOTA DB/index engine" proposal. Measured against the three real downstream packages (VectorIndex, VectorAccelerate, EmbedKit), the verdict was **"hold the line, sharpen the seams"**: most of the proposal already ships downstream, so rather than duplicate it, this PR hardens VectorCore's CPU-primitive foundation and the integration seams the ecosystem was bypassing. Targets release **0.3.0**.

### What shipped

**CPU math primitive**
- `MatrixDistance` — batch distance via Accelerate `cblas_sgemm` (AMX on Apple Silicon), using the identity `‖x−Y‖² = ‖x‖²+‖Y‖²−2⟨x,Y⟩`. `euclideanSquaredMatrix`/`cosineDistanceMatrix` (`into:`/allocating/`prepared:` overloads), `prepare(_:normalized:)` → `PreparedCandidates` for reuse. Results clamped (cancellation can round negative); ~1e-3 agreement with the per-pair kernels.
- `BatchOperations` auto-routes large batches through GEMM (`enableMatrixRouting`, `matrixRoutingMinN` = 256).

**Zero-copy GPU-bridge seam (for VectorAccelerate)**
- `UnifiedVectorBuffer` protocol + `PageAlignedBuffer` — page-aligned, page-rounded buffers valid for `MTLDevice.makeBuffer(bytesNoCopy:)`.
- Opt-in page-aligned `SoA` (`build(from:pageAligned:)`, `pageAlignedBytes`, `consumeAllocation()`, `withUnsafeRawBuffer`) with an allocator-correct free contract.
- **Frozen `SoALayout` contract** — `SoA.layoutDescriptor` / `SoALayout.forType`, documented at `Docs/SoA_Layout_Contract.md`, so VA's Metal kernels index our buffer from one source of truth. Golden parity fixture included.

**Provider + selection seams**
- `BatchKernelProvider` (a `ComputeProvider` sub-protocol) — `Operations.findNearest`/`findNearestBatch` downcast and delegate to an installed GPU provider (precedence over CPU GEMM).
- `TieBreaker` — deterministic Top-K tie-breaking.
- Pointer-level Top-K (S1) and in-place raw-buffer normalize (S2) regression-locked; provider conformance contract + suite (S4).

### Breaking changes
- Removed the **no-op `blockSize:` parameter** from `SoA.init(vectors:…)` and `SoAFP16.init(vectors:…)`. It was ignored and implied a candidate-axis padding that does not exist. Source-breaking only for call sites that passed it explicitly (it had a default).

### Deferred / redirected (documented, not built)
- **Q8_0 block quantization** — specced (`DOCUMENT-3`) but consumer-gated; not built.
- mmap storage, pinned Metal arenas, ADC LUTs, HNSW visited-lists, concurrent priority queue, prefetch, binary-packed vectors, sparse CSR — **redirected** to the sibling that already owns each. Rationale in `Docs/beta-evolution-4/`.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (the `blockSize:` removal — source-breaking only for explicit callers)
- [x] Performance improvement (GEMM batch distance / AMX)
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review (+ per-task spec/quality reviews and an adversarial contract-vs-source review of the frozen layout)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG, README, guides, `SoA_Layout_Contract.md`, beta-evolution-4 suite)
- [x] My changes generate no new warnings
- [x] I have added tests (MatrixDistance parity, SoALayout contract + golden fixture, BatchKernelProvider dispatch, tie-breaking, page-align, provider conformance, S1/S2 seam locks)
- [x] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published (VectorAccelerate consumes these seams on their side as a follow-up)

## Performance Impact
- [x] Performance improvements are documented (GEMM routes to AMX; crossover at `matrixRoutingMinN`=256, calibrated via the `matrix` bench suite)
- [ ] I have run benchmarks and confirmed no regression — *core kernels unchanged; GEMM is an additive routed path. `--suites matrix` is provided for crossover calibration.*
- [x] Changes have been tested with optimization flags enabled (correctness suite)

## Testing
- Test configuration:
  - Platform: macOS (Apple Silicon, arm64)
  - Swift version: 6.0 (strict concurrency)
  - Build configuration: Debug
- **Full suite: 1078 tests in 152 suites passing** (run with `VECTORCORE_TEST_EXTENDED=0` to exclude the known wall-clock perf-ratio flake). New coverage: `SoALayoutContractTests` (descriptor + golden parity fixture), `MatrixDistanceTests`, `BatchKernelProviderTests`, `TopKTieBreakingTests`, `SoAPageAlignTests`, `ProviderConformanceTests`, `UnifiedVectorBufferTests`, plus S1/S2 regression locks.

## Additional Notes
- Design + rationale: `Docs/beta-evolution-4/` (master review + DOCUMENT-1…6) and the frozen `Docs/SoA_Layout_Contract.md`.
- A point-by-point reply to VectorAccelerate's integration requests (R1–R4) and their layout-freeze follow-up is captured in `DOCUMENT-5`.
- 43 files, +5436/−566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)