### PR TITLE
Linear algebra stack: LAPACK seam, randomized-SVD PCA, UMAP layout

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,17 @@ let package = Package(
         .target(
             name: "VectorCoreC",
             path: "Sources/VectorCoreC",
-            publicHeadersPath: "include"
+            publicHeadersPath: "include",
+            linkerSettings: [
+                // LAPACK shim (vc_lapack.c) calls Accelerate's modern LAPACK
+                // interface (ACCELERATE_NEW_LAPACK) on Apple platforms.
+                // Explicit link keeps VectorCoreC self-contained rather than
+                // relying on Swift-side autolinking of Accelerate.
+                .linkedFramework(
+                    "Accelerate",
+                    .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS])
+                )
+            ]
         ),
 
         // Benchmarking library - models and utilities for benchmark tools

--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,16 @@ let package = Package(
             name: "VectorCoreC",
             path: "Sources/VectorCoreC",
             publicHeadersPath: "include",
+            cSettings: [
+                // SPM compiles C targets with clang modules, so an in-source
+                // `#define ACCELERATE_NEW_LAPACK` before the include is ignored
+                // for the module import — the macro must come from the command
+                // line. `.define` is a safe (non-unsafeFlags) setting.
+                // ACCELERATE_LAPACK_ILP64 intentionally NOT defined — see
+                // vc_lapack.h (32-bit LAPACK indices by design).
+                .define("ACCELERATE_NEW_LAPACK", to: "1",
+                        .when(platforms: [.macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .visionOS]))
+            ],
             linkerSettings: [
                 // LAPACK shim (vc_lapack.c) calls Accelerate's modern LAPACK
                 // interface (ACCELERATE_NEW_LAPACK) on Apple platforms.
@@ -73,7 +83,7 @@ let package = Package(
             dependencies: ["VectorCore"],
             swiftSettings: [ .enableExperimentalFeature("StrictConcurrency") ]
         ),
-        
+
         // New comprehensive test suite (skeleton only)
         .testTarget(
             name: "ComprehensiveTests",

--- a/Package.swift
+++ b/Package.swift
@@ -47,9 +47,12 @@ let package = Package(
                 // interface (ACCELERATE_NEW_LAPACK) on Apple platforms.
                 // Explicit link keeps VectorCoreC self-contained rather than
                 // relying on Swift-side autolinking of Accelerate.
+                // .macCatalyst is a distinct SPM platform (iOS conditions do
+                // not cover it) and __APPLE__ is defined there, so the shim
+                // references LAPACK symbols — it must link Accelerate too.
                 .linkedFramework(
                     "Accelerate",
-                    .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS])
+                    .when(platforms: [.macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .visionOS])
                 )
             ]
         ),

--- a/Sources/VectorCore/LinearAlgebra/LAPACKLinearAlgebraProvider.swift
+++ b/Sources/VectorCore/LinearAlgebra/LAPACKLinearAlgebraProvider.swift
@@ -1,0 +1,157 @@
+//
+//  LAPACKLinearAlgebraProvider.swift
+//  VectorCore
+//
+//  LAPACK-backed LinearAlgebraProvider, routed through the VectorCoreC
+//  vc_lapack shim (Accelerate's modern LAPACK, ACCELERATE_NEW_LAPACK).
+//
+//  Why the shim exists (vs. importing Accelerate here): the modern LAPACK
+//  interface is macro-gated at C-header level; defining it from Swift would
+//  require `unsafeFlags`. See Sources/VectorCoreC/include/vc_lapack.h.
+//
+//  Availability is a runtime probe (`vc_lapack_available()`), so this type
+//  compiles on every platform and fails with a typed error rather than a
+//  missing symbol on platforms without a backend. Use
+//  `LAPACKLinearAlgebraProvider.isAvailable` to branch ahead of time.
+//
+
+import Foundation
+import VectorCoreC
+
+public struct LAPACKLinearAlgebraProvider: LinearAlgebraProvider {
+
+    public init() {}
+
+    /// Whether a LAPACK backend is compiled in on this platform.
+    public static var isAvailable: Bool { vc_lapack_available() != 0 }
+
+    // MARK: - QR
+
+    public func qrThin(_ a: [Float], rows: Int, columns: Int) throws -> QRFactorization {
+        try LinearAlgebraValidation.validateQR(count: a.count, rows: rows, columns: columns)
+        try Self.ensureAvailable()
+
+        let m = Int32(rows), n = Int32(columns)
+        var work = a                       // sgeqrf factors in place
+        var tau = [Float](repeating: 0, count: columns)
+
+        let geqrfInfo = work.withUnsafeMutableBufferPointer { wp in
+            tau.withUnsafeMutableBufferPointer { tp in
+                vc_lapack_sgeqrf(m, n, wp.baseAddress!, m, tp.baseAddress!)
+            }
+        }
+        try Self.check(geqrfInfo, routine: "sgeqrf")
+
+        // Extract R (n×n upper triangle) before sorgqr overwrites `work` with Q.
+        var r = [Float](repeating: 0, count: columns * columns)
+        for j in 0..<columns {
+            for i in 0...j {
+                r[j * columns + i] = work[j * rows + i]
+            }
+        }
+
+        // Form explicit thin Q (m×n) from the n reflectors.
+        let orgqrInfo = work.withUnsafeMutableBufferPointer { wp in
+            tau.withUnsafeBufferPointer { tp in
+                vc_lapack_sorgqr(m, n, n, wp.baseAddress!, m, tp.baseAddress!)
+            }
+        }
+        try Self.check(orgqrInfo, routine: "sorgqr")
+
+        return QRFactorization(q: work, r: r, rows: rows, columns: columns)
+    }
+
+    // MARK: - SVD
+
+    public func svdThin(_ a: [Float], rows: Int, columns: Int) throws -> SingularValueDecomposition {
+        try LinearAlgebraValidation.validateRect(count: a.count, rows: rows, columns: columns)
+        try Self.ensureAvailable()
+
+        let m = Int32(rows), n = Int32(columns)
+        let k = Swift.min(rows, columns)
+        var work = a                       // sgesdd destroys A
+        var s = [Float](repeating: 0, count: k)
+        var u = [Float](repeating: 0, count: rows * k)
+        var vt = [Float](repeating: 0, count: k * columns)
+
+        let info = work.withUnsafeMutableBufferPointer { ap in
+            s.withUnsafeMutableBufferPointer { sp in
+                u.withUnsafeMutableBufferPointer { up in
+                    vt.withUnsafeMutableBufferPointer { vtp in
+                        vc_lapack_sgesdd(
+                            m, n,
+                            ap.baseAddress!, m,
+                            sp.baseAddress!,
+                            up.baseAddress!, m,
+                            vtp.baseAddress!, Int32(k)
+                        )
+                    }
+                }
+            }
+        }
+        try Self.check(info, routine: "sgesdd")
+
+        return SingularValueDecomposition(u: u, singularValues: s, vt: vt, rows: rows, columns: columns)
+    }
+
+    // MARK: - Symmetric eigen
+
+    public func symmetricEigen(
+        _ a: [Float],
+        dimension: Int,
+        computeEigenvectors: Bool
+    ) throws -> SymmetricEigenDecomposition {
+        try LinearAlgebraValidation.validateSquare(count: a.count, dimension: dimension)
+        try Self.ensureAvailable()
+
+        let n = Int32(dimension)
+        var work = a                       // ssyevd overwrites A with eigenvectors (jobz='V')
+        var w = [Float](repeating: 0, count: dimension)
+        let jobz: CChar = computeEigenvectors ? 86 /* 'V' */ : 78 /* 'N' */
+
+        let info = work.withUnsafeMutableBufferPointer { ap in
+            w.withUnsafeMutableBufferPointer { wp in
+                vc_lapack_ssyevd(jobz, 76 /* 'L' */, n, ap.baseAddress!, n, wp.baseAddress!)
+            }
+        }
+        try Self.check(info, routine: "ssyevd")
+
+        return SymmetricEigenDecomposition(
+            eigenvalues: w,
+            eigenvectors: computeEigenvectors ? work : nil,
+            dimension: dimension
+        )
+    }
+
+    // MARK: - Error mapping
+
+    private static func ensureAvailable() throws {
+        guard isAvailable else {
+            throw ErrorBuilder(.resourceUnavailable)
+                .message("No LAPACK backend on this platform; use SwiftLinearAlgebraProvider")
+                .build()
+        }
+    }
+
+    /// Mirrors VC_LAPACK_UNAVAILABLE in vc_lapack.h. Re-declared here because
+    /// parenthesized negative macros don't reliably cross the Clang importer.
+    private static let unavailableCode: Int32 = -1000
+
+    private static func check(_ info: Int32, routine: String) throws {
+        guard info != 0 else { return }
+        if info == Self.unavailableCode {
+            throw ErrorBuilder(.resourceUnavailable)
+                .message("LAPACK shim unavailable or workspace allocation failed in \(routine)")
+                .build()
+        }
+        if info < 0 {
+            // Illegal argument — indicates a bug in this provider, not user input.
+            throw VectorError.invalidOperation(
+                routine, reason: "illegal argument at position \(-info) (provider bug)")
+        }
+        // info > 0: routine-specific algorithmic failure (e.g. D&C non-convergence).
+        throw ErrorBuilder(.operationFailed)
+            .message("\(routine) failed to converge (info=\(info))")
+            .build()
+    }
+}

--- a/Sources/VectorCore/LinearAlgebra/LAPACKLinearAlgebraProvider.swift
+++ b/Sources/VectorCore/LinearAlgebra/LAPACKLinearAlgebraProvider.swift
@@ -15,7 +15,6 @@
 //  `LAPACKLinearAlgebraProvider.isAvailable` to branch ahead of time.
 //
 
-import Foundation
 import VectorCoreC
 
 public struct LAPACKLinearAlgebraProvider: LinearAlgebraProvider {

--- a/Sources/VectorCore/LinearAlgebra/LinearAlgebraProvider.swift
+++ b/Sources/VectorCore/LinearAlgebra/LinearAlgebraProvider.swift
@@ -1,0 +1,183 @@
+//
+//  LinearAlgebraProvider.swift
+//  VectorCore
+//
+//  Dense linear-algebra seam: QR, thin SVD, symmetric eigendecomposition.
+//
+//  This is the foundational enabler for projection primitives (PCA /
+//  randomized SVD; see Docs/gap-analysis-hn-semantic-search.md §3.0–3.1).
+//  It mirrors the SIMDProvider pattern: a protocol seam with a LAPACK-backed
+//  implementation on Apple platforms (via the VectorCoreC vc_lapack shim)
+//  and a pure-Swift fallback everywhere else.
+//
+//  ## Layout contract — COLUMN-MAJOR
+//
+//  All matrices cross this seam as flat `[Float]` in COLUMN-MAJOR order
+//  (element (i,j) of an m×n matrix lives at index `j*m + i`), matching
+//  LAPACK's native layout so the fast path is copy-free in orientation.
+//  This is an internal-facing seam; higher-level APIs (e.g. the future
+//  `Operations.pca`) own the translation from row-major vector collections.
+//
+//  ## Scale contract
+//
+//  These are SMALL-PANEL routines: covariance/Gram matrices (d ≤ a few
+//  thousand) and randomized-SVD sketch panels (n × (k+p), k+p ≤ ~100).
+//  They are deliberately not streamed or tiled — the streaming happens a
+//  level above, in the GEMM passes that build the panels.
+//
+
+import Foundation
+
+// MARK: - Result types
+
+/// Thin QR factorization: `A (m×n, m ≥ n) = Q (m×n) · R (n×n)`.
+public struct QRFactorization: Sendable {
+    /// Orthonormal factor, m×n, column-major. Columns satisfy QᵀQ = I.
+    public let q: [Float]
+    /// Upper-triangular factor, n×n, column-major.
+    public let r: [Float]
+    /// Row count of A (and Q).
+    public let rows: Int
+    /// Column count of A (and Q; also the dimension of R).
+    public let columns: Int
+
+    public init(q: [Float], r: [Float], rows: Int, columns: Int) {
+        self.q = q
+        self.r = r
+        self.rows = rows
+        self.columns = columns
+    }
+}
+
+/// Thin singular value decomposition: `A (m×n) = U (m×k) · diag(s) · Vᵀ (k×n)`
+/// with `k = min(m, n)`.
+public struct SingularValueDecomposition: Sendable {
+    /// Left singular vectors, m×k, column-major, orthonormal columns.
+    public let u: [Float]
+    /// Singular values, length k, in DESCENDING order (LAPACK convention).
+    public let singularValues: [Float]
+    /// Right singular vectors transposed, k×n, column-major, orthonormal rows.
+    public let vt: [Float]
+    /// Row count of A.
+    public let rows: Int
+    /// Column count of A.
+    public let columns: Int
+
+    /// k = min(rows, columns).
+    public var rank: Int { Swift.min(rows, columns) }
+
+    public init(u: [Float], singularValues: [Float], vt: [Float], rows: Int, columns: Int) {
+        self.u = u
+        self.singularValues = singularValues
+        self.vt = vt
+        self.rows = rows
+        self.columns = columns
+    }
+}
+
+/// Symmetric eigendecomposition: `A (n×n, symmetric) = V · diag(λ) · Vᵀ`.
+public struct SymmetricEigenDecomposition: Sendable {
+    /// Eigenvalues, length n, in ASCENDING order (LAPACK ssyevd convention).
+    /// Note this is the opposite of `SingularValueDecomposition.singularValues`.
+    public let eigenvalues: [Float]
+    /// Eigenvectors, n×n column-major (column j pairs with eigenvalues[j]),
+    /// or `nil` when vectors were not requested.
+    public let eigenvectors: [Float]?
+    /// Matrix dimension.
+    public let dimension: Int
+
+    public init(eigenvalues: [Float], eigenvectors: [Float]?, dimension: Int) {
+        self.eigenvalues = eigenvalues
+        self.eigenvectors = eigenvectors
+        self.dimension = dimension
+    }
+}
+
+// MARK: - Provider protocol
+
+/// Seam for dense factorizations consumed by projection primitives.
+///
+/// Implementations: `LAPACKLinearAlgebraProvider` (Accelerate's modern LAPACK
+/// via the VectorCoreC shim; Apple platforms) and
+/// `SwiftLinearAlgebraProvider` (pure Swift Householder/Jacobi; everywhere).
+///
+/// All inputs/outputs are column-major flat buffers — see the layout contract
+/// in this file's header.
+public protocol LinearAlgebraProvider: Sendable {
+
+    /// Thin QR of an m×n matrix with m ≥ n.
+    ///
+    /// - Parameters:
+    ///   - a: m×n matrix, column-major, `a.count == rows * columns`.
+    ///   - rows: m. - columns: n. Requires `rows >= columns >= 1`.
+    /// - Throws: `VectorError` (.invalidDimension on bad shape,
+    ///   .operationFailed on backend failure).
+    func qrThin(_ a: [Float], rows: Int, columns: Int) throws -> QRFactorization
+
+    /// Thin SVD of an arbitrary m×n matrix.
+    ///
+    /// - Throws: `VectorError` (.operationFailed if the algorithm fails to
+    ///   converge — LAPACK info > 0, or Jacobi sweep exhaustion in fallback).
+    func svdThin(_ a: [Float], rows: Int, columns: Int) throws -> SingularValueDecomposition
+
+    /// Eigendecomposition of a symmetric n×n matrix.
+    ///
+    /// Only the LOWER triangle of `a` is required to be populated (both
+    /// implementations reference uplo='L'); the strict upper triangle is
+    /// ignored. Eigenvalues return ascending.
+    func symmetricEigen(_ a: [Float], dimension: Int, computeEigenvectors: Bool) throws -> SymmetricEigenDecomposition
+}
+
+// MARK: - Operations integration
+
+extension Operations {
+    /// The active dense linear-algebra provider, mirroring `simdProvider`.
+    ///
+    /// Defaults to the LAPACK-backed provider on Apple platforms and the
+    /// pure-Swift provider elsewhere. Override per-scope via:
+    /// ```swift
+    /// Operations.$linearAlgebraProvider.withValue(SwiftLinearAlgebraProvider()) {
+    ///     // deterministic cross-platform path, e.g. in parity tests
+    /// }
+    /// ```
+    #if canImport(Accelerate)
+    @TaskLocal public static var linearAlgebraProvider: any LinearAlgebraProvider = LAPACKLinearAlgebraProvider()
+    #else
+    @TaskLocal public static var linearAlgebraProvider: any LinearAlgebraProvider = SwiftLinearAlgebraProvider()
+    #endif
+}
+
+// MARK: - Shared validation
+
+internal enum LinearAlgebraValidation {
+    static func validateQR(count: Int, rows: Int, columns: Int) throws {
+        guard rows >= 1, columns >= 1 else {
+            throw VectorError.invalidDimension(rows <= 0 ? rows : columns, reason: "matrix dimensions must be positive")
+        }
+        guard rows >= columns else {
+            throw VectorError.invalidOperation(
+                "qrThin", reason: "thin QR requires rows (\(rows)) >= columns (\(columns)); transpose or use svdThin")
+        }
+        guard count == rows * columns else {
+            throw VectorError.dimensionMismatch(expected: rows * columns, actual: count)
+        }
+    }
+
+    static func validateRect(count: Int, rows: Int, columns: Int) throws {
+        guard rows >= 1, columns >= 1 else {
+            throw VectorError.invalidDimension(rows <= 0 ? rows : columns, reason: "matrix dimensions must be positive")
+        }
+        guard count == rows * columns else {
+            throw VectorError.dimensionMismatch(expected: rows * columns, actual: count)
+        }
+    }
+
+    static func validateSquare(count: Int, dimension: Int) throws {
+        guard dimension >= 1 else {
+            throw VectorError.invalidDimension(dimension, reason: "matrix dimension must be positive")
+        }
+        guard count == dimension * dimension else {
+            throw VectorError.dimensionMismatch(expected: dimension * dimension, actual: count)
+        }
+    }
+}

--- a/Sources/VectorCore/LinearAlgebra/LinearAlgebraProvider.swift
+++ b/Sources/VectorCore/LinearAlgebra/LinearAlgebraProvider.swift
@@ -26,8 +26,6 @@
 //  level above, in the GEMM passes that build the panels.
 //
 
-import Foundation
-
 // MARK: - Result types
 
 /// Thin QR factorization: `A (m×n, m ≥ n) = Q (m×n) · R (n×n)`.
@@ -53,6 +51,10 @@ public struct QRFactorization: Sendable {
 /// with `k = min(m, n)`.
 public struct SingularValueDecomposition: Sendable {
     /// Left singular vectors, m×k, column-major, orthonormal columns.
+    ///
+    /// Caveat: for exactly rank-deficient inputs, the pure-Swift fallback
+    /// does not complete U columns paired with zero singular values to an
+    /// orthonormal basis (LAPACK does). See SwiftLinearAlgebraProvider.
     public let u: [Float]
     /// Singular values, length k, in DESCENDING order (LAPACK convention).
     public let singularValues: [Float]
@@ -62,9 +64,6 @@ public struct SingularValueDecomposition: Sendable {
     public let rows: Int
     /// Column count of A.
     public let columns: Int
-
-    /// k = min(rows, columns).
-    public var rank: Int { Swift.min(rows, columns) }
 
     public init(u: [Float], singularValues: [Float], vt: [Float], rows: Int, columns: Int) {
         self.u = u
@@ -109,9 +108,11 @@ public protocol LinearAlgebraProvider: Sendable {
     ///
     /// - Parameters:
     ///   - a: m×n matrix, column-major, `a.count == rows * columns`.
-    ///   - rows: m. - columns: n. Requires `rows >= columns >= 1`.
-    /// - Throws: `VectorError` (.invalidDimension on bad shape,
-    ///   .operationFailed on backend failure).
+    ///   - rows: m.
+    ///   - columns: n. Requires `rows >= columns >= 1`.
+    /// - Throws: `VectorError` — `.invalidOperation` for wide matrices,
+    ///   `.dimensionMismatch`/`.invalidDimension` on bad shape,
+    ///   `.operationFailed` on backend failure.
     func qrThin(_ a: [Float], rows: Int, columns: Int) throws -> QRFactorization
 
     /// Thin SVD of an arbitrary m×n matrix.
@@ -150,10 +151,24 @@ extension Operations {
 // MARK: - Shared validation
 
 internal enum LinearAlgebraValidation {
-    static func validateQR(count: Int, rows: Int, columns: Int) throws {
+    /// Both backends use 32-bit LAPACK indices (see vc_lapack.h's integer
+    /// model note); reject out-of-range dims with a typed error rather than
+    /// letting `Int32(_:)` trap in the provider.
+    private static let maxLAPACKDimension = Int(Int32.max)
+
+    private static func validatePositiveAndRepresentable(_ rows: Int, _ columns: Int) throws {
         guard rows >= 1, columns >= 1 else {
             throw VectorError.invalidDimension(rows <= 0 ? rows : columns, reason: "matrix dimensions must be positive")
         }
+        guard rows <= maxLAPACKDimension, columns <= maxLAPACKDimension else {
+            throw VectorError.invalidDimension(
+                Swift.max(rows, columns),
+                reason: "exceeds the 32-bit LAPACK index model (see vc_lapack.h)")
+        }
+    }
+
+    static func validateQR(count: Int, rows: Int, columns: Int) throws {
+        try validatePositiveAndRepresentable(rows, columns)
         guard rows >= columns else {
             throw VectorError.invalidOperation(
                 "qrThin", reason: "thin QR requires rows (\(rows)) >= columns (\(columns)); transpose or use svdThin")
@@ -164,18 +179,14 @@ internal enum LinearAlgebraValidation {
     }
 
     static func validateRect(count: Int, rows: Int, columns: Int) throws {
-        guard rows >= 1, columns >= 1 else {
-            throw VectorError.invalidDimension(rows <= 0 ? rows : columns, reason: "matrix dimensions must be positive")
-        }
+        try validatePositiveAndRepresentable(rows, columns)
         guard count == rows * columns else {
             throw VectorError.dimensionMismatch(expected: rows * columns, actual: count)
         }
     }
 
     static func validateSquare(count: Int, dimension: Int) throws {
-        guard dimension >= 1 else {
-            throw VectorError.invalidDimension(dimension, reason: "matrix dimension must be positive")
-        }
+        try validatePositiveAndRepresentable(dimension, dimension)
         guard count == dimension * dimension else {
             throw VectorError.dimensionMismatch(expected: dimension * dimension, actual: count)
         }

--- a/Sources/VectorCore/LinearAlgebra/MatrixMultiply.swift
+++ b/Sources/VectorCore/LinearAlgebra/MatrixMultiply.swift
@@ -1,0 +1,110 @@
+//
+//  MatrixMultiply.swift
+//  VectorCore
+//
+//  Internal GEMM utility for the LinearAlgebra layer.
+//
+//  COLUMN-MAJOR, matching the LinearAlgebraProvider seam, so panels flow
+//  between GEMM passes and qrThin/svdThin with no physical transposes.
+//  Apple platforms route to cblas_sgemm (AMX on Apple Silicon, same path
+//  as Operations/MatrixDistance.swift); elsewhere a plain column-oriented
+//  Swift kernel runs. The Swift kernel compiles on all platforms (and is
+//  parity-tested against cblas) so the cross-platform path is never
+//  dead code on CI. Not a public seam: PCA and future projection
+//  primitives are the only intended callers, and they validate shapes
+//  before calling — this layer traps on programmer error instead of
+//  throwing.
+//
+
+#if canImport(Accelerate)
+import Accelerate
+#endif
+
+internal enum LAMatMul {
+
+    /// `C (m×n) = op(A) (m×k) · op(B) (k×n)`, all column-major flat buffers.
+    ///
+    /// `transposeA` means `a` is stored k×m and op(A) = aᵀ (likewise for B);
+    /// storage dimensions are derived, so no leading-dimension bookkeeping
+    /// leaks to callers.
+    static func multiply(
+        _ a: [Float], _ b: [Float],
+        m: Int, n: Int, k: Int,
+        transposeA: Bool = false,
+        transposeB: Bool = false
+    ) -> [Float] {
+        validate(a, b, m: m, n: n, k: k)
+        #if canImport(Accelerate)
+        var c = [Float](repeating: 0, count: m * n)
+        let lda = Int32(transposeA ? k : m)
+        let ldb = Int32(transposeB ? n : k)
+        a.withUnsafeBufferPointer { ap in
+            b.withUnsafeBufferPointer { bp in
+                c.withUnsafeMutableBufferPointer { cp in
+                    cblas_sgemm(
+                        CblasColMajor,
+                        transposeA ? CblasTrans : CblasNoTrans,
+                        transposeB ? CblasTrans : CblasNoTrans,
+                        Int32(m), Int32(n), Int32(k),
+                        1, ap.baseAddress, lda,
+                        bp.baseAddress, ldb,
+                        0, cp.baseAddress, Int32(m)
+                    )
+                }
+            }
+        }
+        return c
+        #else
+        return multiplySwift(a, b, m: m, n: n, k: k, transposeA: transposeA, transposeB: transposeB)
+        #endif
+    }
+
+    /// Pure-Swift kernel — the non-Accelerate path, kept unconditionally
+    /// compiled so it can be parity-tested against cblas on Apple platforms.
+    ///
+    /// Column-oriented update: `C[:, j] += B(l, j) · op(A)[:, l]`. The inner
+    /// loop is contiguous in C; op(A) columns are contiguous when A is
+    /// untransposed (the dominant case in PCA's panels).
+    internal static func multiplySwift(
+        _ a: [Float], _ b: [Float],
+        m: Int, n: Int, k: Int,
+        transposeA: Bool = false,
+        transposeB: Bool = false
+    ) -> [Float] {
+        validate(a, b, m: m, n: n, k: k)
+        var c = [Float](repeating: 0, count: m * n)
+        a.withUnsafeBufferPointer { ap in
+            b.withUnsafeBufferPointer { bp in
+                c.withUnsafeMutableBufferPointer { cp in
+                    for j in 0..<n {
+                        for l in 0..<k {
+                            // Storage of b: untransposed is k×n (col-major:
+                            // (l,j) at j*k+l); transposed is n×k ((j,l) at l*n+j).
+                            let scale = transposeB ? bp[l * n + j] : bp[j * k + l]
+                            if scale == 0 { continue }
+                            if transposeA {
+                                // a stored k×m: op(A)(i,l) = a(l,i) at i*k + l
+                                for i in 0..<m {
+                                    cp[j * m + i] += scale * ap[i * k + l]
+                                }
+                            } else {
+                                // a stored m×k: op(A)(:,l) contiguous at l*m
+                                let base = l * m
+                                for i in 0..<m {
+                                    cp[j * m + i] += scale * ap[base + i]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return c
+    }
+
+    private static func validate(_ a: [Float], _ b: [Float], m: Int, n: Int, k: Int) {
+        precondition(m >= 1 && n >= 1 && k >= 1, "GEMM dimensions must be positive")
+        precondition(a.count == m * k, "A element count \(a.count) != \(m)×\(k)")
+        precondition(b.count == k * n, "B element count \(b.count) != \(k)×\(n)")
+    }
+}

--- a/Sources/VectorCore/LinearAlgebra/PCA.swift
+++ b/Sources/VectorCore/LinearAlgebra/PCA.swift
@@ -1,0 +1,378 @@
+//
+//  PCA.swift
+//  VectorCore
+//
+//  Principal Component Analysis via randomized SVD (Halko–Martinsson–Tropp,
+//  "Finding Structure with Randomness", 2011). Gap analysis §3.1: the
+//  384→~50 pre-reduction feeding UMAP, and the projection primitive for the
+//  2-D corpus scatter.
+//
+//  ## Why randomized rather than full SVD
+//
+//  Cost is a few GEMM passes over the data — O(n·d·ℓ) with ℓ = k + p — plus
+//  factorizations of small panels only (n×ℓ QR, ℓ×d SVD). No n×n or full
+//  n×d factorization is ever formed, so fitting on a 100–500k sample is
+//  GEMM-bound and fast. When ℓ ≥ min(n, d) the sketch cannot help; the
+//  implementation falls back to one exact thin SVD of the centered sample.
+//
+//  ## Usage at corpus scale
+//
+//  `PCAModel.fit` on a representative sample, then `transform` the full
+//  corpus in caller-sized batches (one GEMM per batch) — the model is an
+//  immutable value and `transform` is pure, so batches parallelize freely.
+//
+//  ## Layout
+//
+//  Internally everything is COLUMN-MAJOR (the LinearAlgebraProvider/LAMatMul
+//  contract). The public surface speaks vectors and row-major `components`;
+//  the column-major identity (row-major k×d ≡ column-major d×k transposed)
+//  makes `transform`'s GEMM copy-free over the components buffer.
+//
+
+import Foundation
+
+// MARK: - Configuration
+
+/// Tuning knobs for randomized-SVD PCA. The defaults follow Halko et al.'s
+/// recommendations and are appropriate for embedding workloads.
+public struct PCAConfig: Sendable {
+    /// Sketch oversampling `p`: the sketch width is `k + p` columns.
+    /// 5–10 suffices when singular values decay; raise for flat spectra.
+    public var oversampling: Int
+
+    /// Power (subspace) iterations `q`. Each costs two extra GEMM passes and
+    /// sharpens accuracy on slowly decaying spectra; 1–2 is standard.
+    public var powerIterations: Int
+
+    /// Subtract the per-dimension mean before factorization (classical PCA).
+    /// With `false` this computes truncated SVD of the raw data and
+    /// `explainedVariance` reads as raw second moments, not variances.
+    public var center: Bool
+
+    /// Seed for the Gaussian sketch. Fits are fully deterministic for a
+    /// given (data, config) pair — including across the LAPACK and Swift
+    /// providers up to floating-point noise.
+    public var seed: UInt64
+
+    public init(
+        oversampling: Int = 8,
+        powerIterations: Int = 2,
+        center: Bool = true,
+        seed: UInt64 = 0x5EED_CAFE
+    ) {
+        self.oversampling = oversampling
+        self.powerIterations = powerIterations
+        self.center = center
+        self.seed = seed
+    }
+}
+
+// MARK: - Model
+
+/// A fitted PCA projection: `y = W · (x − μ)` with orthonormal rows `W`.
+///
+/// Fit on a sample with `fit`, then apply with `transform` — see the header
+/// note on corpus-scale batching.
+public struct PCAModel: Sendable {
+    /// Per-dimension mean μ of the fit data (zeros when fit uncentered).
+    public let mean: [Float]
+
+    /// Principal axes `W`, k×d ROW-MAJOR: `components[r*d + j]` is
+    /// coordinate j of axis r. Rows are orthonormal and ordered by
+    /// decreasing explained variance. Sign convention: each row's
+    /// largest-magnitude coordinate is positive (first index on ties).
+    public let components: [Float]
+
+    /// Variance captured per axis, descending: σᵣ² / (n − 1).
+    public let explainedVariance: [Float]
+
+    /// `explainedVariance` as a fraction of the fit data's total variance.
+    public let explainedVarianceRatio: [Float]
+
+    /// d — dimension of the input space.
+    public let inputDimension: Int
+
+    /// k — dimension of the projected space.
+    public let componentCount: Int
+
+    // MARK: Fit
+
+    /// Fits a k-component PCA on `vectors` (the sample) via randomized SVD.
+    ///
+    /// - Throws: `VectorError.invalidDimension` for k outside
+    ///   `1...min(n − 1, d)` (n − 1: centering loses one rank) or invalid
+    ///   config; `.dimensionMismatch` for ragged input;
+    ///   `.invalidOperation` for n < 2; plus anything the active
+    ///   `Operations.linearAlgebraProvider` throws.
+    public static func fit<V: VectorProtocol>(
+        _ vectors: [V],
+        components k: Int,
+        config: PCAConfig = PCAConfig()
+    ) throws -> PCAModel where V.Scalar == Float {
+        let n = vectors.count
+        guard n >= 2 else {
+            throw VectorError.invalidOperation(
+                "PCAModel.fit", reason: "PCA requires at least 2 vectors, got \(n)")
+        }
+        let d = vectors[0].scalarCount
+        let flat = try flattenColumnMajor(vectors, count: n, dimension: d)
+        return try fit(columnMajor: flat, rows: n, dimension: d, components: k, config: config)
+    }
+
+    /// Core fit on an n×d column-major buffer (consumed and mutated).
+    internal static func fit(
+        columnMajor a: [Float],
+        rows n: Int,
+        dimension d: Int,
+        components k: Int,
+        config: PCAConfig
+    ) throws -> PCAModel {
+        guard config.oversampling >= 0, config.powerIterations >= 0 else {
+            throw VectorError.invalidDimension(
+                min(config.oversampling, config.powerIterations),
+                reason: "oversampling and powerIterations must be non-negative")
+        }
+        let maxRank = min(config.center ? n - 1 : n, d)
+        guard k >= 1, k <= maxRank else {
+            throw VectorError.invalidDimension(
+                k, reason: "components must be in 1...\(maxRank) (n=\(n), d=\(d), centered=\(config.center))")
+        }
+
+        var a = a
+
+        // Center and measure total variance in one pass. Column j is
+        // contiguous (length n); Double accumulation keeps the mean and the
+        // variance stable at sample sizes in the 10⁵–10⁶ range.
+        var mean = [Float](repeating: 0, count: d)
+        var totalVariance: Double = 0
+        let varianceDenominator = Double(max(n - 1, 1))
+        a.withUnsafeMutableBufferPointer { ab in
+            for j in 0..<d {
+                let base = j * n
+                if config.center {
+                    var sum: Double = 0
+                    for i in 0..<n { sum += Double(ab[base + i]) }
+                    let mu = Float(sum / Double(n))
+                    mean[j] = mu
+                    for i in 0..<n { ab[base + i] -= mu }
+                }
+                var sumSq: Double = 0
+                for i in 0..<n { sumSq += Double(ab[base + i]) * Double(ab[base + i]) }
+                totalVariance += sumSq / varianceDenominator
+            }
+        }
+
+        let provider = Operations.linearAlgebraProvider
+        let sketchWidth = min(k + config.oversampling, min(n, d))
+
+        // The ℓ×d panel whose SVD yields the principal axes: either the
+        // projected sketch B = QᵀA (randomized path) or A itself (exact
+        // path, when the sketch could not be thinner than the data).
+        let panel: [Float]
+        let panelRows: Int
+        if sketchWidth >= min(n, d) {
+            panel = a
+            panelRows = n
+        } else {
+            var gaussian = GaussianSource(seed: config.seed)
+            let omega = gaussian.matrix(count: d * sketchWidth)
+
+            // Y = A·Ω, then q rounds of QR-stabilized subspace iteration:
+            // Q = qr(Y).q;  Y ← A·qr(AᵀQ).q — re-orthonormalizing between
+            // multiplications prevents the sketch from collapsing onto the
+            // dominant axis (the classic power-iteration failure mode).
+            var y = LAMatMul.multiply(a, omega, m: n, n: sketchWidth, k: d)
+            for _ in 0..<config.powerIterations {
+                let q = try provider.qrThin(y, rows: n, columns: sketchWidth).q
+                let z = LAMatMul.multiply(a, q, m: d, n: sketchWidth, k: n, transposeA: true)
+                let qz = try provider.qrThin(z, rows: d, columns: sketchWidth).q
+                y = LAMatMul.multiply(a, qz, m: n, n: sketchWidth, k: d)
+            }
+            let q = try provider.qrThin(y, rows: n, columns: sketchWidth).q
+            panel = LAMatMul.multiply(q, a, m: sketchWidth, n: d, k: n, transposeA: true)
+            panelRows = sketchWidth
+        }
+
+        let svd = try provider.svdThin(panel, rows: panelRows, columns: d)
+        let panelRank = min(panelRows, d) // rows of vt
+
+        // Extract the top-k right singular vectors (rows of vt) into
+        // row-major components, applying the sign convention.
+        var componentsRowMajor = [Float](repeating: 0, count: k * d)
+        for r in 0..<k {
+            var maxAbs: Float = -1
+            var flip: Float = 1
+            for j in 0..<d {
+                let value = svd.vt[j * panelRank + r] // vt is panelRank×d col-major
+                let magnitude = abs(value)
+                if magnitude > maxAbs {
+                    maxAbs = magnitude
+                    flip = value < 0 ? -1 : 1
+                }
+            }
+            for j in 0..<d {
+                componentsRowMajor[r * d + j] = flip * svd.vt[j * panelRank + r]
+            }
+        }
+
+        var explained = [Float](repeating: 0, count: k)
+        var ratios = [Float](repeating: 0, count: k)
+        for r in 0..<k {
+            let sigma = Double(svd.singularValues[r])
+            let variance = sigma * sigma / varianceDenominator
+            explained[r] = Float(variance)
+            ratios[r] = totalVariance > 0 ? Float(variance / totalVariance) : 0
+        }
+
+        return PCAModel(
+            mean: mean,
+            components: componentsRowMajor,
+            explainedVariance: explained,
+            explainedVarianceRatio: ratios,
+            inputDimension: d,
+            componentCount: k)
+    }
+
+    // MARK: Transform
+
+    /// Projects a batch: one GEMM over the whole batch. Returns one k-dim
+    /// row per input vector.
+    public func transform<V: VectorProtocol>(
+        _ vectors: [V]
+    ) throws -> [[Float]] where V.Scalar == Float {
+        guard !vectors.isEmpty else { return [] }
+        let n = vectors.count
+        let d = inputDimension
+        var centered = try Self.flattenColumnMajor(vectors, count: n, dimension: d)
+        if mean.contains(where: { $0 != 0 }) {
+            centered.withUnsafeMutableBufferPointer { cb in
+                for j in 0..<d {
+                    let mu = mean[j]
+                    if mu == 0 { continue }
+                    let base = j * n
+                    for i in 0..<n { cb[base + i] -= mu }
+                }
+            }
+        }
+
+        // components is k×d row-major, which IS d×k column-major Wᵀ —
+        // so P (n×k, col-major) = Xc (n×d) · Wᵀ (d×k) needs no transpose.
+        let projected = LAMatMul.multiply(
+            centered, components, m: n, n: componentCount, k: d)
+
+        var out = [[Float]](repeating: [], count: n)
+        for i in 0..<n {
+            var row = [Float](repeating: 0, count: componentCount)
+            for r in 0..<componentCount { row[r] = projected[r * n + i] }
+            out[i] = row
+        }
+        return out
+    }
+
+    /// Projects a single raw vector — the streaming-friendly form.
+    public func transform(_ vector: [Float]) throws -> [Float] {
+        guard vector.count == inputDimension else {
+            throw VectorError.dimensionMismatch(expected: inputDimension, actual: vector.count)
+        }
+        let d = inputDimension
+        var out = [Float](repeating: 0, count: componentCount)
+        vector.withUnsafeBufferPointer { xb in
+            components.withUnsafeBufferPointer { wb in
+                for r in 0..<componentCount {
+                    var acc: Float = 0
+                    let base = r * d
+                    for j in 0..<d { acc += wb[base + j] * (xb[j] - mean[j]) }
+                    out[r] = acc
+                }
+            }
+        }
+        return out
+    }
+
+    // MARK: Flattening
+
+    /// Flattens vectors into an n×d COLUMN-MAJOR buffer, validating that
+    /// every vector has dimension d. Writes for consecutive vectors land on
+    /// adjacent addresses within each of the d column panels, so the pass
+    /// stays cache-resident for embedding-sized d.
+    private static func flattenColumnMajor<V: VectorProtocol>(
+        _ vectors: [V], count n: Int, dimension d: Int
+    ) throws -> [Float] where V.Scalar == Float {
+        guard d >= 1 else {
+            throw VectorError.invalidDimension(d, reason: "vectors must be non-empty")
+        }
+        var flat = [Float](repeating: 0, count: n * d)
+        try flat.withUnsafeMutableBufferPointer { fb in
+            for i in 0..<n {
+                let v = vectors[i]
+                guard v.scalarCount == d else {
+                    throw VectorError.dimensionMismatch(expected: d, actual: v.scalarCount)
+                }
+                v.withUnsafeBufferPointer { vb in
+                    for j in 0..<d { fb[j * n + i] = vb[j] }
+                }
+            }
+        }
+        return flat
+    }
+}
+
+// MARK: - Operations integration
+
+extension Operations {
+    /// One-shot PCA: fit on `vectors` and project them, per the gap-report
+    /// API sketch. For fit-on-sample / transform-the-corpus workflows use
+    /// `PCAModel.fit` + `PCAModel.transform` directly.
+    public static func pca<V: VectorProtocol>(
+        _ vectors: [V],
+        components: Int,
+        config: PCAConfig = PCAConfig()
+    ) throws -> (projected: [[Float]], model: PCAModel) where V.Scalar == Float {
+        let model = try PCAModel.fit(vectors, components: components, config: config)
+        let projected = try model.transform(vectors)
+        return (projected, model)
+    }
+}
+
+// MARK: - Seeded Gaussian source
+
+/// Deterministic standard-normal stream: SplitMix64 → Box–Muller.
+/// Cross-platform reproducible for a given seed (pure integer state plus
+/// libm; no rejection sampling, so the stream position is data-independent).
+internal struct GaussianSource {
+    private var state: UInt64
+    private var spare: Float?
+
+    init(seed: UInt64) {
+        self.state = seed
+    }
+
+    private mutating func nextUniform() -> Double {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        z ^= z >> 31
+        // 53-bit mantissa → [0, 1); the +0.5 offset keeps log() off zero.
+        return (Double(z >> 11) + 0.5) * 0x1p-53
+    }
+
+    mutating func next() -> Float {
+        if let cached = spare {
+            spare = nil
+            return cached
+        }
+        let u1 = nextUniform()
+        let u2 = nextUniform()
+        let radius = (-2 * Foundation.log(u1)).squareRoot()
+        let angle = 2 * Double.pi * u2
+        spare = Float(radius * Foundation.sin(angle))
+        return Float(radius * Foundation.cos(angle))
+    }
+
+    mutating func matrix(count: Int) -> [Float] {
+        var out = [Float](repeating: 0, count: count)
+        for i in 0..<count { out[i] = next() }
+        return out
+    }
+}

--- a/Sources/VectorCore/LinearAlgebra/PCA.swift
+++ b/Sources/VectorCore/LinearAlgebra/PCA.swift
@@ -295,7 +295,8 @@ public struct PCAModel: Sendable {
     /// every vector has dimension d. Writes for consecutive vectors land on
     /// adjacent addresses within each of the d column panels, so the pass
     /// stays cache-resident for embedding-sized d.
-    private static func flattenColumnMajor<V: VectorProtocol>(
+    /// Internal: also the flatten used by `KNNGraph.bruteForce`.
+    internal static func flattenColumnMajor<V: VectorProtocol>(
         _ vectors: [V], count n: Int, dimension d: Int
     ) throws -> [Float] where V.Scalar == Float {
         guard d >= 1 else {

--- a/Sources/VectorCore/LinearAlgebra/SwiftLinearAlgebraProvider.swift
+++ b/Sources/VectorCore/LinearAlgebra/SwiftLinearAlgebraProvider.swift
@@ -1,0 +1,296 @@
+//
+//  SwiftLinearAlgebraProvider.swift
+//  VectorCore
+//
+//  Pure-Swift LinearAlgebraProvider fallback. Algorithm choices favor
+//  implementation transparency and unconditional numerical robustness over
+//  speed — this is the portability/parity path, not the fast path:
+//
+//  - QR:    Householder reflections (LAPACK-style storage: reflectors below
+//           the diagonal, accumulated backward to form thin Q).
+//  - Eigen: cyclic Jacobi rotations. Unconditionally convergent for
+//           symmetric matrices, quadratic in the tail. O(n³·sweeps).
+//  - SVD:   Hestenes one-sided Jacobi — orthogonalizes column pairs of A
+//           directly, accumulating V; singular values fall out as column
+//           norms. Avoids forming AᵀA (which would square the condition
+//           number — significant in Float32).
+//
+//  Caveat (documented, deliberate): for exactly rank-deficient inputs the
+//  SVD's U columns paired with zero singular values are not completed to an
+//  orthonormal basis (LAPACK completes them). Downstream PCA/randomized-SVD
+//  consumers truncate at k ≪ rank, so this is unobservable there.
+//
+//  All matrices column-major; see LinearAlgebraProvider layout contract.
+//
+
+import Foundation
+
+public struct SwiftLinearAlgebraProvider: LinearAlgebraProvider {
+
+    /// Hard cap on Jacobi sweeps (eigen and SVD). Jacobi converges
+    /// quadratically once rotations get small; well-posed Float32 problems
+    /// finish in < 15 sweeps. Exhaustion ⇒ throw rather than return junk.
+    private static let maxSweeps = 60
+
+    public init() {}
+
+    // MARK: - QR (Householder)
+
+    public func qrThin(_ a: [Float], rows m: Int, columns n: Int) throws -> QRFactorization {
+        try LinearAlgebraValidation.validateQR(count: a.count, rows: m, columns: n)
+
+        var fac = a                                  // factored form: R upper, reflectors below
+        var tau = [Float](repeating: 0, count: n)
+
+        for j in 0..<n {
+            // Householder vector for column j, rows j..<m.
+            var normSq: Float = 0
+            for i in j..<m { normSq += fac[j * m + i] * fac[j * m + i] }
+            let norm = normSq.squareRoot()
+            if norm == 0 { tau[j] = 0; continue }    // zero column: identity reflector
+
+            let alpha = fac[j * m + j]
+            let beta: Float = alpha >= 0 ? -norm : norm
+            tau[j] = (beta - alpha) / beta
+            let invScale = 1 / (alpha - beta)        // v = [1, x_tail/(alpha-beta)]
+            for i in (j + 1)..<m { fac[j * m + i] *= invScale }
+            fac[j * m + j] = beta                    // R diagonal entry
+
+            // Apply H_j = I − τ v vᵀ to trailing columns.
+            for c in (j + 1)..<n {
+                var w = fac[c * m + j]               // v_j = 1 implicit
+                for i in (j + 1)..<m { w += fac[j * m + i] * fac[c * m + i] }
+                w *= tau[j]
+                fac[c * m + j] -= w
+                for i in (j + 1)..<m { fac[c * m + i] -= w * fac[j * m + i] }
+            }
+        }
+
+        // Extract R (n×n upper triangle).
+        var r = [Float](repeating: 0, count: n * n)
+        for j in 0..<n {
+            for i in 0...j { r[j * n + i] = fac[j * m + i] }
+        }
+
+        // Accumulate thin Q: apply H_{n-1}…H_0 to the first n identity columns,
+        // backward so each reflector touches only rows/cols it acts on.
+        var q = [Float](repeating: 0, count: m * n)
+        for j in 0..<n { q[j * m + j] = 1 }
+        for j in stride(from: n - 1, through: 0, by: -1) {
+            let t = tau[j]
+            if t == 0 { continue }
+            for c in j..<n {
+                var w = q[c * m + j]
+                for i in (j + 1)..<m { w += fac[j * m + i] * q[c * m + i] }
+                w *= t
+                q[c * m + j] -= w
+                for i in (j + 1)..<m { q[c * m + i] -= w * fac[j * m + i] }
+            }
+        }
+
+        return QRFactorization(q: q, r: r, rows: m, columns: n)
+    }
+
+    // MARK: - Symmetric eigen (cyclic Jacobi)
+
+    public func symmetricEigen(
+        _ a: [Float],
+        dimension n: Int,
+        computeEigenvectors: Bool
+    ) throws -> SymmetricEigenDecomposition {
+        try LinearAlgebraValidation.validateSquare(count: a.count, dimension: n)
+
+        // Symmetrize from the LOWER triangle (matches LAPACK uplo='L' contract).
+        var mat = a
+        for j in 0..<n {
+            for i in (j + 1)..<n { mat[i * n + j] = mat[j * n + i] }
+        }
+
+        var vecs: [Float] = []
+        if computeEigenvectors {
+            vecs = [Float](repeating: 0, count: n * n)
+            for j in 0..<n { vecs[j * n + j] = 1 }
+        }
+
+        var frobSq: Float = 0
+        for v in mat { frobSq += v * v }
+        let negligible = Float.ulpOfOne * frobSq.squareRoot()
+
+        var converged = (n == 1)
+        var sweep = 0
+        while !converged && sweep < Self.maxSweeps {
+            sweep += 1
+            converged = true
+            for p in 0..<(n - 1) {
+                for q in (p + 1)..<n {
+                    let apq = mat[q * n + p]
+                    if abs(apq) <= negligible { continue }
+                    converged = false
+
+                    let app = mat[p * n + p]
+                    let aqq = mat[q * n + q]
+                    let theta = (aqq - app) / (2 * apq)
+                    // Stable smaller root of t² + 2θt − 1 = 0.
+                    let t: Float = (theta >= 0 ? 1 : -1) / (abs(theta) + (theta * theta + 1).squareRoot())
+                    let c = 1 / (t * t + 1).squareRoot()
+                    let s = t * c
+
+                    for i in 0..<n where i != p && i != q {
+                        let aip = mat[p * n + i]
+                        let aiq = mat[q * n + i]
+                        let newIP = c * aip - s * aiq
+                        let newIQ = s * aip + c * aiq
+                        mat[p * n + i] = newIP; mat[i * n + p] = newIP
+                        mat[q * n + i] = newIQ; mat[i * n + q] = newIQ
+                    }
+                    mat[p * n + p] = app - t * apq
+                    mat[q * n + q] = aqq + t * apq
+                    mat[q * n + p] = 0
+                    mat[p * n + q] = 0
+
+                    if computeEigenvectors {
+                        for i in 0..<n {
+                            let vip = vecs[p * n + i]
+                            let viq = vecs[q * n + i]
+                            vecs[p * n + i] = c * vip - s * viq
+                            vecs[q * n + i] = s * vip + c * viq
+                        }
+                    }
+                }
+            }
+        }
+        guard converged else {
+            throw ErrorBuilder(.operationFailed)
+                .message("Jacobi eigendecomposition did not converge in \(Self.maxSweeps) sweeps (n=\(n))")
+                .build()
+        }
+
+        // Sort ascending (ssyevd convention), permuting eigenvector columns.
+        var order = Array(0..<n)
+        order.sort { mat[$0 * n + $0] < mat[$1 * n + $1] }
+
+        var eigenvalues = [Float](repeating: 0, count: n)
+        for (dst, src) in order.enumerated() { eigenvalues[dst] = mat[src * n + src] }
+
+        var sortedVecs: [Float]?
+        if computeEigenvectors {
+            var sorted = [Float](repeating: 0, count: n * n)
+            for (dst, src) in order.enumerated() {
+                for i in 0..<n { sorted[dst * n + i] = vecs[src * n + i] }
+            }
+            sortedVecs = sorted
+        }
+
+        return SymmetricEigenDecomposition(
+            eigenvalues: eigenvalues, eigenvectors: sortedVecs, dimension: n)
+    }
+
+    // MARK: - SVD (Hestenes one-sided Jacobi)
+
+    public func svdThin(_ a: [Float], rows m: Int, columns n: Int) throws -> SingularValueDecomposition {
+        try LinearAlgebraValidation.validateRect(count: a.count, rows: m, columns: n)
+
+        // Hestenes wants m ≥ n (orthogonalizes columns). For wide matrices,
+        // decompose Aᵀ and swap factors: A = UΣVᵀ ⇔ Aᵀ = VΣUᵀ.
+        if m < n {
+            let t = Self.transpose(a, rows: m, columns: n)        // n×m
+            let tDec = try svdThin(t, rows: n, columns: m)
+            return SingularValueDecomposition(
+                u: Self.transpose(tDec.vt, rows: tDec.rank, columns: m),   // (k×m)ᵀ = m×k
+                singularValues: tDec.singularValues,
+                vt: Self.transpose(tDec.u, rows: n, columns: tDec.rank),   // (n×k)ᵀ = k×n
+                rows: m, columns: n
+            )
+        }
+
+        var u = a                                    // m×n, columns rotated toward orthogonality
+        var v = [Float](repeating: 0, count: n * n)  // accumulates right rotations
+        for j in 0..<n { v[j * n + j] = 1 }
+
+        // Rotate while any column pair has |⟨u_p,u_q⟩| > ε‖u_p‖‖u_q‖.
+        let eps: Float = 1e-6                        // relative orthogonality target (Float32)
+        var converged = (n == 1)
+        var sweep = 0
+        while !converged && sweep < Self.maxSweeps {
+            sweep += 1
+            converged = true
+            for p in 0..<(n - 1) {
+                for q in (p + 1)..<n {
+                    var alpha: Float = 0, beta: Float = 0, gamma: Float = 0
+                    for i in 0..<m {
+                        let up = u[p * m + i], uq = u[q * m + i]
+                        alpha += up * up
+                        beta += uq * uq
+                        gamma += up * uq
+                    }
+                    if gamma == 0 || gamma * gamma <= eps * eps * alpha * beta { continue }
+                    converged = false
+
+                    let zeta = (beta - alpha) / (2 * gamma)
+                    let t: Float = (zeta >= 0 ? 1 : -1) / (abs(zeta) + (zeta * zeta + 1).squareRoot())
+                    let c = 1 / (t * t + 1).squareRoot()
+                    let s = t * c
+
+                    for i in 0..<m {
+                        let up = u[p * m + i], uq = u[q * m + i]
+                        u[p * m + i] = c * up - s * uq
+                        u[q * m + i] = s * up + c * uq
+                    }
+                    for i in 0..<n {
+                        let vp = v[p * n + i], vq = v[q * n + i]
+                        v[p * n + i] = c * vp - s * vq
+                        v[q * n + i] = s * vp + c * vq
+                    }
+                }
+            }
+        }
+        guard converged else {
+            throw ErrorBuilder(.operationFailed)
+                .message("Hestenes SVD did not converge in \(Self.maxSweeps) sweeps (m=\(m), n=\(n))")
+                .build()
+        }
+
+        // Singular values = column norms; normalize U columns.
+        var sv = [Float](repeating: 0, count: n)
+        for j in 0..<n {
+            var normSq: Float = 0
+            for i in 0..<m { normSq += u[j * m + i] * u[j * m + i] }
+            let norm = normSq.squareRoot()
+            sv[j] = norm
+            if norm > 0 {
+                let inv = 1 / norm
+                for i in 0..<m { u[j * m + i] *= inv }
+            }
+        }
+
+        // Sort descending (LAPACK convention), permuting U and V columns.
+        var order = Array(0..<n)
+        order.sort { sv[$0] > sv[$1] }
+
+        var sortedS = [Float](repeating: 0, count: n)
+        var sortedU = [Float](repeating: 0, count: m * n)
+        var vt = [Float](repeating: 0, count: n * n)
+        for (dst, src) in order.enumerated() {
+            sortedS[dst] = sv[src]
+            for i in 0..<m { sortedU[dst * m + i] = u[src * m + i] }
+            // vt row `dst` = V column `src`  ⇒ vt[col j, row dst] = v[src*n + j]
+            for j in 0..<n { vt[j * n + dst] = v[src * n + j] }
+        }
+
+        return SingularValueDecomposition(
+            u: sortedU, singularValues: sortedS, vt: vt, rows: m, columns: n)
+    }
+
+    // MARK: - Helpers
+
+    /// Column-major transpose: (rows×columns) → (columns×rows).
+    private static func transpose(_ a: [Float], rows: Int, columns: Int) -> [Float] {
+        var out = [Float](repeating: 0, count: a.count)
+        for j in 0..<columns {
+            for i in 0..<rows {
+                out[i * columns + j] = a[j * rows + i]
+            }
+        }
+        return out
+    }
+}

--- a/Sources/VectorCore/LinearAlgebra/SwiftLinearAlgebraProvider.swift
+++ b/Sources/VectorCore/LinearAlgebra/SwiftLinearAlgebraProvider.swift
@@ -91,6 +91,7 @@ public struct SwiftLinearAlgebraProvider: LinearAlgebraProvider {
 
     // MARK: - Symmetric eigen (cyclic Jacobi)
 
+    // swiftlint:disable:next cyclomatic_complexity
     public func symmetricEigen(
         _ a: [Float],
         dimension n: Int,
@@ -191,6 +192,7 @@ public struct SwiftLinearAlgebraProvider: LinearAlgebraProvider {
 
     // MARK: - SVD (Hestenes one-sided Jacobi)
 
+    // swiftlint:disable:next cyclomatic_complexity
     public func svdThin(_ a: [Float], rows m: Int, columns n: Int) throws -> SingularValueDecomposition {
         try LinearAlgebraValidation.validateRect(count: a.count, rows: m, columns: n)
 

--- a/Sources/VectorCore/LinearAlgebra/SwiftLinearAlgebraProvider.swift
+++ b/Sources/VectorCore/LinearAlgebra/SwiftLinearAlgebraProvider.swift
@@ -23,8 +23,6 @@
 //  All matrices column-major; see LinearAlgebraProvider layout contract.
 //
 
-import Foundation
-
 public struct SwiftLinearAlgebraProvider: LinearAlgebraProvider {
 
     /// Hard cap on Jacobi sweeps (eigen and SVD). Jacobi converges
@@ -114,6 +112,12 @@ public struct SwiftLinearAlgebraProvider: LinearAlgebraProvider {
 
         var frobSq: Float = 0
         for v in mat { frobSq += v * v }
+        // Overflow here would make `negligible` infinite and silently return
+        // the unrotated diagonal as the spectrum — fail loudly instead.
+        guard frobSq.isFinite else {
+            throw VectorError.invalidData(
+                "symmetricEigen input overflows Float32 Frobenius norm; rescale the matrix")
+        }
         let negligible = Float.ulpOfOne * frobSq.squareRoot()
 
         var converged = (n == 1)
@@ -195,10 +199,11 @@ public struct SwiftLinearAlgebraProvider: LinearAlgebraProvider {
         if m < n {
             let t = Self.transpose(a, rows: m, columns: n)        // n×m
             let tDec = try svdThin(t, rows: n, columns: m)
+            let k = tDec.singularValues.count                     // = min(m, n)
             return SingularValueDecomposition(
-                u: Self.transpose(tDec.vt, rows: tDec.rank, columns: m),   // (k×m)ᵀ = m×k
+                u: Self.transpose(tDec.vt, rows: k, columns: m),   // (k×m)ᵀ = m×k
                 singularValues: tDec.singularValues,
-                vt: Self.transpose(tDec.u, rows: n, columns: tDec.rank),   // (n×k)ᵀ = k×n
+                vt: Self.transpose(tDec.u, rows: n, columns: k),   // (n×k)ᵀ = k×n
                 rows: m, columns: n
             )
         }
@@ -208,7 +213,11 @@ public struct SwiftLinearAlgebraProvider: LinearAlgebraProvider {
         for j in 0..<n { v[j * n + j] = 1 }
 
         // Rotate while any column pair has |⟨u_p,u_q⟩| > ε‖u_p‖‖u_q‖.
-        let eps: Float = 1e-6                        // relative orthogonality target (Float32)
+        // The floor scales with √m: a naive Float32 dot of two exactly
+        // orthogonal m-vectors carries ~√m·ulp relative noise, so a fixed
+        // 1e-6 target becomes unreachable (spurious non-convergence) once
+        // m exceeds a few hundred rows.
+        let eps = Swift.max(1e-6, 4 * Float.ulpOfOne * Float(m).squareRoot())
         var converged = (n == 1)
         var sweep = 0
         while !converged && sweep < Self.maxSweeps {

--- a/Sources/VectorCore/ManifoldLearning/FuzzySimplicialSet.swift
+++ b/Sources/VectorCore/ManifoldLearning/FuzzySimplicialSet.swift
@@ -1,0 +1,158 @@
+//
+//  FuzzySimplicialSet.swift
+//  VectorCore
+//
+//  UMAP step 1 (gap analysis §3.3.1): convert a kNN graph into a fuzzy
+//  simplicial set. Per point, a binary search finds the adaptive bandwidth
+//  σᵢ whose exponential memberships sum to a log₂ perplexity-like target;
+//  the directed memberships are then fused into a symmetric weighted graph
+//  with the probabilistic t-conorm. Pure math on the CSR graph, following
+//  the reference implementation (McInnes, Healy & Melville 2018; umap-learn
+//  `smooth_knn_dist` / `compute_membership_strengths` / fuzzy set union
+//  with set_op_mix_ratio = 1).
+//
+
+import Foundation
+
+/// Symmetric weighted edge list — both directions of every pair are present
+/// with equal weight, sorted by (head, tail). The layout stage's input.
+internal struct UMAPEdgeList {
+    var heads: [Int32]
+    var tails: [Int32]
+    var weights: [Float]
+    var count: Int { heads.count }
+}
+
+internal enum FuzzySimplicialSet {
+    /// umap-learn constants: psum convergence tolerance, σ floor scale,
+    /// and bisection depth.
+    private static let smoothTolerance = 1e-5
+    private static let minBandwidthScale = 1e-3
+    private static let searchIterations = 64
+
+    /// ρᵢ (distance to the nearest non-duplicate neighbor) and σᵢ solving
+    /// `Σⱼ exp(−max(0, dᵢⱼ − ρᵢ)/σᵢ) = log₂(kᵢ + 1)` by bisection.
+    ///
+    /// The +1 mirrors umap-learn, whose `n_neighbors` counts the point
+    /// itself (its kNN rows carry a zero-distance self entry); `KNNGraph`
+    /// forbids self-loops, so kᵢ stored neighbors correspond to
+    /// n_neighbors = kᵢ + 1. Rows with no entries (isolated points) keep
+    /// ρ = σ = 0 and contribute no edges.
+    static func smoothDistances(_ graph: KNNGraph) -> (rho: [Float], sigma: [Float]) {
+        let n = graph.pointCount
+        var rho = [Float](repeating: 0, count: n)
+        var sigma = [Float](repeating: 0, count: n)
+
+        var globalSum = 0.0
+        for dist in graph.distances { globalSum += Double(dist) }
+        let globalMean = graph.distances.isEmpty ? 0 : globalSum / Double(graph.distances.count)
+
+        for i in 0..<n {
+            let range = graph.neighborRange(of: i)
+            let k = range.count
+            if k == 0 { continue }
+
+            var rowSum = 0.0
+            var minPositive = Double.infinity
+            for idx in range {
+                let dist = Double(graph.distances[idx])
+                rowSum += dist
+                if dist > 0 && dist < minPositive { minPositive = dist }
+            }
+            let rhoI = minPositive.isFinite ? minPositive : 0
+            rho[i] = Float(rhoI)
+
+            let target = Foundation.log2(Double(k + 1))
+            var low = 0.0
+            var high = Double.infinity
+            var mid = 1.0
+            for _ in 0..<searchIterations {
+                var psum = 0.0
+                for idx in range {
+                    let shifted = Double(graph.distances[idx]) - rhoI
+                    psum += shifted > 0 ? Foundation.exp(-shifted / mid) : 1
+                }
+                if abs(psum - target) < smoothTolerance { break }
+                if psum > target {
+                    high = mid
+                    mid = (low + high) / 2
+                } else {
+                    low = mid
+                    mid = high.isInfinite ? mid * 2 : (low + high) / 2
+                }
+            }
+            // Bandwidth floor: a fraction of the local (or, for pure
+            // duplicate rows, global) mean distance keeps σ off zero.
+            let reference = rhoI > 0 ? rowSum / Double(k) : globalMean
+            sigma[i] = Float(max(mid, minBandwidthScale * reference))
+        }
+        return (rho, sigma)
+    }
+
+    /// Directed memberships `exp(−max(0, d − ρᵢ)/σᵢ)` fused into a
+    /// symmetric edge list with the probabilistic t-conorm
+    /// `w = w₁ + w₂ − w₁·w₂` (fuzzy set union). Duplicate directed entries
+    /// merge by max before fusing; pairs whose fused weight underflows to
+    /// zero are dropped.
+    static func build(_ graph: KNNGraph) -> UMAPEdgeList {
+        let (rho, sigma) = smoothDistances(graph)
+        let n = graph.pointCount
+
+        // Key each directed membership by its canonical (low, high) pair so
+        // one sort lands both directions adjacently.
+        var canonical = [(key: UInt64, forward: Float, backward: Float)]()
+        canonical.reserveCapacity(graph.edgeCount)
+        for i in 0..<n {
+            let rhoI = Double(rho[i])
+            let sigmaI = Double(sigma[i])
+            for idx in graph.neighborRange(of: i) {
+                let j = Int(graph.neighborIndices[idx])
+                let shifted = Double(graph.distances[idx]) - rhoI
+                let weight: Float = (shifted <= 0 || sigmaI == 0)
+                    ? 1
+                    : Float(Foundation.exp(-shifted / sigmaI))
+                if i < j {
+                    canonical.append((UInt64(i) << 32 | UInt64(j), weight, 0))
+                } else {
+                    canonical.append((UInt64(j) << 32 | UInt64(i), 0, weight))
+                }
+            }
+        }
+        canonical.sort { $0.key < $1.key }
+
+        var fused = [(key: UInt64, weight: Float)]()
+        fused.reserveCapacity(2 * canonical.count)
+        var cursor = 0
+        while cursor < canonical.count {
+            let key = canonical[cursor].key
+            var forward: Float = 0
+            var backward: Float = 0
+            while cursor < canonical.count && canonical[cursor].key == key {
+                forward = max(forward, canonical[cursor].forward)
+                backward = max(backward, canonical[cursor].backward)
+                cursor += 1
+            }
+            let weight = forward + backward - forward * backward
+            if weight > 0 {
+                let low = key >> 32
+                let high = key & 0xFFFF_FFFF
+                fused.append((low << 32 | high, weight))
+                fused.append((high << 32 | low, weight))
+            }
+        }
+        fused.sort { $0.key < $1.key }
+
+        var heads = [Int32]()
+        var tails = [Int32]()
+        var weights = [Float]()
+        heads.reserveCapacity(fused.count)
+        tails.reserveCapacity(fused.count)
+        weights.reserveCapacity(fused.count)
+        for (key, weight) in fused {
+            heads.append(Int32(key >> 32))
+            tails.append(Int32(key & 0xFFFF_FFFF))
+            weights.append(weight)
+        }
+        return UMAPEdgeList(heads: heads, tails: tails, weights: weights)
+    }
+}

--- a/Sources/VectorCore/ManifoldLearning/KNNGraph.swift
+++ b/Sources/VectorCore/ManifoldLearning/KNNGraph.swift
@@ -1,0 +1,195 @@
+//
+//  KNNGraph.swift
+//  VectorCore
+//
+//  CSR k-nearest-neighbor graph — the Core-owned interchange contract from
+//  gap analysis §3.2. VectorCore declares zero package dependencies and the
+//  dependency arrow points VectorIndex → VectorCore only, so graph-consuming
+//  math (UMAP, §3.3) takes this struct as INPUT: VectorIndex (or any ANN
+//  backend) populates it at corpus scale, and data flows Index → Core while
+//  code never does. `bruteForce` below is the exact in-Core builder, so the
+//  full UMAP pipeline also runs with no external producer at sample scale.
+//
+
+import Foundation
+
+/// A k-nearest-neighbor graph in compressed-sparse-row form.
+///
+/// Row `i`'s neighbors occupy `neighborIndices[rowOffsets[i]..<rowOffsets[i+1]]`
+/// with matching `distances`. The contract:
+/// - no self-loops (`neighborIndices` in a row never names that row),
+/// - distances are finite and non-negative (zero is legal: duplicate points),
+/// - rows may have differing neighbor counts and need not be distance-sorted
+///   (CSR generality — ANN backends prune asymmetrically).
+public struct KNNGraph: Sendable {
+    /// n — number of points (rows).
+    public let pointCount: Int
+
+    /// n+1 monotone offsets into the entry arrays; `rowOffsets[0] == 0`.
+    public let rowOffsets: [Int]
+
+    /// Column indices, one per stored edge. `Int32` keeps 5M×k graphs
+    /// compact (and bounds `pointCount` at `Int32.max`).
+    public let neighborIndices: [Int32]
+
+    /// Edge lengths, parallel to `neighborIndices`.
+    public let distances: [Float]
+
+    /// Total number of stored directed edges (nnz).
+    public var edgeCount: Int { neighborIndices.count }
+
+    /// Validates the CSR invariants above and stores the arrays.
+    ///
+    /// - Throws: `VectorError.invalidData` for malformed structure,
+    ///   `.invalidDimension` for a non-positive or over-`Int32` point count.
+    public init(
+        pointCount: Int,
+        rowOffsets: [Int],
+        neighborIndices: [Int32],
+        distances: [Float]
+    ) throws {
+        guard pointCount >= 1, pointCount <= Int(Int32.max) else {
+            throw VectorError.invalidDimension(
+                pointCount, reason: "pointCount must be in 1...Int32.max")
+        }
+        guard rowOffsets.count == pointCount + 1 else {
+            throw VectorError.invalidData(
+                "rowOffsets has \(rowOffsets.count) entries, expected pointCount + 1 = \(pointCount + 1)")
+        }
+        guard rowOffsets[0] == 0, rowOffsets[pointCount] == neighborIndices.count else {
+            throw VectorError.invalidData(
+                "rowOffsets must run from 0 to edge count \(neighborIndices.count)")
+        }
+        guard neighborIndices.count == distances.count else {
+            throw VectorError.invalidData(
+                "neighborIndices (\(neighborIndices.count)) and distances (\(distances.count)) differ in length")
+        }
+        for i in 0..<pointCount {
+            let low = rowOffsets[i]
+            let high = rowOffsets[i + 1]
+            guard low <= high else {
+                throw VectorError.invalidData("rowOffsets must be non-decreasing (row \(i))")
+            }
+            for idx in low..<high {
+                let j = Int(neighborIndices[idx])
+                guard j >= 0, j < pointCount else {
+                    throw VectorError.invalidData(
+                        "neighbor index \(j) out of range 0..<\(pointCount) (row \(i))")
+                }
+                guard j != i else {
+                    throw VectorError.invalidData("self-loop at row \(i)")
+                }
+                let dist = distances[idx]
+                guard dist >= 0, dist.isFinite else {
+                    throw VectorError.invalidData(
+                        "distance \(dist) at row \(i) must be finite and non-negative")
+                }
+            }
+        }
+        self.pointCount = pointCount
+        self.rowOffsets = rowOffsets
+        self.neighborIndices = neighborIndices
+        self.distances = distances
+    }
+
+    /// CSR storage range of row `i`'s entries.
+    public func neighborRange(of i: Int) -> Range<Int> {
+        rowOffsets[i]..<rowOffsets[i + 1]
+    }
+}
+
+// MARK: - Exact construction
+
+extension KNNGraph {
+    /// Exact kNN by blocked all-pairs Euclidean distance — O(n²·d) GEMM
+    /// passes plus O(n²) selection. This is the reference builder for
+    /// samples and tests; at corpus scale build the graph with an ANN index
+    /// (VectorIndex, §3.2) and pass it in.
+    ///
+    /// Distances are Euclidean via the Gram identity
+    /// ‖x−y‖² = ‖x‖² + ‖y‖² − 2⟨x,y⟩. For unit-normalized embeddings this
+    /// is monotone in cosine distance (‖x−y‖² = 2 − 2cosθ), so the neighbor
+    /// sets match cosine kNN. Each row comes back distance-sorted ascending
+    /// with index-order tie-breaking — fully deterministic.
+    ///
+    /// - Throws: `VectorError.invalidOperation` for n < 2,
+    ///   `.invalidDimension` for k outside `1...n−1`,
+    ///   `.dimensionMismatch` for ragged input.
+    public static func bruteForce<V: VectorProtocol>(
+        _ vectors: [V],
+        neighbors k: Int
+    ) throws -> KNNGraph where V.Scalar == Float {
+        let n = vectors.count
+        guard n >= 2 else {
+            throw VectorError.invalidOperation(
+                "KNNGraph.bruteForce", reason: "need at least 2 points, got \(n)")
+        }
+        guard k >= 1, k <= n - 1 else {
+            throw VectorError.invalidDimension(
+                k, reason: "neighbors must be in 1...\(n - 1) (n = \(n))")
+        }
+        let d = vectors[0].scalarCount
+        let flat = try PCAModel.flattenColumnMajor(vectors, count: n, dimension: d)
+
+        var norms = [Float](repeating: 0, count: n)
+        flat.withUnsafeBufferPointer { fb in
+            for c in 0..<d {
+                let base = c * n
+                for i in 0..<n { norms[i] += fb[base + i] * fb[base + i] }
+            }
+        }
+
+        var neighborIndices = [Int32](repeating: 0, count: n * k)
+        var distances = [Float](repeating: 0, count: n * k)
+        var bestDistance = [Float](repeating: .infinity, count: k)
+        var bestIndex = [Int32](repeating: -1, count: k)
+
+        // Query-row blocks bound the Gram panel at blockRows×n floats.
+        let blockSize = min(n, 256)
+        var start = 0
+        while start < n {
+            let blockRows = min(blockSize, n - start)
+            var block = [Float](repeating: 0, count: blockRows * d)
+            for c in 0..<d {
+                let source = c * n + start
+                let target = c * blockRows
+                for r in 0..<blockRows { block[target + r] = flat[source + r] }
+            }
+            // G (blockRows×n) = X_block · Xᵀ, all column-major.
+            let gram = LAMatMul.multiply(block, flat, m: blockRows, n: n, k: d, transposeB: true)
+
+            for r in 0..<blockRows {
+                let gi = start + r
+                for s in 0..<k {
+                    bestDistance[s] = .infinity
+                    bestIndex[s] = -1
+                }
+                for j in 0..<n where j != gi {
+                    var squared = norms[gi] + norms[j] - 2 * gram[j * blockRows + r]
+                    if squared < 0 { squared = 0 }
+                    if squared >= bestDistance[k - 1] { continue }
+                    var pos = k - 1
+                    while pos > 0 && bestDistance[pos - 1] > squared {
+                        bestDistance[pos] = bestDistance[pos - 1]
+                        bestIndex[pos] = bestIndex[pos - 1]
+                        pos -= 1
+                    }
+                    bestDistance[pos] = squared
+                    bestIndex[pos] = Int32(j)
+                }
+                let rowBase = gi * k
+                for s in 0..<k {
+                    neighborIndices[rowBase + s] = bestIndex[s]
+                    distances[rowBase + s] = bestDistance[s].squareRoot()
+                }
+            }
+            start += blockRows
+        }
+
+        return try KNNGraph(
+            pointCount: n,
+            rowOffsets: (0...n).map { $0 * k },
+            neighborIndices: neighborIndices,
+            distances: distances)
+    }
+}

--- a/Sources/VectorCore/ManifoldLearning/UMAP.swift
+++ b/Sources/VectorCore/ManifoldLearning/UMAP.swift
@@ -1,0 +1,552 @@
+//
+//  UMAP.swift
+//  VectorCore
+//
+//  UMAP layout (gap analysis §3.3): fuzzy simplicial set → initialization →
+//  SGD with negative sampling. The math follows McInnes, Healy & Melville
+//  2018 and mirrors umap-learn's reference schedule (find_ab_params /
+//  make_epochs_per_sample / optimize_layout_euclidean) so results are
+//  comparable to the de-facto standard implementation.
+//
+//  ## Boundary (§1, §3.2)
+//
+//  VectorCore owns the math only. The kNN graph arrives as a `KNNGraph`
+//  CSR value — produced by VectorIndex (or any ANN backend) at corpus
+//  scale, or by `KNNGraph.bruteForce` in-Core at sample scale — so this
+//  package never depends on VectorIndex; data flows Index → Core.
+//
+//  ## Initialization (§3.3.2)
+//
+//  PCA initialization is the default (reusing §3.1), per the gap report's
+//  scale correction: dense spectral init is not viable at 5M nodes, and a
+//  sparse Lanczos path is a stretch goal, not a dependency.
+//
+//  ## Determinism
+//
+//  The optimizer is single-threaded and fully seeded: a given (graph,
+//  initial coordinates, config) triple reproduces the layout bit-for-bit.
+//  The Hogwild-parallel variant trades that away and is the natural future
+//  ComputeProvider/GPU candidate (§3.3.3) — not this baseline.
+//
+
+import Foundation
+
+// MARK: - Configuration
+
+/// Strategy for seeding the layout coordinates (vectors entry point).
+public enum UMAPInitialization: Sendable {
+    /// PCA of the input vectors (§3.1), rescaled to a ±10 extent with tiny
+    /// seeded jitter — umap-learn's convention, and the gap report's
+    /// recommended default at scale.
+    case pca
+    /// Seeded uniform coordinates in [−10, 10] per axis.
+    case random
+}
+
+/// Tuning knobs for UMAP. Defaults match umap-learn's.
+public struct UMAPConfig: Sendable {
+    /// k for the in-Core brute-force kNN — used only when the vectors entry
+    /// point has to build its own graph; ignored when a graph is supplied.
+    public var neighbors: Int
+
+    /// Minimum spacing between embedded points; the low-distance plateau of
+    /// the output kernel. Must not exceed `spread`.
+    public var minDist: Float
+
+    /// Scale of the output kernel's decay. Together with `minDist` it
+    /// determines the fitted (a, b) curve parameters.
+    public var spread: Float
+
+    /// SGD epochs; nil picks umap-learn's default (500 when n ≤ 10 000,
+    /// else 200).
+    public var epochs: Int?
+
+    /// Initial SGD step size, annealed linearly to zero.
+    public var learningRate: Float
+
+    /// Repulsive samples drawn per attractive update. Zero disables
+    /// repulsion (attraction-only layouts collapse; useful for debugging).
+    public var negativeSampleRate: Int
+
+    /// Coordinate seeding strategy (vectors entry point only; the graph
+    /// entry point takes explicit coordinates or random).
+    public var initialization: UMAPInitialization
+
+    /// Seed for the PCA sketch, init jitter, and negative sampling.
+    public var seed: UInt64
+
+    public init(
+        neighbors: Int = 15,
+        minDist: Float = 0.1,
+        spread: Float = 1.0,
+        epochs: Int? = nil,
+        learningRate: Float = 1.0,
+        negativeSampleRate: Int = 5,
+        initialization: UMAPInitialization = .pca,
+        seed: UInt64 = 0x5EED_CAFE
+    ) {
+        self.neighbors = neighbors
+        self.minDist = minDist
+        self.spread = spread
+        self.epochs = epochs
+        self.learningRate = learningRate
+        self.negativeSampleRate = negativeSampleRate
+        self.initialization = initialization
+        self.seed = seed
+    }
+
+    internal func validate() throws {
+        guard neighbors >= 2 else {
+            throw VectorError.invalidDimension(neighbors, reason: "neighbors must be at least 2")
+        }
+        guard spread > 0, minDist >= 0, minDist <= spread else {
+            throw VectorError.invalidOperation(
+                "UMAPConfig", reason: "require 0 ≤ minDist ≤ spread and spread > 0 "
+                    + "(minDist = \(minDist), spread = \(spread))")
+        }
+        if let epochs {
+            guard epochs >= 1 else {
+                throw VectorError.invalidOperation("UMAPConfig", reason: "epochs must be ≥ 1")
+            }
+        }
+        guard learningRate > 0 else {
+            throw VectorError.invalidOperation("UMAPConfig", reason: "learningRate must be > 0")
+        }
+        guard negativeSampleRate >= 0 else {
+            throw VectorError.invalidOperation(
+                "UMAPConfig", reason: "negativeSampleRate must be ≥ 0")
+        }
+    }
+}
+
+// MARK: - Result
+
+/// An embedded layout: n points in m dimensions, flat point-major storage
+/// (point i occupies `coordinates[i*dimension ..< (i+1)*dimension]`).
+public struct UMAPResult: Sendable {
+    public let coordinates: [Float]
+    public let pointCount: Int
+    public let dimension: Int
+
+    /// Copy of point i's coordinate row.
+    public func point(_ i: Int) -> [Float] {
+        precondition(i >= 0 && i < pointCount, "point index \(i) out of range 0..<\(pointCount)")
+        let base = i * dimension
+        return Array(coordinates[base..<(base + dimension)])
+    }
+
+    /// The 2-D scatter as SIMD pairs (the gap-report sketch's shape);
+    /// nil unless `dimension == 2`.
+    public var points2D: [SIMD2<Float>]? {
+        guard dimension == 2 else { return nil }
+        var out = [SIMD2<Float>]()
+        out.reserveCapacity(pointCount)
+        for i in 0..<pointCount {
+            out.append(SIMD2(coordinates[2 * i], coordinates[2 * i + 1]))
+        }
+        return out
+    }
+}
+
+// MARK: - Operations integration
+
+extension Operations {
+    /// Self-contained UMAP: kNN (supplied or exact in-Core brute force) →
+    /// fuzzy simplicial set → PCA (or random) init → SGD layout.
+    ///
+    /// Pass `graph` to reuse an ANN-built kNN graph (VectorIndex, §3.2) —
+    /// the vectors then only feed the PCA initialization. With `graph: nil`
+    /// the O(n²·d) brute-force builder runs, which is meant for samples and
+    /// tests, not the 5M corpus.
+    ///
+    /// - Throws: `VectorError` on invalid config/shapes, plus anything PCA
+    ///   or the brute-force builder throws.
+    public static func umap<V: VectorProtocol>(
+        _ vectors: [V],
+        dimensions: Int = 2,
+        graph: KNNGraph? = nil,
+        config: UMAPConfig = UMAPConfig()
+    ) throws -> UMAPResult where V.Scalar == Float {
+        try config.validate()
+        guard dimensions >= 1 else {
+            throw VectorError.invalidDimension(dimensions, reason: "output dimension must be ≥ 1")
+        }
+        let knn: KNNGraph
+        if let graph {
+            guard graph.pointCount == vectors.count else {
+                throw VectorError.dimensionMismatch(
+                    expected: vectors.count, actual: graph.pointCount)
+            }
+            knn = graph
+        } else {
+            knn = try KNNGraph.bruteForce(vectors, neighbors: config.neighbors)
+        }
+        let initial: [Float]
+        switch config.initialization {
+        case .pca:
+            initial = try pcaInitialCoordinates(vectors, dimensions: dimensions, config: config)
+        case .random:
+            initial = UMAPLayout.randomCoordinates(
+                count: vectors.count * dimensions, seed: config.seed)
+        }
+        return try umapLayout(graph: knn, dimensions: dimensions, initial: initial, config: config)
+    }
+
+    /// Graph-only UMAP for callers that no longer hold the original
+    /// vectors: consumes the §3.2 CSR interchange directly.
+    /// `initialCoordinates` rows (e.g. a PCA projection of the same points)
+    /// seed the layout; nil falls back to seeded random in [−10, 10].
+    public static func umap(
+        graph: KNNGraph,
+        dimensions: Int = 2,
+        initialCoordinates: [[Float]]? = nil,
+        config: UMAPConfig = UMAPConfig()
+    ) throws -> UMAPResult {
+        try config.validate()
+        guard dimensions >= 1 else {
+            throw VectorError.invalidDimension(dimensions, reason: "output dimension must be ≥ 1")
+        }
+        let n = graph.pointCount
+        let initial: [Float]
+        if let provided = initialCoordinates {
+            guard provided.count == n else {
+                throw VectorError.dimensionMismatch(expected: n, actual: provided.count)
+            }
+            var flat = [Float](repeating: 0, count: n * dimensions)
+            let m = dimensions
+            for i in 0..<n {
+                guard provided[i].count == m else {
+                    throw VectorError.dimensionMismatch(expected: m, actual: provided[i].count)
+                }
+                for c in 0..<m { flat[i * m + c] = provided[i][c] }
+            }
+            initial = flat
+        } else {
+            initial = UMAPLayout.randomCoordinates(count: n * dimensions, seed: config.seed)
+        }
+        return try umapLayout(graph: graph, dimensions: dimensions, initial: initial, config: config)
+    }
+
+    /// Shared tail: fuzzy set → curve fit → SGD.
+    private static func umapLayout(
+        graph: KNNGraph,
+        dimensions: Int,
+        initial: [Float],
+        config: UMAPConfig
+    ) throws -> UMAPResult {
+        let n = graph.pointCount
+        guard n >= 2 else {
+            throw VectorError.invalidOperation(
+                "Operations.umap", reason: "need at least 2 points, got \(n)")
+        }
+        let edges = FuzzySimplicialSet.build(graph)
+        guard edges.count > 0 else {
+            throw VectorError.invalidData("kNN graph produced no usable edges")
+        }
+        let curve = UMAPLayout.fitABParams(spread: config.spread, minDist: config.minDist)
+        let epochs = config.epochs ?? (n <= 10_000 ? 500 : 200)
+        var coordinates = initial
+        UMAPLayout.optimize(
+            edges: edges,
+            coordinates: &coordinates,
+            pointCount: n,
+            dimension: dimensions,
+            parameters: UMAPLayout.Parameters(
+                a: curve.a, b: curve.b,
+                epochs: epochs,
+                learningRate: config.learningRate,
+                negativeSampleRate: config.negativeSampleRate,
+                seed: config.seed))
+        return UMAPResult(coordinates: coordinates, pointCount: n, dimension: dimensions)
+    }
+
+    /// PCA projection rescaled to a ±10 extent plus 1e-4 seeded jitter
+    /// (umap-learn's pca-init convention; the jitter breaks exact
+    /// coincidences before SGD).
+    private static func pcaInitialCoordinates<V: VectorProtocol>(
+        _ vectors: [V],
+        dimensions: Int,
+        config: UMAPConfig
+    ) throws -> [Float] where V.Scalar == Float {
+        let model = try PCAModel.fit(
+            vectors, components: dimensions, config: PCAConfig(seed: config.seed))
+        let projected = try model.transform(vectors)
+        let n = vectors.count
+        let m = dimensions
+        var flat = [Float](repeating: 0, count: n * m)
+        var maxAbs: Float = 0
+        for i in 0..<n {
+            for c in 0..<m {
+                let value = projected[i][c]
+                flat[i * m + c] = value
+                maxAbs = max(maxAbs, abs(value))
+            }
+        }
+        let scale: Float = maxAbs > 0 ? 10 / maxAbs : 1
+        var noise = GaussianSource(seed: config.seed ^ 0x9E37_79B9_7F4A_7C15)
+        for idx in 0..<flat.count {
+            flat[idx] = flat[idx] * scale + 1e-4 * noise.next()
+        }
+        return flat
+    }
+}
+
+// MARK: - Layout engine
+
+/// The SGD optimizer and its supporting math — umap-learn's
+/// `optimize_layout_euclidean`, single-threaded for determinism.
+internal enum UMAPLayout {
+
+    internal struct Parameters {
+        var a: Float
+        var b: Float
+        var epochs: Int
+        var learningRate: Float
+        var negativeSampleRate: Int
+        var seed: UInt64
+    }
+
+    /// Output-kernel parameters: least-squares fit of `1/(1 + a·x^{2b})` to
+    /// the piecewise target (1 below `minDist`, `exp(−(x−minDist)/spread)`
+    /// above) on 300 samples of `[0, 3·spread]` — umap-learn's
+    /// `find_ab_params` grid. Solved by Levenberg–Marquardt on the
+    /// 2-parameter normal equations; deterministic, no RNG.
+    static func fitABParams(spread: Float, minDist: Float) -> (a: Float, b: Float) {
+        let samples = 300
+        let spreadD = Double(spread)
+        let minDistD = Double(minDist)
+        var xs = [Double](repeating: 0, count: samples)
+        var ys = [Double](repeating: 0, count: samples)
+        for idx in 0..<samples {
+            let x = 3 * spreadD * Double(idx) / Double(samples - 1)
+            xs[idx] = x
+            ys[idx] = x < minDistD ? 1 : Foundation.exp(-(x - minDistD) / spreadD)
+        }
+
+        var a = 1.0
+        var b = 1.0
+        var lambda = 1e-3
+        var sse = curveSSE(xs, ys, a: a, b: b)
+        for _ in 0..<200 {
+            // Accumulate JᵀJ and Jᵀr for r(x) = f(x) − y(x).
+            var jaa = 0.0, jab = 0.0, jbb = 0.0
+            var ga = 0.0, gb = 0.0
+            for s in 0..<samples where xs[s] > 0 {
+                let x = xs[s]
+                let xp = Foundation.pow(x, 2 * b)
+                let denom = 1 + a * xp
+                let residual = 1 / denom - ys[s]
+                let dfda = -xp / (denom * denom)
+                let dfdb = -2 * a * xp * Foundation.log(x) / (denom * denom)
+                jaa += dfda * dfda
+                jab += dfda * dfdb
+                jbb += dfdb * dfdb
+                ga += dfda * residual
+                gb += dfdb * residual
+            }
+            // (JᵀJ + λ·diag(JᵀJ)) δ = −Jᵀr, 2×2 closed form.
+            let daa = jaa * (1 + lambda)
+            let dbb = jbb * (1 + lambda)
+            let det = daa * dbb - jab * jab
+            if abs(det) < 1e-30 { break }
+            let deltaA = (-ga * dbb + gb * jab) / det
+            let deltaB = (-gb * daa + ga * jab) / det
+            let candidateA = a + deltaA
+            let candidateB = b + deltaB
+            if candidateA <= 0 || candidateB <= 0 {
+                lambda *= 10
+                continue
+            }
+            let candidateSSE = curveSSE(xs, ys, a: candidateA, b: candidateB)
+            if candidateSSE < sse {
+                a = candidateA
+                b = candidateB
+                sse = candidateSSE
+                lambda = max(lambda / 3, 1e-12)
+                if abs(deltaA) < 1e-10 && abs(deltaB) < 1e-10 { break }
+            } else {
+                lambda *= 10
+                if lambda > 1e12 { break }
+            }
+        }
+        return (Float(a), Float(b))
+    }
+
+    private static func curveSSE(_ xs: [Double], _ ys: [Double], a: Double, b: Double) -> Double {
+        var total = 0.0
+        for s in 0..<xs.count {
+            let x = xs[s]
+            let fitted = x > 0 ? 1 / (1 + a * Foundation.pow(x, 2 * b)) : 1
+            let residual = fitted - ys[s]
+            total += residual * residual
+        }
+        return total
+    }
+
+    /// Seeded uniform coordinates in [−10, 10] (umap-learn's random init).
+    static func randomCoordinates(count: Int, seed: UInt64) -> [Float] {
+        var rng = SplitMix64(state: seed)
+        var out = [Float](repeating: 0, count: count)
+        for idx in 0..<count { out[idx] = Float(rng.nextUniform() * 20 - 10) }
+        return out
+    }
+
+    /// In-place SGD over the symmetric edge list, mirroring umap-learn's
+    /// schedule: edges below `maxW/epochs` are pruned, edge e then fires
+    /// every `maxW/wₑ` epochs; each firing attracts both endpoints along
+    /// the edge and repulses the head against `negativeSampleRate` random
+    /// vertices; the step anneals linearly to zero. Gradients are clamped
+    /// to ±4 per coordinate (the reference's stability clip).
+    static func optimize(
+        edges: UMAPEdgeList,
+        coordinates: inout [Float],
+        pointCount n: Int,
+        dimension m: Int,
+        parameters: Parameters
+    ) {
+        var maxWeight: Float = 0
+        for w in edges.weights where w > maxWeight { maxWeight = w }
+        guard maxWeight > 0, parameters.epochs >= 1, n >= 1 else { return }
+
+        let pruneBelow = parameters.epochs > 10 ? maxWeight / Float(parameters.epochs) : 0
+        var heads = [Int32]()
+        var tails = [Int32]()
+        var cadence = [Double]() // epochs between samples of each edge
+        for e in 0..<edges.count {
+            let w = edges.weights[e]
+            guard w > 0, w >= pruneBelow else { continue }
+            heads.append(edges.heads[e])
+            tails.append(edges.tails[e])
+            cadence.append(Double(maxWeight / w))
+        }
+        guard !cadence.isEmpty else { return }
+
+        let negativeRate = parameters.negativeSampleRate
+        var nextSample = cadence
+        var negativeCadence = [Double](repeating: 0, count: cadence.count)
+        var nextNegative = [Double](repeating: 0, count: cadence.count)
+        if negativeRate > 0 {
+            for e in 0..<cadence.count {
+                negativeCadence[e] = cadence[e] / Double(negativeRate)
+                nextNegative[e] = negativeCadence[e]
+            }
+        }
+
+        var rng = SplitMix64(state: parameters.seed ^ 0xD6E8_FEB8_6659_FD93)
+        let kernel = (a: parameters.a, b: parameters.b)
+        let totalEpochs = parameters.epochs
+
+        coordinates.withUnsafeMutableBufferPointer { coords in
+            for epoch in 0..<totalEpochs {
+                let alpha = parameters.learningRate * (1 - Float(epoch) / Float(totalEpochs))
+                let now = Double(epoch)
+                for e in 0..<heads.count where nextSample[e] <= now {
+                    let headBase = Int(heads[e]) * m
+                    let tailBase = Int(tails[e]) * m
+                    attract(coords, headBase, tailBase, m, kernel, alpha)
+                    nextSample[e] += cadence[e]
+
+                    guard negativeRate > 0 else { continue }
+                    let due = Int((now - nextNegative[e]) / negativeCadence[e])
+                    guard due > 0 else { continue }
+                    for _ in 0..<due {
+                        let otherBase = Int(rng.next() % UInt64(n)) * m
+                        if otherBase == headBase { continue }
+                        repulse(coords, headBase, otherBase, m, kernel, alpha)
+                    }
+                    nextNegative[e] += Double(due) * negativeCadence[e]
+                }
+            }
+        }
+    }
+
+    /// Attractive update along edge (head, tail): both endpoints move by
+    /// ∓clip(−2ab·d^{2(b−1)}/(1 + a·d^{2b}) · Δ) · α. Coincident endpoints
+    /// are a no-op (zero gradient).
+    @inline(__always)
+    private static func attract(
+        _ coords: UnsafeMutableBufferPointer<Float>,
+        _ headBase: Int,
+        _ tailBase: Int,
+        _ m: Int,
+        _ kernel: (a: Float, b: Float),
+        _ alpha: Float
+    ) {
+        var squared: Float = 0
+        for c in 0..<m {
+            let diff = coords[headBase + c] - coords[tailBase + c]
+            squared += diff * diff
+        }
+        guard squared > 0 else { return }
+        let pd = powf32(squared, kernel.b)
+        let coefficient = -2 * kernel.a * kernel.b * pd / (squared * (1 + kernel.a * pd))
+        for c in 0..<m {
+            let g = clip4(coefficient * (coords[headBase + c] - coords[tailBase + c]))
+            coords[headBase + c] += alpha * g
+            coords[tailBase + c] -= alpha * g
+        }
+    }
+
+    /// Repulsive update of head against a sampled vertex:
+    /// clip(2b/((0.001 + d²)(1 + a·d^{2b})) · Δ) · α; coincident pairs take
+    /// the full clip bound to break the tie (umap-learn's behavior).
+    @inline(__always)
+    private static func repulse(
+        _ coords: UnsafeMutableBufferPointer<Float>,
+        _ headBase: Int,
+        _ otherBase: Int,
+        _ m: Int,
+        _ kernel: (a: Float, b: Float),
+        _ alpha: Float
+    ) {
+        var squared: Float = 0
+        for c in 0..<m {
+            let diff = coords[headBase + c] - coords[otherBase + c]
+            squared += diff * diff
+        }
+        if squared > 0 {
+            let pd = powf32(squared, kernel.b)
+            let coefficient = 2 * kernel.b / ((0.001 + squared) * (1 + kernel.a * pd))
+            for c in 0..<m {
+                let g = clip4(coefficient * (coords[headBase + c] - coords[otherBase + c]))
+                coords[headBase + c] += alpha * g
+            }
+        } else {
+            for c in 0..<m { coords[headBase + c] += alpha * 4 }
+        }
+    }
+
+    @inline(__always)
+    private static func clip4(_ x: Float) -> Float {
+        min(4, max(-4, x))
+    }
+
+    /// Float power via libm's Double pow — portable across the Darwin and
+    /// Glibc overlays; the conversion cost is irrelevant next to pow itself.
+    @inline(__always)
+    private static func powf32(_ x: Float, _ y: Float) -> Float {
+        Float(Foundation.pow(Double(x), Double(y)))
+    }
+}
+
+// MARK: - Seeded uniform source
+
+/// Minimal deterministic RNG (the same SplitMix64 mixer that drives
+/// `GaussianSource`) for negative sampling and random initialization.
+/// Not cryptographic.
+internal struct SplitMix64 {
+    var state: UInt64
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+
+    /// Uniform in [0, 1) with a 53-bit mantissa.
+    mutating func nextUniform() -> Double {
+        (Double(next() >> 11) + 0.5) * 0x1p-53
+    }
+}

--- a/Sources/VectorCoreC/common/vc_lapack.c
+++ b/Sources/VectorCoreC/common/vc_lapack.c
@@ -1,0 +1,160 @@
+// vc_lapack.c — LAPACK shim implementation.
+//
+// Apple platforms: routes to Accelerate's modern LAPACK interface
+// (ACCELERATE_NEW_LAPACK). Requires macOS 13.3+/iOS 16.4+ at the SDK level;
+// the package's platform floor (macOS 14 / iOS 17) already exceeds this.
+//
+// Other platforms: stubs returning VC_LAPACK_UNAVAILABLE. The Swift
+// SwiftLinearAlgebraProvider is the cross-platform fallback; this shim is
+// only the fast path. (A future system-LAPACK/OpenBLAS hookup for Linux
+// would land here behind the same five entry points.)
+
+#include "../include/vc_lapack.h"
+
+#include <stdlib.h>
+
+#if defined(__APPLE__)
+  #define ACCELERATE_NEW_LAPACK 1
+  // ACCELERATE_LAPACK_ILP64 intentionally NOT defined — see vc_lapack.h.
+  #include <Accelerate/Accelerate.h>
+  #define VC_HAS_LAPACK 1
+#endif
+
+int32_t vc_lapack_available(void) {
+#if defined(VC_HAS_LAPACK)
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+#if defined(VC_HAS_LAPACK)
+
+// Helper: round a float workspace-size query result up to an int element
+// count. LAPACK returns optimal lwork in work[0] as a float; add a small
+// epsilon before truncation to guard against representational round-down.
+static int32_t vc__lwork_from_query(float q) {
+    return (int32_t)(q + 0.5f);
+}
+
+int32_t vc_lapack_sgeqrf(int32_t m, int32_t n, float *a, int32_t lda, float *tau) {
+    __LAPACK_int mm = m, nn = n, ldaa = lda, info = 0;
+
+    // Workspace query (lwork = -1)
+    float query = 0.0f;
+    __LAPACK_int lwork = -1;
+    sgeqrf_(&mm, &nn, a, &ldaa, tau, &query, &lwork, &info);
+    if (info != 0) { return (int32_t)info; }
+
+    lwork = vc__lwork_from_query(query);
+    float *work = (float *)malloc((size_t)lwork * sizeof(float));
+    if (work == NULL) { return VC_LAPACK_UNAVAILABLE; }
+
+    sgeqrf_(&mm, &nn, a, &ldaa, tau, work, &lwork, &info);
+    free(work);
+    return (int32_t)info;
+}
+
+int32_t vc_lapack_sorgqr(int32_t m, int32_t n, int32_t k,
+                         float *a, int32_t lda, const float *tau) {
+    __LAPACK_int mm = m, nn = n, kk = k, ldaa = lda, info = 0;
+
+    float query = 0.0f;
+    __LAPACK_int lwork = -1;
+    sorgqr_(&mm, &nn, &kk, a, &ldaa, tau, &query, &lwork, &info);
+    if (info != 0) { return (int32_t)info; }
+
+    lwork = vc__lwork_from_query(query);
+    float *work = (float *)malloc((size_t)lwork * sizeof(float));
+    if (work == NULL) { return VC_LAPACK_UNAVAILABLE; }
+
+    sorgqr_(&mm, &nn, &kk, a, &ldaa, tau, work, &lwork, &info);
+    free(work);
+    return (int32_t)info;
+}
+
+int32_t vc_lapack_sgesdd(int32_t m, int32_t n,
+                         float *a, int32_t lda,
+                         float *s,
+                         float *u, int32_t ldu,
+                         float *vt, int32_t ldvt) {
+    __LAPACK_int mm = m, nn = n, ldaa = lda, lduu = ldu, ldvtt = ldvt, info = 0;
+    const char jobz = 'S';  // thin factors only
+
+    __LAPACK_int minmn = (m < n) ? m : n;
+    __LAPACK_int *iwork = (__LAPACK_int *)malloc((size_t)(8 * minmn) * sizeof(__LAPACK_int));
+    if (iwork == NULL) { return VC_LAPACK_UNAVAILABLE; }
+
+    float query = 0.0f;
+    __LAPACK_int lwork = -1;
+    sgesdd_(&jobz, &mm, &nn, a, &ldaa, s, u, &lduu, vt, &ldvtt,
+            &query, &lwork, iwork, &info);
+    if (info != 0) { free(iwork); return (int32_t)info; }
+
+    lwork = vc__lwork_from_query(query);
+    float *work = (float *)malloc((size_t)lwork * sizeof(float));
+    if (work == NULL) { free(iwork); return VC_LAPACK_UNAVAILABLE; }
+
+    sgesdd_(&jobz, &mm, &nn, a, &ldaa, s, u, &lduu, vt, &ldvtt,
+            work, &lwork, iwork, &info);
+    free(work);
+    free(iwork);
+    return (int32_t)info;
+}
+
+int32_t vc_lapack_ssyevd(char jobz, char uplo, int32_t n,
+                         float *a, int32_t lda, float *w) {
+    __LAPACK_int nn = n, ldaa = lda, info = 0;
+
+    // Dual workspace query: optimal lwork (float) and liwork (int).
+    float fquery = 0.0f;
+    __LAPACK_int iquery = 0;
+    __LAPACK_int lwork = -1, liwork = -1;
+    ssyevd_(&jobz, &uplo, &nn, a, &ldaa, w,
+            &fquery, &lwork, &iquery, &liwork, &info);
+    if (info != 0) { return (int32_t)info; }
+
+    lwork = vc__lwork_from_query(fquery);
+    liwork = iquery;
+    float *work = (float *)malloc((size_t)lwork * sizeof(float));
+    __LAPACK_int *iwork = (__LAPACK_int *)malloc((size_t)liwork * sizeof(__LAPACK_int));
+    if (work == NULL || iwork == NULL) {
+        free(work);
+        free(iwork);
+        return VC_LAPACK_UNAVAILABLE;
+    }
+
+    ssyevd_(&jobz, &uplo, &nn, a, &ldaa, w,
+            work, &lwork, iwork, &liwork, &info);
+    free(work);
+    free(iwork);
+    return (int32_t)info;
+}
+
+#else  // !VC_HAS_LAPACK — stubs
+
+int32_t vc_lapack_sgeqrf(int32_t m, int32_t n, float *a, int32_t lda, float *tau) {
+    (void)m; (void)n; (void)a; (void)lda; (void)tau;
+    return VC_LAPACK_UNAVAILABLE;
+}
+
+int32_t vc_lapack_sorgqr(int32_t m, int32_t n, int32_t k,
+                         float *a, int32_t lda, const float *tau) {
+    (void)m; (void)n; (void)k; (void)a; (void)lda; (void)tau;
+    return VC_LAPACK_UNAVAILABLE;
+}
+
+int32_t vc_lapack_sgesdd(int32_t m, int32_t n, float *a, int32_t lda, float *s,
+                         float *u, int32_t ldu, float *vt, int32_t ldvt) {
+    (void)m; (void)n; (void)a; (void)lda; (void)s;
+    (void)u; (void)ldu; (void)vt; (void)ldvt;
+    return VC_LAPACK_UNAVAILABLE;
+}
+
+int32_t vc_lapack_ssyevd(char jobz, char uplo, int32_t n,
+                         float *a, int32_t lda, float *w) {
+    (void)jobz; (void)uplo; (void)n; (void)a; (void)lda; (void)w;
+    return VC_LAPACK_UNAVAILABLE;
+}
+
+#endif

--- a/Sources/VectorCoreC/common/vc_lapack.c
+++ b/Sources/VectorCoreC/common/vc_lapack.c
@@ -11,6 +11,7 @@
 
 #include "../include/vc_lapack.h"
 
+#include <math.h>
 #include <stdlib.h>
 
 #if defined(__APPLE__)
@@ -30,11 +31,18 @@ int32_t vc_lapack_available(void) {
 
 #if defined(VC_HAS_LAPACK)
 
-// Helper: round a float workspace-size query result up to an int element
-// count. LAPACK returns optimal lwork in work[0] as a float; add a small
-// epsilon before truncation to guard against representational round-down.
+// Helper: convert a float workspace-size query result (work[0]) to an int
+// element count. Must round UP with margin: above 2^24, Float spacing
+// exceeds 1 and the reported value may sit below the true integer, and
+// Accelerate's LAPACK (3.9.x) predates the SROUNDUP_LWORK round-up
+// guarantee introduced in LAPACK 3.10. Undershooting lwork yields a clean
+// info=-N argument error, but only at panel sizes tests never reach —
+// so over-allocate slightly (1/64th) instead.
 static int32_t vc__lwork_from_query(float q) {
-    return (int32_t)(q + 0.5f);
+    int64_t r = (int64_t)ceilf(q);
+    r += r / 64 + 1;
+    if (r > INT32_MAX) { r = INT32_MAX; }
+    return (int32_t)r;
 }
 
 int32_t vc_lapack_sgeqrf(int32_t m, int32_t n, float *a, int32_t lda, float *tau) {

--- a/Sources/VectorCoreC/common/vc_lapack.c
+++ b/Sources/VectorCoreC/common/vc_lapack.c
@@ -15,8 +15,14 @@
 #include <stdlib.h>
 
 #if defined(__APPLE__)
-  #define ACCELERATE_NEW_LAPACK 1
+  // ACCELERATE_NEW_LAPACK is defined via cSettings in Package.swift: under
+  // clang modules (SPM default for C targets) the include below is a module
+  // import, so an in-source #define would not reach Accelerate's headers.
+  // The guarded define keeps plain textual inclusion working too.
   // ACCELERATE_LAPACK_ILP64 intentionally NOT defined — see vc_lapack.h.
+  #if !defined(ACCELERATE_NEW_LAPACK)
+    #define ACCELERATE_NEW_LAPACK 1
+  #endif
   #include <Accelerate/Accelerate.h>
   #define VC_HAS_LAPACK 1
 #endif

--- a/Sources/VectorCoreC/include/VectorCoreC.h
+++ b/Sources/VectorCoreC/include/VectorCoreC.h
@@ -1,8 +1,14 @@
 // VectorCoreC.h — Public C API for VectorCore kernels (scaffold)
+//
+// This header shares the target's name, so SPM treats it as the module's
+// umbrella header: every public header must be included here to be visible
+// to Swift.
 #pragma once
 
 #include <stddef.h>
 #include <stdint.h>
+
+#include "vc_lapack.h"
 
 // --- Portability & visibility macros ---
 #if !defined(VC_EXPORT)

--- a/Sources/VectorCoreC/include/vc_lapack.h
+++ b/Sources/VectorCoreC/include/vc_lapack.h
@@ -1,0 +1,90 @@
+// vc_lapack.h — LAPACK shim for VectorCore dense linear algebra.
+//
+// Why a C shim instead of calling LAPACK from Swift directly:
+//   1. Accelerate's modern LAPACK interface is gated behind the
+//      ACCELERATE_NEW_LAPACK preprocessor macro, which must be defined
+//      *before* <Accelerate/Accelerate.h> is processed. Swift cannot inject
+//      C macros into the Clang importer without `unsafeFlags`, which would
+//      make the package unconsumable as a dependency. A C translation unit
+//      defines the macro locally — zero flags leak into Package.swift.
+//   2. The shim owns LAPACK workspace negotiation (lwork=-1 probes, iwork
+//      sizing), so the Swift side never touches raw Fortran calling
+//      conventions.
+//   3. Non-Apple platforms compile the same header against stub
+//      implementations; availability is a runtime probe, mirroring the
+//      vc_has_* CPU-feature pattern in VectorCoreC.h.
+//
+// Integer model: 32-bit LAPACK indices (ACCELERATE_LAPACK_ILP64 deliberately
+// NOT defined). Every factorization VectorCore performs is on small panels —
+// covariance/Gram matrices (d ≤ ~2k) and randomized-SVD sketches
+// (n × (k+p), k+p ≤ ~100). Element counts never approach 2^31; ILP64 would
+// only complicate the Swift boundary. Revisit if a consumer ever factors a
+// matrix with >2^31 elements (they should not — that is GEMM territory).
+//
+// Matrix layout: ALL matrices are COLUMN-MAJOR (LAPACK native). Callers are
+// responsible for layout; the Swift providers document this contract.
+
+#pragma once
+
+#include <stdint.h>
+
+#if !defined(VC_EXPORT)
+  #if defined(_WIN32)
+    #define VC_EXPORT __declspec(dllexport)
+  #else
+    #define VC_EXPORT __attribute__((visibility("default")))
+  #endif
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// Returned when no LAPACK backend exists on this platform (non-Apple build).
+// Positive/negative values in the small range are LAPACK `info` codes:
+//   0 = success; <0 = illegal argument at position -info; >0 = algorithm
+//   failure (did not converge / not positive definite, routine-specific).
+#define VC_LAPACK_UNAVAILABLE (-1000)
+
+/// 1 if a LAPACK backend is compiled in and callable, 0 otherwise.
+VC_EXPORT int32_t vc_lapack_available(void);
+
+/// QR factorization (SGEQRF): A (m×n, col-major, lda≥m) is overwritten with
+/// R in the upper triangle and Householder reflectors below the diagonal.
+/// tau must hold min(m,n) elements. Returns LAPACK info.
+VC_EXPORT int32_t vc_lapack_sgeqrf(int32_t m, int32_t n,
+                                   float *a, int32_t lda,
+                                   float *tau);
+
+/// Generate explicit Q (SORGQR) from SGEQRF output. On entry `a` holds the
+/// reflectors (m×n as left by sgeqrf); on exit the first k columns of `a`
+/// are the orthonormal Q (m×k). k = number of reflectors (= tau length used).
+/// Returns LAPACK info.
+VC_EXPORT int32_t vc_lapack_sorgqr(int32_t m, int32_t n, int32_t k,
+                                   float *a, int32_t lda,
+                                   const float *tau);
+
+/// Thin SVD via divide-and-conquer (SGESDD, jobz='S').
+/// A (m×n, col-major) is DESTROYED. With kk = min(m,n):
+///   u:  m×kk col-major (ldu≥m)   s: kk singular values, descending
+///   vt: kk×n col-major (ldvt≥kk)
+/// Returns LAPACK info (>0 means the D&C algorithm failed to converge).
+VC_EXPORT int32_t vc_lapack_sgesdd(int32_t m, int32_t n,
+                                   float *a, int32_t lda,
+                                   float *s,
+                                   float *u, int32_t ldu,
+                                   float *vt, int32_t ldvt);
+
+/// Symmetric eigendecomposition via divide-and-conquer (SSYEVD).
+/// jobz: 'V' = eigenvalues + eigenvectors, 'N' = eigenvalues only.
+/// uplo: 'L'/'U' — which triangle of A is referenced.
+/// A (n×n, col-major) is overwritten: for jobz='V' its columns become the
+/// orthonormal eigenvectors. w receives the n eigenvalues in ASCENDING order.
+/// Returns LAPACK info.
+VC_EXPORT int32_t vc_lapack_ssyevd(char jobz, char uplo, int32_t n,
+                                   float *a, int32_t lda,
+                                   float *w);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/Tests/ComprehensiveTests/LinearAlgebraProviderTests.swift
+++ b/Tests/ComprehensiveTests/LinearAlgebraProviderTests.swift
@@ -277,7 +277,10 @@ struct SVDThinSuite {
     @Test("Known diagonal: σ(diag(3,2)) padded = {3, 2}")
     func knownSingularValues() throws {
         // 4×2 column-major: columns [3,0,0,0], [0,2,0,0]
-        let a: [Float] = [3, 0, 0, 0,   0, 2, 0, 0]
+        let a: [Float] = [
+            3, 0, 0, 0, // column 0
+            0, 2, 0, 0  // column 1
+        ]
         for (name, p) in LA.providers {
             let d = try p.svdThin(a, rows: 4, columns: 2)
             #expect(abs(d.singularValues[0] - 3) < 1e-5, "\(name): σ₀")

--- a/Tests/ComprehensiveTests/LinearAlgebraProviderTests.swift
+++ b/Tests/ComprehensiveTests/LinearAlgebraProviderTests.swift
@@ -1,0 +1,315 @@
+//
+//  LinearAlgebraProviderTests.swift
+//  VectorCore
+//
+//  Correctness + cross-provider parity tests for the LinearAlgebraProvider
+//  seam (LAPACK shim and pure-Swift fallback).
+//
+//  Conventions under test (see LinearAlgebraProvider.swift):
+//  - column-major flat [Float] buffers
+//  - SVD singular values DESCENDING, eigen eigenvalues ASCENDING
+//  - symmetricEigen reads only the LOWER triangle (uplo='L')
+//
+//  Sign conventions (Q column signs, singular/eigenvector signs) are NOT
+//  pinned by either backend, so tests assert backend-free invariants:
+//  reconstruction, orthonormality, triangularity, and spectra (sign-free).
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+// MARK: - Deterministic fixtures & dense helpers (column-major)
+
+private enum LA {
+    /// SplitMix64 → uniform Float in [-1, 1]; deterministic across platforms.
+    static func matrix(seed: UInt64, _ rows: Int, _ columns: Int) -> [Float] {
+        var state = seed &+ 0x9E3779B97F4A7C15
+        func next() -> Float {
+            state &+= 0x9E3779B97F4A7C15
+            var z = state
+            z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+            z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+            z ^= z >> 31
+            return Float(z >> 40) / Float(1 << 24) * 2 - 1
+        }
+        return (0..<(rows * columns)).map { _ in next() }
+    }
+
+    static func symmetric(seed: UInt64, _ n: Int) -> [Float] {
+        let b = matrix(seed: seed, n, n)
+        var a = [Float](repeating: 0, count: n * n)
+        for j in 0..<n {
+            for i in 0..<n {
+                a[j * n + i] = (b[j * n + i] + b[i * n + j]) / 2
+            }
+        }
+        return a
+    }
+
+    /// C = A (m×k) · B (k×n), all column-major.
+    static func matmul(_ a: [Float], _ b: [Float], m: Int, k: Int, n: Int) -> [Float] {
+        var c = [Float](repeating: 0, count: m * n)
+        for j in 0..<n {
+            for l in 0..<k {
+                let blj = b[j * k + l]
+                if blj == 0 { continue }
+                for i in 0..<m {
+                    c[j * m + i] += a[l * m + i] * blj
+                }
+            }
+        }
+        return c
+    }
+
+    static func maxAbsDiff(_ a: [Float], _ b: [Float]) -> Float {
+        zip(a, b).reduce(0) { Swift.max($0, abs($1.0 - $1.1)) }
+    }
+
+    /// max |GᵀG − I| over a column-major m×n G — orthonormality defect.
+    static func orthoDefect(_ g: [Float], rows m: Int, columns n: Int) -> Float {
+        var worst: Float = 0
+        for j1 in 0..<n {
+            for j2 in j1..<n {
+                var dot: Float = 0
+                for i in 0..<m { dot += g[j1 * m + i] * g[j2 * m + i] }
+                let target: Float = j1 == j2 ? 1 : 0
+                worst = Swift.max(worst, abs(dot - target))
+            }
+        }
+        return worst
+    }
+
+    /// Providers to exercise. The Swift fallback always runs; LAPACK runs
+    /// where a backend is compiled in (all Apple platforms).
+    static var providers: [(name: String, provider: any LinearAlgebraProvider)] {
+        var list: [(String, any LinearAlgebraProvider)] = [("Swift", SwiftLinearAlgebraProvider())]
+        if LAPACKLinearAlgebraProvider.isAvailable {
+            list.append(("LAPACK", LAPACKLinearAlgebraProvider()))
+        }
+        return list
+    }
+}
+
+// MARK: - QR
+
+@Suite("LinearAlgebra - QR")
+struct QRThinSuite {
+
+    @Test("Reconstruction, orthonormality, triangularity across shapes")
+    func qrInvariants() throws {
+        for (name, p) in LA.providers {
+            for (m, n) in [(8, 8), (20, 5), (50, 30), (7, 1), (1, 1)] {
+                let a = LA.matrix(seed: UInt64(m * 31 + n), m, n)
+                let f = try p.qrThin(a, rows: m, columns: n)
+
+                #expect(f.q.count == m * n, "\(name) \(m)x\(n): Q shape")
+                #expect(f.r.count == n * n, "\(name) \(m)x\(n): R shape")
+
+                let recon = LA.matmul(f.q, f.r, m: m, k: n, n: n)
+                #expect(LA.maxAbsDiff(recon, a) < 1e-4, "\(name) \(m)x\(n): QR ≠ A")
+                #expect(LA.orthoDefect(f.q, rows: m, columns: n) < 1e-4, "\(name) \(m)x\(n): QᵀQ ≠ I")
+
+                // R strictly lower triangle must be exactly zero (we construct it).
+                for j in 0..<n {
+                    for i in (j + 1)..<n {
+                        #expect(f.r[j * n + i] == 0, "\(name) \(m)x\(n): R not upper-triangular")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test("Rank-deficient input still reconstructs")
+    func qrRankDeficient() throws {
+        let m = 10, n = 4
+        var a = LA.matrix(seed: 7, m, n)
+        for i in 0..<m { a[2 * m + i] = a[1 * m + i] }   // duplicate column
+
+        for (name, p) in LA.providers {
+            let f = try p.qrThin(a, rows: m, columns: n)
+            let recon = LA.matmul(f.q, f.r, m: m, k: n, n: n)
+            #expect(LA.maxAbsDiff(recon, a) < 1e-4, "\(name): rank-deficient QR ≠ A")
+        }
+    }
+
+    @Test("Wide matrix (m < n) throws invalidOperation")
+    func qrWideThrows() {
+        for (_, p) in LA.providers {
+            #expect(throws: VectorError.self) {
+                _ = try p.qrThin(LA.matrix(seed: 1, 3, 5), rows: 3, columns: 5)
+            }
+        }
+    }
+
+    @Test("Element-count mismatch throws")
+    func qrShapeMismatchThrows() {
+        for (_, p) in LA.providers {
+            #expect(throws: VectorError.self) {
+                _ = try p.qrThin([1, 2, 3], rows: 4, columns: 2)
+            }
+        }
+    }
+}
+
+// MARK: - Symmetric eigendecomposition
+
+@Suite("LinearAlgebra - SymmetricEigen")
+struct SymmetricEigenSuite {
+
+    @Test("Known 2x2 spectrum: [[2,1],[1,2]] → {1, 3}")
+    func knownSpectrum() throws {
+        let a: [Float] = [2, 1, 1, 2]   // column-major (symmetric, layout-agnostic)
+        for (name, p) in LA.providers {
+            let e = try p.symmetricEigen(a, dimension: 2, computeEigenvectors: true)
+            #expect(abs(e.eigenvalues[0] - 1) < 1e-5, "\(name): λ₀")
+            #expect(abs(e.eigenvalues[1] - 3) < 1e-5, "\(name): λ₁")
+        }
+    }
+
+    @Test("Random symmetric: AV = VΛ, VᵀV = I, λ ascending")
+    func eigenInvariants() throws {
+        for (name, p) in LA.providers {
+            for n in [2, 10, 50] {
+                let a = LA.symmetric(seed: UInt64(n), n)
+                let e = try p.symmetricEigen(a, dimension: n, computeEigenvectors: true)
+                let v = try #require(e.eigenvectors, "\(name) n=\(n): vectors missing")
+
+                #expect(LA.orthoDefect(v, rows: n, columns: n) < 1e-4, "\(name) n=\(n): VᵀV ≠ I")
+
+                for j in 1..<n {
+                    #expect(e.eigenvalues[j - 1] <= e.eigenvalues[j] + 1e-6,
+                            "\(name) n=\(n): eigenvalues not ascending")
+                }
+
+                // residual max |AV − VΛ|
+                let av = LA.matmul(a, v, m: n, k: n, n: n)
+                var worst: Float = 0
+                for j in 0..<n {
+                    for i in 0..<n {
+                        worst = max(worst, abs(av[j * n + i] - v[j * n + i] * e.eigenvalues[j]))
+                    }
+                }
+                #expect(worst < 1e-3, "\(name) n=\(n): |AV − VΛ| = \(worst)")
+            }
+        }
+    }
+
+    @Test("Only the lower triangle is read (uplo='L' contract)")
+    func lowerTriangleContract() throws {
+        let n = 8
+        let a = LA.symmetric(seed: 99, n)
+        var poisoned = a
+        for j in 0..<n {
+            for i in 0..<j { poisoned[j * n + i] = 999 }   // strict upper, col-major
+        }
+        for (name, p) in LA.providers {
+            let clean = try p.symmetricEigen(a, dimension: n, computeEigenvectors: false)
+            let dirty = try p.symmetricEigen(poisoned, dimension: n, computeEigenvectors: false)
+            #expect(LA.maxAbsDiff(clean.eigenvalues, dirty.eigenvalues) < 1e-5,
+                    "\(name): upper triangle leaked into result")
+        }
+    }
+
+    @Test("computeEigenvectors: false returns nil vectors")
+    func valuesOnly() throws {
+        for (_, p) in LA.providers {
+            let e = try p.symmetricEigen(LA.symmetric(seed: 3, 6), dimension: 6, computeEigenvectors: false)
+            #expect(e.eigenvectors == nil)
+            #expect(e.eigenvalues.count == 6)
+        }
+    }
+}
+
+// MARK: - SVD
+
+@Suite("LinearAlgebra - SVD")
+struct SVDThinSuite {
+
+    @Test("Reconstruction + orthonormality across shapes (incl. wide)")
+    func svdInvariants() throws {
+        for (name, p) in LA.providers {
+            for (m, n) in [(8, 8), (30, 10), (10, 30), (5, 1), (1, 5)] {
+                let k = min(m, n)
+                let a = LA.matrix(seed: UInt64(m * 131 + n), m, n)
+                let d = try p.svdThin(a, rows: m, columns: n)
+
+                #expect(d.u.count == m * k && d.vt.count == k * n && d.singularValues.count == k,
+                        "\(name) \(m)x\(n): factor shapes")
+
+                for j in 1..<k {
+                    #expect(d.singularValues[j - 1] >= d.singularValues[j] - 1e-6,
+                            "\(name) \(m)x\(n): singular values not descending")
+                }
+                #expect(d.singularValues.allSatisfy { $0 >= 0 }, "\(name) \(m)x\(n): negative σ")
+
+                #expect(LA.orthoDefect(d.u, rows: m, columns: k) < 1e-4, "\(name) \(m)x\(n): UᵀU ≠ I")
+                // Vᵀ has orthonormal ROWS ⇒ V = (Vᵀ)ᵀ has orthonormal columns;
+                // check via Vᵀ·V structure using matmul on (k×n)(n×k).
+                var v = [Float](repeating: 0, count: n * k)
+                for j in 0..<n {
+                    for i in 0..<k { v[i * n + j] = d.vt[j * k + i] }
+                }
+                #expect(LA.orthoDefect(v, rows: n, columns: k) < 1e-4, "\(name) \(m)x\(n): VVᵀ ≠ I")
+
+                // U · diag(σ) · Vᵀ = A
+                var us = d.u
+                for j in 0..<k {
+                    for i in 0..<m { us[j * m + i] *= d.singularValues[j] }
+                }
+                let recon = LA.matmul(us, d.vt, m: m, k: k, n: n)
+                #expect(LA.maxAbsDiff(recon, a) < 1e-3, "\(name) \(m)x\(n): UΣVᵀ ≠ A")
+            }
+        }
+    }
+
+    @Test("Known diagonal: σ(diag(3,2)) padded = {3, 2}")
+    func knownSingularValues() throws {
+        // 4×2 column-major: columns [3,0,0,0], [0,2,0,0]
+        let a: [Float] = [3, 0, 0, 0,   0, 2, 0, 0]
+        for (name, p) in LA.providers {
+            let d = try p.svdThin(a, rows: 4, columns: 2)
+            #expect(abs(d.singularValues[0] - 3) < 1e-5, "\(name): σ₀")
+            #expect(abs(d.singularValues[1] - 2) < 1e-5, "\(name): σ₁")
+        }
+    }
+}
+
+// MARK: - Cross-provider parity + integration
+
+@Suite("LinearAlgebra - Parity & Integration")
+struct LinearAlgebraParitySuite {
+
+    @Test("LAPACK and Swift fallback agree on spectra (sign-free quantities)")
+    func parity() throws {
+        guard LAPACKLinearAlgebraProvider.isAvailable else { return }
+        let lapack = LAPACKLinearAlgebraProvider()
+        let swift = SwiftLinearAlgebraProvider()
+
+        let (m, n) = (40, 12)
+        let a = LA.matrix(seed: 2026, m, n)
+        let sL = try lapack.svdThin(a, rows: m, columns: n).singularValues
+        let sS = try swift.svdThin(a, rows: m, columns: n).singularValues
+        #expect(LA.maxAbsDiff(sL, sS) < 5e-4, "singular value parity: \(LA.maxAbsDiff(sL, sS))")
+
+        let sym = LA.symmetric(seed: 2027, 24)
+        let wL = try lapack.symmetricEigen(sym, dimension: 24, computeEigenvectors: false).eigenvalues
+        let wS = try swift.symmetricEigen(sym, dimension: 24, computeEigenvectors: false).eigenvalues
+        #expect(LA.maxAbsDiff(wL, wS) < 5e-4, "eigenvalue parity: \(LA.maxAbsDiff(wL, wS))")
+    }
+
+    @Test("Operations.linearAlgebraProvider default works and is overridable")
+    func taskLocalSeam() async throws {
+        // Default provider resolves and factors.
+        let a = LA.matrix(seed: 5, 6, 3)
+        let f = try Operations.linearAlgebraProvider.qrThin(a, rows: 6, columns: 3)
+        #expect(f.q.count == 18)
+
+        // Per-scope override, mirroring the simdProvider TaskLocal pattern.
+        try await Operations.$linearAlgebraProvider.withValue(SwiftLinearAlgebraProvider()) {
+            #expect(Operations.linearAlgebraProvider is SwiftLinearAlgebraProvider)
+            let g = try Operations.linearAlgebraProvider.qrThin(a, rows: 6, columns: 3)
+            #expect(LA.orthoDefect(g.q, rows: 6, columns: 3) < 1e-4)
+        }
+    }
+}

--- a/Tests/ComprehensiveTests/LinearAlgebraProviderTests.swift
+++ b/Tests/ComprehensiveTests/LinearAlgebraProviderTests.swift
@@ -66,6 +66,19 @@ private enum LA {
         zip(a, b).reduce(0) { Swift.max($0, abs($1.0 - $1.1)) }
     }
 
+    /// Runs `body`, returning the thrown VectorError kind (nil = didn't
+    /// throw / wrong error type) — lets tests pin the exact error contract.
+    static func thrownKind(_ body: () throws -> Void) -> VectorError.ErrorKind? {
+        do {
+            try body()
+            return nil
+        } catch let error as VectorError {
+            return error.kind
+        } catch {
+            return nil
+        }
+    }
+
     /// max |GᵀG − I| over a column-major m×n G — orthonormality defect.
     static func orthoDefect(_ g: [Float], rows m: Int, columns n: Int) -> Float {
         var worst: Float = 0
@@ -133,21 +146,19 @@ struct QRThinSuite {
         }
     }
 
-    @Test("Wide matrix (m < n) throws invalidOperation")
+    @Test("Wide matrix (m < n) throws .invalidOperation")
     func qrWideThrows() {
-        for (_, p) in LA.providers {
-            #expect(throws: VectorError.self) {
-                _ = try p.qrThin(LA.matrix(seed: 1, 3, 5), rows: 3, columns: 5)
-            }
+        for (name, p) in LA.providers {
+            #expect(LA.thrownKind { _ = try p.qrThin(LA.matrix(seed: 1, 3, 5), rows: 3, columns: 5) }
+                == .invalidOperation, "\(name)")
         }
     }
 
-    @Test("Element-count mismatch throws")
+    @Test("Element-count mismatch throws .dimensionMismatch")
     func qrShapeMismatchThrows() {
-        for (_, p) in LA.providers {
-            #expect(throws: VectorError.self) {
-                _ = try p.qrThin([1, 2, 3], rows: 4, columns: 2)
-            }
+        for (name, p) in LA.providers {
+            #expect(LA.thrownKind { _ = try p.qrThin([1, 2, 3], rows: 4, columns: 2) }
+                == .dimensionMismatch, "\(name)")
         }
     }
 }
@@ -273,6 +284,22 @@ struct SVDThinSuite {
             #expect(abs(d.singularValues[1] - 2) < 1e-5, "\(name): σ₁")
         }
     }
+
+    @Test("Error contract: shape mismatch and bad dimensions")
+    func svdErrorPaths() {
+        for (name, p) in LA.providers {
+            #expect(LA.thrownKind { _ = try p.svdThin([1, 2, 3], rows: 2, columns: 2) }
+                == .dimensionMismatch, "\(name): count mismatch")
+            #expect(LA.thrownKind { _ = try p.svdThin([], rows: 0, columns: 3) }
+                == .invalidDimension, "\(name): zero rows")
+            #expect(LA.thrownKind {
+                _ = try p.symmetricEigen([1, 2, 3], dimension: 2, computeEigenvectors: false)
+            } == .dimensionMismatch, "\(name): eigen count mismatch")
+            #expect(LA.thrownKind {
+                _ = try p.symmetricEigen([], dimension: -1, computeEigenvectors: false)
+            } == .invalidDimension, "\(name): eigen bad dimension")
+        }
+    }
 }
 
 // MARK: - Cross-provider parity + integration
@@ -280,9 +307,9 @@ struct SVDThinSuite {
 @Suite("LinearAlgebra - Parity & Integration")
 struct LinearAlgebraParitySuite {
 
-    @Test("LAPACK and Swift fallback agree on spectra (sign-free quantities)")
+    @Test("LAPACK and Swift fallback agree on spectra (sign-free quantities)",
+          .enabled(if: LAPACKLinearAlgebraProvider.isAvailable))
     func parity() throws {
-        guard LAPACKLinearAlgebraProvider.isAvailable else { return }
         let lapack = LAPACKLinearAlgebraProvider()
         let swift = SwiftLinearAlgebraProvider()
 
@@ -300,6 +327,13 @@ struct LinearAlgebraParitySuite {
 
     @Test("Operations.linearAlgebraProvider default works and is overridable")
     func taskLocalSeam() async throws {
+        // Platform-expected default (so the override below is non-vacuous).
+        #if canImport(Accelerate)
+        #expect(Operations.linearAlgebraProvider is LAPACKLinearAlgebraProvider)
+        #else
+        #expect(Operations.linearAlgebraProvider is SwiftLinearAlgebraProvider)
+        #endif
+
         // Default provider resolves and factors.
         let a = LA.matrix(seed: 5, 6, 3)
         let f = try Operations.linearAlgebraProvider.qrThin(a, rows: 6, columns: 3)

--- a/Tests/ComprehensiveTests/PCATests.swift
+++ b/Tests/ComprehensiveTests/PCATests.swift
@@ -1,0 +1,288 @@
+//
+//  PCATests.swift
+//  VectorCore
+//
+//  Correctness tests for PCAModel / Operations.pca (randomized SVD, gap
+//  report §3.1) against the LinearAlgebraProvider seam.
+//
+//  Strategy: every spectral claim is checked against an independent exact
+//  computation — symmetricEigen of the explicitly assembled sample
+//  covariance — never against PCA's own outputs. Sign conventions ARE
+//  pinned by PCAModel (largest-|coordinate| positive), so component
+//  comparisons use |cosine| only where the reference's signs are free.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+// MARK: - Fixtures & helpers
+
+private enum PCAFixtures {
+    /// Deterministic anisotropic Gaussian sample: x = diag(scales)·z with
+    /// z ~ N(0, I), plus a constant offset so centering is actually tested.
+    static func sample(seed: UInt64, count n: Int, scales: [Float], offset: Float = 3) -> [DynamicVector] {
+        var gaussian = GaussianSource(seed: seed)
+        let d = scales.count
+        return (0..<n).map { _ in
+            var values = [Float](repeating: 0, count: d)
+            for j in 0..<d { values[j] = scales[j] * gaussian.next() + offset }
+            return DynamicVector(values)
+        }
+    }
+
+    /// Sample covariance C = XcᵀXc/(n−1), d×d column-major, built directly
+    /// from definition (independent of LAMatMul and the PCA code paths).
+    static func covariance(_ vectors: [DynamicVector]) -> (matrix: [Float], mean: [Float]) {
+        let n = vectors.count
+        let d = vectors[0].scalarCount
+        var mean = [Float](repeating: 0, count: d)
+        for v in vectors {
+            for j in 0..<d { mean[j] += v[j] }
+        }
+        for j in 0..<d { mean[j] /= Float(n) }
+        var cov = [Float](repeating: 0, count: d * d)
+        for v in vectors {
+            for j in 0..<d {
+                let dj = v[j] - mean[j]
+                for i in 0..<d {
+                    cov[j * d + i] += (v[i] - mean[i]) * dj
+                }
+            }
+        }
+        for idx in 0..<(d * d) { cov[idx] /= Float(n - 1) }
+        return (cov, mean)
+    }
+
+    /// Top-k eigenpairs of the sample covariance (exact, via the seam),
+    /// descending. Columns of `vectors` are the reference principal axes.
+    static func referenceEigen(_ vectors: [DynamicVector], k: Int) throws -> (values: [Float], axes: [[Float]]) {
+        let d = vectors[0].scalarCount
+        let cov = covariance(vectors).matrix
+        let eigen = try Operations.linearAlgebraProvider.symmetricEigen(
+            cov, dimension: d, computeEigenvectors: true)
+        let vecs = try #require(eigen.eigenvectors)
+        // ssyevd convention: ascending — take the tail, reversed.
+        var values = [Float]()
+        var axes = [[Float]]()
+        for r in 0..<k {
+            let column = d - 1 - r
+            values.append(eigen.eigenvalues[column])
+            axes.append((0..<d).map { vecs[column * d + $0] })
+        }
+        return (values, axes)
+    }
+
+    static func dot(_ a: [Float], _ b: [Float]) -> Float {
+        zip(a, b).reduce(0) { $0 + $1.0 * $1.1 }
+    }
+
+    static func componentRow(_ model: PCAModel, _ r: Int) -> [Float] {
+        let d = model.inputDimension
+        return Array(model.components[(r * d)..<((r + 1) * d)])
+    }
+}
+
+// MARK: - Spectral correctness
+
+@Suite("PCA - Spectral correctness")
+struct PCASpectralSuite {
+
+    @Test("Exact path (sketch ≥ min(n,d)) matches covariance eigendecomposition")
+    func exactPathMatchesEigen() throws {
+        // d=8, k=3, p=8 → sketch 11 ≥ 8 forces the exact-SVD path.
+        let scales: [Float] = [10, 7, 5, 1, 0.6, 0.4, 0.25, 0.1]
+        let data = PCAFixtures.sample(seed: 11, count: 240, scales: scales)
+        let model = try PCAModel.fit(data, components: 3)
+        let reference = try PCAFixtures.referenceEigen(data, k: 3)
+
+        for r in 0..<3 {
+            let relativeError = abs(model.explainedVariance[r] - reference.values[r])
+                / reference.values[r]
+            #expect(relativeError < 1e-3, "λ\(r): \(model.explainedVariance[r]) vs \(reference.values[r])")
+            let alignment = abs(PCAFixtures.dot(PCAFixtures.componentRow(model, r), reference.axes[r]))
+            #expect(alignment > 0.999, "axis \(r) misaligned: |cos| = \(alignment)")
+        }
+    }
+
+    @Test("Randomized path matches covariance eigendecomposition on a decaying spectrum")
+    func randomizedPathMatchesEigen() throws {
+        // d=24, k=4, p=4 → sketch 8 < 24 exercises the genuine sketch path.
+        var scales = [Float](repeating: 0.2, count: 24)
+        scales.replaceSubrange(0..<6, with: [12, 9, 6, 4, 0.9, 0.5])
+        let data = PCAFixtures.sample(seed: 17, count: 400, scales: scales)
+        let model = try PCAModel.fit(
+            data, components: 4,
+            config: PCAConfig(oversampling: 4, powerIterations: 2))
+        let reference = try PCAFixtures.referenceEigen(data, k: 4)
+
+        for r in 0..<4 {
+            let relativeError = abs(model.explainedVariance[r] - reference.values[r])
+                / reference.values[r]
+            #expect(relativeError < 0.01, "λ\(r): \(model.explainedVariance[r]) vs \(reference.values[r])")
+            let alignment = abs(PCAFixtures.dot(PCAFixtures.componentRow(model, r), reference.axes[r]))
+            #expect(alignment > 0.99, "axis \(r) misaligned: |cos| = \(alignment)")
+        }
+    }
+
+    @Test("Model invariants: orthonormal rows, descending variance, sane ratios, signs")
+    func modelInvariants() throws {
+        let scales: [Float] = [8, 5, 3, 2, 1.5, 1, 0.7, 0.5, 0.3, 0.2, 0.1, 0.05]
+        let data = PCAFixtures.sample(seed: 23, count: 300, scales: scales)
+        let model = try PCAModel.fit(data, components: 5)
+        let d = model.inputDimension
+
+        for r in 0..<5 {
+            let row = PCAFixtures.componentRow(model, r)
+            for s in r..<5 {
+                let gram = PCAFixtures.dot(row, PCAFixtures.componentRow(model, s))
+                let expected: Float = r == s ? 1 : 0
+                #expect(abs(gram - expected) < 1e-4, "WWᵀ[\(r),\(s)] = \(gram)")
+            }
+            // Pinned sign convention: largest-|coordinate| entry is positive.
+            var maxAbs: Float = -1
+            var signed: Float = 0
+            for j in 0..<d where abs(row[j]) > maxAbs {
+                maxAbs = abs(row[j])
+                signed = row[j]
+            }
+            #expect(signed > 0, "row \(r) violates the sign convention")
+        }
+        for r in 1..<5 {
+            #expect(model.explainedVariance[r] <= model.explainedVariance[r - 1])
+        }
+        let ratioSum = model.explainedVarianceRatio.reduce(0, +)
+        #expect(ratioSum > 0 && ratioSum <= 1 + 1e-4)
+        for r in 0..<5 { #expect(model.explainedVarianceRatio[r] > 0) }
+        #expect(model.mean.count == d)
+        // Check the offset on the lowest-noise dimension (σ = 0.05): the
+        // sample mean's standard error there is 0.05/√300 ≈ 0.003.
+        #expect(abs(model.mean[11] - 3) < 0.05, "offset 3 should appear in the mean")
+    }
+
+    @Test("Full-rank fit reconstructs the data (projection loses nothing at k = d)")
+    func fullRankReconstruction() throws {
+        let scales: [Float] = [4, 3, 2, 1, 0.5, 0.25]
+        let data = PCAFixtures.sample(seed: 29, count: 100, scales: scales)
+        let model = try PCAModel.fit(data, components: 6)
+        let projected = try model.transform(data)
+
+        for (vector, y) in zip(data, projected) {
+            let d = model.inputDimension
+            for j in 0..<d {
+                // x̂ = μ + Wᵀy
+                var reconstructed = model.mean[j]
+                for r in 0..<model.componentCount {
+                    reconstructed += model.components[r * d + j] * y[r]
+                }
+                #expect(abs(reconstructed - vector[j]) < 1e-3)
+            }
+        }
+    }
+}
+
+// MARK: - GEMM parity
+
+@Suite("PCA - GEMM parity")
+struct LAMatMulParitySuite {
+
+    /// The pure-Swift GEMM is the live path on non-Accelerate platforms but
+    /// dead code on Apple CI — pin it against the cblas path here, across
+    /// all four transpose combinations and non-square shapes.
+    @Test("Swift GEMM matches the platform GEMM for all transpose modes")
+    func swiftKernelMatchesPlatform() {
+        var gaussian = GaussianSource(seed: 53)
+        let (m, n, k) = (7, 5, 9)
+        for (transposeA, transposeB) in [(false, false), (true, false), (false, true), (true, true)] {
+            let a = gaussian.matrix(count: m * k)
+            let b = gaussian.matrix(count: k * n)
+            let platform = LAMatMul.multiply(
+                a, b, m: m, n: n, k: k, transposeA: transposeA, transposeB: transposeB)
+            let swift = LAMatMul.multiplySwift(
+                a, b, m: m, n: n, k: k, transposeA: transposeA, transposeB: transposeB)
+            for (x, y) in zip(platform, swift) {
+                #expect(abs(x - y) < 1e-4, "tA=\(transposeA) tB=\(transposeB)")
+            }
+        }
+    }
+}
+
+// MARK: - API behavior
+
+@Suite("PCA - API behavior")
+struct PCABehaviorSuite {
+
+    @Test("Operations.pca one-shot == fit then transform; single == batch")
+    func oneShotAndSingleConsistency() throws {
+        let scales: [Float] = [6, 4, 2, 1, 0.5, 0.3, 0.2, 0.1]
+        let data = PCAFixtures.sample(seed: 31, count: 150, scales: scales)
+
+        let (projected, model) = try Operations.pca(data, components: 3)
+        let viaModel = try PCAModel.fit(data, components: 3).transform(data)
+        #expect(projected == viaModel)
+
+        for i in [0, 7, 149] {
+            let single = try model.transform(data[i].toArray())
+            for r in 0..<3 {
+                #expect(abs(single[r] - projected[i][r]) < 1e-4)
+            }
+        }
+    }
+
+    @Test("Same seed reproduces the model exactly; providers agree on spectra")
+    func determinismAndProviderParity() throws {
+        var scales = [Float](repeating: 0.3, count: 20)
+        scales.replaceSubrange(0..<4, with: [9, 6, 3, 1.5])
+        let data = PCAFixtures.sample(seed: 37, count: 250, scales: scales)
+        let config = PCAConfig(oversampling: 4, powerIterations: 2, seed: 99)
+
+        let first = try PCAModel.fit(data, components: 3, config: config)
+        let second = try PCAModel.fit(data, components: 3, config: config)
+        #expect(first.components == second.components)
+        #expect(first.explainedVariance == second.explainedVariance)
+
+        let swiftModel = try Operations.$linearAlgebraProvider.withValue(SwiftLinearAlgebraProvider()) {
+            try PCAModel.fit(data, components: 3, config: config)
+        }
+        for r in 0..<3 {
+            let difference = abs(first.explainedVariance[r] - swiftModel.explainedVariance[r])
+            #expect(difference < 5e-3, "provider spectra diverge at λ\(r): \(difference)")
+            let alignment = abs(PCAFixtures.dot(
+                PCAFixtures.componentRow(first, r), PCAFixtures.componentRow(swiftModel, r)))
+            #expect(alignment > 0.999, "provider axes diverge at \(r): |cos| = \(alignment)")
+        }
+    }
+
+    @Test("center: false skips the mean and reports raw second moments")
+    func uncenteredFit() throws {
+        let scales: [Float] = [5, 2, 1, 0.5]
+        let data = PCAFixtures.sample(seed: 41, count: 120, scales: scales, offset: 10)
+        let model = try PCAModel.fit(
+            data, components: 2, config: PCAConfig(center: false))
+        #expect(model.mean.allSatisfy { $0 == 0 })
+        // With a +10 offset on every dimension the dominant uncentered
+        // direction is the offset itself, far above any scaled axis.
+        #expect(model.explainedVariance[0] > 50)
+    }
+
+    @Test("Error contracts: bad k, ragged input, tiny n, transform mismatch, bad config")
+    func errorContracts() throws {
+        let data = PCAFixtures.sample(seed: 43, count: 10, scales: [1, 1, 1, 1])
+
+        #expect(throws: VectorError.self) { try PCAModel.fit(data, components: 0) }
+        #expect(throws: VectorError.self) { try PCAModel.fit(data, components: 5) }   // k > d
+        let small = Array(data.prefix(3))
+        #expect(throws: VectorError.self) { try PCAModel.fit(small, components: 3) }  // k > n−1 = 2
+        #expect(throws: VectorError.self) { try PCAModel.fit([data[0]], components: 1) } // n < 2
+
+        var ragged = data
+        ragged[3] = DynamicVector([1, 2, 3])
+        #expect(throws: VectorError.self) { try PCAModel.fit(ragged, components: 2) }
+
+        let model = try PCAModel.fit(data, components: 2)
+        #expect(throws: VectorError.self) { try model.transform([1, 2, 3]) }
+        #expect(throws: VectorError.self) {
+            try PCAModel.fit(data, components: 2, config: PCAConfig(oversampling: -1))
+        }
+    }
+}

--- a/Tests/ComprehensiveTests/UMAPTests.swift
+++ b/Tests/ComprehensiveTests/UMAPTests.swift
@@ -1,0 +1,504 @@
+//
+//  UMAPTests.swift
+//  VectorCore
+//
+//  Correctness tests for the UMAP stack (gap report §3.3): the KNNGraph
+//  CSR contract and exact brute-force builder, the fuzzy simplicial set
+//  (ρ/σ smooth-kNN search, t-conorm symmetrization), the output-kernel
+//  curve fit, and the SGD layout.
+//
+//  Strategy: structural pieces are checked against hand-computed values on
+//  tiny graphs (the σ search against the closed-form solution of its own
+//  defining equation, the curve fit against umap-learn's published
+//  constants for the default config); the end-to-end layout is checked by
+//  geometry — well-separated clusters in ambient space must stay separated
+//  in the embedding — plus exact determinism under a fixed seed.
+//
+
+import Testing
+import Foundation
+@testable import VectorCore
+
+// MARK: - Fixtures & helpers
+
+private enum UMAPFixtures {
+    /// Two isotropic Gaussian blobs in d dims: points [0, half) sit at the
+    /// origin, points [half, 2·half) are offset by `separation` along
+    /// dimension 0. Deterministic for a given seed.
+    static func clusters(
+        seed: UInt64, half: Int, dimensions d: Int, separation: Float, scale: Float
+    ) -> [DynamicVector] {
+        var gaussian = GaussianSource(seed: seed)
+        return (0..<(2 * half)).map { i in
+            var values = [Float](repeating: 0, count: d)
+            for j in 0..<d { values[j] = scale * gaussian.next() }
+            if i >= half { values[0] += separation }
+            return DynamicVector(values)
+        }
+    }
+
+    /// Inter-centroid distance over the larger mean within-cluster radius —
+    /// the embedding-space "how separated did the clusters stay" score.
+    static func separationRatio(_ result: UMAPResult, half: Int) -> Float {
+        let m = result.dimension
+        var centroidA = [Float](repeating: 0, count: m)
+        var centroidB = [Float](repeating: 0, count: m)
+        for i in 0..<half {
+            for c in 0..<m {
+                centroidA[c] += result.coordinates[i * m + c]
+                centroidB[c] += result.coordinates[(half + i) * m + c]
+            }
+        }
+        for c in 0..<m {
+            centroidA[c] /= Float(half)
+            centroidB[c] /= Float(half)
+        }
+        func radius(_ start: Int, _ centroid: [Float]) -> Float {
+            var total: Float = 0
+            for i in start..<(start + half) {
+                var squared: Float = 0
+                for c in 0..<m {
+                    let diff = result.coordinates[i * m + c] - centroid[c]
+                    squared += diff * diff
+                }
+                total += squared.squareRoot()
+            }
+            return total / Float(half)
+        }
+        var betweenSquared: Float = 0
+        for c in 0..<m {
+            let diff = centroidA[c] - centroidB[c]
+            betweenSquared += diff * diff
+        }
+        let spread = max(radius(0, centroidA), radius(half, centroidB))
+        return betweenSquared.squareRoot() / max(spread, .leastNormalMagnitude)
+    }
+
+    /// Direct-from-definition exact kNN (per-pair distances, full sort) —
+    /// the reference for `KNNGraph.bruteForce`'s Gram-trick path.
+    static func naiveNeighbors(
+        _ data: [DynamicVector], k: Int
+    ) -> [[(index: Int, distance: Float)]] {
+        let n = data.count
+        let d = data[0].scalarCount
+        return (0..<n).map { i in
+            var candidates: [(index: Int, distance: Float)] = []
+            for j in 0..<n where j != i {
+                var squared: Float = 0
+                for c in 0..<d {
+                    let diff = data[i][c] - data[j][c]
+                    squared += diff * diff
+                }
+                candidates.append((j, squared.squareRoot()))
+            }
+            candidates.sort { ($0.distance, $0.index) < ($1.distance, $1.index) }
+            return Array(candidates.prefix(k))
+        }
+    }
+
+    static func edgeKey(_ head: Int32, _ tail: Int32) -> UInt64 {
+        UInt64(UInt32(bitPattern: head)) << 32 | UInt64(UInt32(bitPattern: tail))
+    }
+
+    static func weightMap(_ edges: UMAPEdgeList) -> [UInt64: Float] {
+        var map: [UInt64: Float] = [:]
+        for e in 0..<edges.count {
+            map[edgeKey(edges.heads[e], edges.tails[e])] = edges.weights[e]
+        }
+        return map
+    }
+
+    /// Four collinear points at x = 0, 1, 2, 4 with their exact 2-NN graph,
+    /// small enough that every ρ, σ, and fused weight is hand-checkable.
+    static func handGraph() throws -> KNNGraph {
+        try KNNGraph(
+            pointCount: 4,
+            rowOffsets: [0, 2, 4, 6, 8],
+            neighborIndices: [1, 2, 0, 2, 1, 3, 2, 1],
+            distances: [1, 2, 1, 1, 1, 2, 2, 3])
+    }
+}
+
+// MARK: - Curve fit
+
+@Suite("UMAP - Curve fit")
+struct UMAPCurveFitSuite {
+
+    @Test("Default (minDist 0.1, spread 1.0) reproduces umap-learn's a, b")
+    func defaultParameters() {
+        // Reference values from umap-learn's find_ab_params on the same
+        // 300-point grid: a ≈ 1.57694, b ≈ 0.89506.
+        let (a, b) = UMAPLayout.fitABParams(spread: 1.0, minDist: 0.1)
+        #expect(abs(a - 1.57694) < 0.02, "a = \(a)")
+        #expect(abs(b - 0.89506) < 0.01, "b = \(b)")
+    }
+
+    @Test("Fitted kernel respects the plateau and the tail for other configs")
+    func fitQuality() {
+        for (minDist, spread) in [(Float(0), Float(1)), (0.5, 1.5), (0.25, 0.7)] {
+            let (a, b) = UMAPLayout.fitABParams(spread: spread, minDist: minDist)
+            #expect(a > 0 && b > 0)
+            func kernel(_ x: Float) -> Float {
+                x > 0 ? 1 / (1 + a * Foundation.pow(x, 2 * b)) : 1
+            }
+            // Plateau: still near 1 at the minimum distance.
+            #expect(kernel(minDist) > 0.8, "minDist=\(minDist) spread=\(spread)")
+            // Tail: mostly decayed at the grid edge.
+            #expect(kernel(3 * spread) < 0.2, "minDist=\(minDist) spread=\(spread)")
+            // Monotone decreasing on the fit grid.
+            var previous = kernel(0)
+            for s in 1...30 {
+                let value = kernel(3 * spread * Float(s) / 30)
+                #expect(value <= previous + 1e-6)
+                previous = value
+            }
+        }
+    }
+}
+
+// MARK: - KNNGraph
+
+@Suite("UMAP - KNNGraph")
+struct KNNGraphSuite {
+
+    @Test("Brute force matches direct-from-definition kNN")
+    func bruteForceMatchesNaive() throws {
+        let data = UMAPFixtures.clusters(seed: 61, half: 20, dimensions: 6, separation: 4, scale: 1)
+        let k = 5
+        let graph = try KNNGraph.bruteForce(data, neighbors: k)
+        let reference = UMAPFixtures.naiveNeighbors(data, k: k)
+
+        #expect(graph.pointCount == 40)
+        #expect(graph.edgeCount == 40 * k)
+        for i in 0..<40 {
+            let range = graph.neighborRange(of: i)
+            #expect(range.count == k)
+            let got = Set(range.map { Int(graph.neighborIndices[$0]) })
+            let expected = Set(reference[i].map(\.index))
+            #expect(got == expected, "row \(i): \(got) vs \(expected)")
+            // Distances ascending and matching the direct computation.
+            for (offset, idx) in range.enumerated() {
+                #expect(abs(graph.distances[idx] - reference[i][offset].distance) < 2e-3)
+                if idx > range.lowerBound {
+                    #expect(graph.distances[idx] >= graph.distances[idx - 1])
+                }
+            }
+        }
+    }
+
+    @Test("CSR validation rejects malformed graphs")
+    func csrValidation() throws {
+        // Baseline that should construct fine.
+        _ = try KNNGraph(
+            pointCount: 3, rowOffsets: [0, 1, 2, 2],
+            neighborIndices: [1, 0], distances: [1, 1])
+
+        #expect(throws: VectorError.self) { // offsets wrong length
+            try KNNGraph(pointCount: 3, rowOffsets: [0, 1, 2],
+                         neighborIndices: [1, 0], distances: [1, 1])
+        }
+        #expect(throws: VectorError.self) { // offsets do not start at 0
+            try KNNGraph(pointCount: 2, rowOffsets: [1, 1, 2],
+                         neighborIndices: [1, 0], distances: [1, 1])
+        }
+        #expect(throws: VectorError.self) { // decreasing offsets
+            try KNNGraph(pointCount: 2, rowOffsets: [0, 2, 1],
+                         neighborIndices: [1, 0], distances: [1, 1])
+        }
+        #expect(throws: VectorError.self) { // offsets end != nnz
+            try KNNGraph(pointCount: 2, rowOffsets: [0, 1, 1],
+                         neighborIndices: [1, 0], distances: [1, 1])
+        }
+        #expect(throws: VectorError.self) { // index out of range
+            try KNNGraph(pointCount: 2, rowOffsets: [0, 1, 2],
+                         neighborIndices: [2, 0], distances: [1, 1])
+        }
+        #expect(throws: VectorError.self) { // self-loop
+            try KNNGraph(pointCount: 2, rowOffsets: [0, 1, 2],
+                         neighborIndices: [0, 0], distances: [1, 1])
+        }
+        #expect(throws: VectorError.self) { // negative distance
+            try KNNGraph(pointCount: 2, rowOffsets: [0, 1, 2],
+                         neighborIndices: [1, 0], distances: [-1, 1])
+        }
+        #expect(throws: VectorError.self) { // non-finite distance
+            try KNNGraph(pointCount: 2, rowOffsets: [0, 1, 2],
+                         neighborIndices: [1, 0], distances: [.infinity, 1])
+        }
+        #expect(throws: VectorError.self) { // arrays disagree in length
+            try KNNGraph(pointCount: 2, rowOffsets: [0, 1, 2],
+                         neighborIndices: [1, 0], distances: [1])
+        }
+    }
+
+    @Test("Brute-force contracts: tiny n, k out of range, ragged input")
+    func bruteForceContracts() throws {
+        let data = UMAPFixtures.clusters(seed: 67, half: 5, dimensions: 4, separation: 3, scale: 1)
+        #expect(throws: VectorError.self) {
+            try KNNGraph.bruteForce([data[0]], neighbors: 1)
+        }
+        #expect(throws: VectorError.self) {
+            try KNNGraph.bruteForce(data, neighbors: 0)
+        }
+        #expect(throws: VectorError.self) {
+            try KNNGraph.bruteForce(data, neighbors: 10) // k > n−1 = 9
+        }
+        var ragged = data
+        ragged[2] = DynamicVector([1, 2])
+        #expect(throws: VectorError.self) {
+            try KNNGraph.bruteForce(ragged, neighbors: 3)
+        }
+    }
+}
+
+// MARK: - Fuzzy simplicial set
+
+@Suite("UMAP - Fuzzy simplicial set")
+struct FuzzySimplicialSetSuite {
+
+    @Test("ρ and σ solve the smooth-kNN equation on a hand graph")
+    func smoothDistancesHandGraph() throws {
+        let graph = try UMAPFixtures.handGraph()
+        let (rho, sigma) = FuzzySimplicialSet.smoothDistances(graph)
+
+        // ρ is the nearest positive neighbor distance per row.
+        #expect(rho == [1, 1, 1, 2])
+
+        // Rows 0, 2, 3 share the same shifted-distance profile {0, 1}, so
+        // each σ solves 1 + exp(−1/σ) = log₂(3); closed form σ ≈ 1.86495.
+        let target = Float(Foundation.log2(3.0))
+        for i in [0, 2, 3] {
+            let psum = 1 + Foundation.exp(-1 / Double(sigma[i]))
+            #expect(abs(Float(psum) - target) < 1e-4, "row \(i): psum = \(psum)")
+            #expect(abs(sigma[i] - 1.86495) < 1e-3, "row \(i): σ = \(sigma[i])")
+        }
+        // Row 1's neighbors are both at d = ρ (psum is constantly 2 > the
+        // target), so the bisection collapses and the floor takes over:
+        // σ = 1e-3 × mean(1, 1).
+        #expect(abs(sigma[1] - 0.001) < 1e-6)
+    }
+
+    @Test("Memberships and t-conorm symmetrization on the hand graph")
+    func symmetrizationHandGraph() throws {
+        let graph = try UMAPFixtures.handGraph()
+        let edges = FuzzySimplicialSet.build(graph)
+        let weights = UMAPFixtures.weightMap(edges)
+
+        // 5 undirected pairs → 10 directed entries.
+        #expect(edges.count == 10)
+
+        // Every edge appears in both directions with the same weight.
+        for e in 0..<edges.count {
+            let reverse = weights[UMAPFixtures.edgeKey(edges.tails[e], edges.heads[e])]
+            #expect(reverse == edges.weights[e])
+            #expect(edges.weights[e] > 0 && edges.weights[e] <= 1)
+        }
+
+        // Hand-checked fused weights. exp(−1/σ) with σ ≈ 1.86495 is
+        // w ≈ 0.58496:
+        //   (0,1): 1 ∪ 1 = 1            (mutual nearest neighbors)
+        //   (1,2): 1 ∪ 1 = 1
+        //   (2,3): 0.58496 ∪ 1 = 1      (t-conorm with a certain edge)
+        //   (0,2): 0.58496 ∪ ∅ = 0.58496 (one-directional edge survives)
+        //   (1,3): ∅ ∪ 0.58496 = 0.58496
+        let w = Float(0.58496)
+        #expect(abs(weights[UMAPFixtures.edgeKey(0, 1)]! - 1) < 1e-4)
+        #expect(abs(weights[UMAPFixtures.edgeKey(1, 2)]! - 1) < 1e-4)
+        #expect(abs(weights[UMAPFixtures.edgeKey(2, 3)]! - 1) < 1e-4)
+        #expect(abs(weights[UMAPFixtures.edgeKey(0, 2)]! - w) < 1e-3)
+        #expect(abs(weights[UMAPFixtures.edgeKey(1, 3)]! - w) < 1e-3)
+        #expect(weights[UMAPFixtures.edgeKey(0, 3)] == nil, "0 and 3 are not kNN-adjacent")
+    }
+
+    @Test("Isolated rows contribute no edges and keep σ = 0")
+    func isolatedRow() throws {
+        let graph = try KNNGraph(
+            pointCount: 3, rowOffsets: [0, 1, 2, 2],
+            neighborIndices: [1, 0], distances: [1, 1])
+        let (rho, sigma) = FuzzySimplicialSet.smoothDistances(graph)
+        #expect(rho[2] == 0 && sigma[2] == 0)
+
+        let edges = FuzzySimplicialSet.build(graph)
+        #expect(edges.count == 2)
+        for e in 0..<edges.count {
+            #expect(edges.heads[e] != 2 && edges.tails[e] != 2)
+            #expect(edges.weights[e] == 1) // mutual NN at d == ρ
+        }
+    }
+
+    @Test("Symmetry and weight range hold on a real brute-force graph")
+    func symmetryOnRealGraph() throws {
+        let data = UMAPFixtures.clusters(seed: 71, half: 25, dimensions: 8, separation: 6, scale: 0.8)
+        let graph = try KNNGraph.bruteForce(data, neighbors: 6)
+        let edges = FuzzySimplicialSet.build(graph)
+        let weights = UMAPFixtures.weightMap(edges)
+
+        #expect(edges.count >= graph.edgeCount, "union can only add directions")
+        for e in 0..<edges.count {
+            #expect(edges.weights[e] > 0 && edges.weights[e] <= 1)
+            #expect(weights[UMAPFixtures.edgeKey(edges.tails[e], edges.heads[e])] == edges.weights[e])
+        }
+        // Every point's nearest neighbor edge has weight 1 (d == ρ ⇒
+        // membership 1): the t-conorm gives 1 + w − 1·w, which is exactly 1
+        // up to one Float rounding of the add/subtract pair.
+        for i in 0..<graph.pointCount {
+            let first = graph.neighborRange(of: i).lowerBound
+            let nearest = graph.neighborIndices[first]
+            let weight = weights[UMAPFixtures.edgeKey(Int32(i), nearest)] ?? 0
+            #expect(abs(weight - 1) < 1e-6, "point \(i) nearest-neighbor weight: \(weight)")
+        }
+    }
+}
+
+// MARK: - Layout
+
+@Suite("UMAP - Layout")
+struct UMAPLayoutSuite {
+
+    @Test("Well-separated clusters stay separated (PCA and random init)")
+    func clusterSeparation() throws {
+        let half = 60
+        let data = UMAPFixtures.clusters(seed: 73, half: half, dimensions: 10, separation: 12, scale: 0.5)
+
+        for initialization in [UMAPInitialization.pca, .random] {
+            let config = UMAPConfig(neighbors: 10, initialization: initialization)
+            let result = try Operations.umap(data, config: config)
+            #expect(result.pointCount == 2 * half)
+            #expect(result.dimension == 2)
+            #expect(result.coordinates.count == 2 * half * 2)
+            let allFinite = result.coordinates.allSatisfy { $0.isFinite }
+            #expect(allFinite)
+            let ratio = UMAPFixtures.separationRatio(result, half: half)
+            #expect(ratio > 2, "init \(initialization): separation ratio \(ratio)")
+        }
+    }
+
+    @Test("Same seed reproduces the layout exactly; a different seed does not")
+    func determinism() throws {
+        let data = UMAPFixtures.clusters(seed: 79, half: 30, dimensions: 8, separation: 8, scale: 0.6)
+        let config = UMAPConfig(neighbors: 8, epochs: 150)
+
+        let first = try Operations.umap(data, config: config)
+        let second = try Operations.umap(data, config: config)
+        #expect(first.coordinates == second.coordinates)
+
+        var reseeded = config
+        reseeded.seed = 1
+        let third = try Operations.umap(data, config: reseeded)
+        #expect(first.coordinates != third.coordinates)
+    }
+
+    @Test("Injected graph takes the same path as the internal brute force")
+    func graphInjectionEquivalence() throws {
+        let data = UMAPFixtures.clusters(seed: 83, half: 25, dimensions: 8, separation: 8, scale: 0.6)
+        let config = UMAPConfig(neighbors: 6, epochs: 100)
+        let graph = try KNNGraph.bruteForce(data, neighbors: config.neighbors)
+
+        let implicit = try Operations.umap(data, config: config)
+        let injected = try Operations.umap(data, graph: graph, config: config)
+        #expect(implicit.coordinates == injected.coordinates)
+    }
+
+    @Test("Graph-only entry point: custom initial coordinates and random fallback")
+    func graphEntryPoint() throws {
+        let data = UMAPFixtures.clusters(seed: 89, half: 25, dimensions: 8, separation: 8, scale: 0.6)
+        let config = UMAPConfig(neighbors: 6, epochs: 100)
+        let graph = try KNNGraph.bruteForce(data, neighbors: config.neighbors)
+
+        // PCA projection as explicit init — the corpus-scale composition.
+        let projected = try Operations.pca(data, components: 2).projected
+        let seeded = try Operations.umap(
+            graph: graph, initialCoordinates: projected, config: config)
+        let seededFinite = seeded.coordinates.allSatisfy { $0.isFinite }
+        #expect(seededFinite)
+        #expect(UMAPFixtures.separationRatio(seeded, half: 25) > 2)
+
+        // Random fallback is deterministic too.
+        let randomA = try Operations.umap(graph: graph, config: config)
+        let randomB = try Operations.umap(graph: graph, config: config)
+        #expect(randomA.coordinates == randomB.coordinates)
+    }
+}
+
+// MARK: - API behavior
+
+@Suite("UMAP - API behavior")
+struct UMAPBehaviorSuite {
+
+    @Test("Result accessors: point rows and the 2-D SIMD view")
+    func resultAccessors() throws {
+        let data = UMAPFixtures.clusters(seed: 97, half: 15, dimensions: 5, separation: 6, scale: 0.5)
+        let result = try Operations.umap(data, config: UMAPConfig(neighbors: 5, epochs: 50))
+
+        let points = try #require(result.points2D)
+        #expect(points.count == result.pointCount)
+        for i in [0, 7, result.pointCount - 1] {
+            let row = result.point(i)
+            #expect(row.count == 2)
+            #expect(row[0] == result.coordinates[2 * i] && row[1] == result.coordinates[2 * i + 1])
+            #expect(points[i] == SIMD2(row[0], row[1]))
+        }
+
+        let volume = try Operations.umap(
+            data, dimensions: 3, config: UMAPConfig(neighbors: 5, epochs: 50))
+        #expect(volume.points2D == nil)
+        #expect(volume.dimension == 3)
+        #expect(volume.coordinates.count == result.pointCount * 3)
+    }
+
+    @Test("Attraction-only runs (negativeSampleRate 0)")
+    func attractionOnly() throws {
+        let data = UMAPFixtures.clusters(seed: 101, half: 15, dimensions: 5, separation: 6, scale: 0.5)
+        let result = try Operations.umap(
+            data, config: UMAPConfig(neighbors: 5, epochs: 50, negativeSampleRate: 0))
+        let allFinite = result.coordinates.allSatisfy { $0.isFinite }
+        #expect(allFinite)
+    }
+
+    @Test("Error contracts: config, shapes, and initialization limits")
+    func errorContracts() throws {
+        let data = UMAPFixtures.clusters(seed: 103, half: 10, dimensions: 4, separation: 5, scale: 0.5)
+        let graph = try KNNGraph.bruteForce(data, neighbors: 4)
+
+        #expect(throws: VectorError.self) { // neighbors < 2
+            try Operations.umap(data, config: UMAPConfig(neighbors: 1))
+        }
+        #expect(throws: VectorError.self) { // minDist > spread
+            try Operations.umap(data, config: UMAPConfig(minDist: 2, spread: 1))
+        }
+        #expect(throws: VectorError.self) { // non-positive learning rate
+            try Operations.umap(data, config: UMAPConfig(learningRate: 0))
+        }
+        #expect(throws: VectorError.self) { // epochs < 1
+            try Operations.umap(data, config: UMAPConfig(epochs: 0))
+        }
+        #expect(throws: VectorError.self) { // negative sampling rate < 0
+            try Operations.umap(data, config: UMAPConfig(negativeSampleRate: -1))
+        }
+        #expect(throws: VectorError.self) { // output dimension < 1
+            try Operations.umap(data, dimensions: 0, config: UMAPConfig(neighbors: 4))
+        }
+        #expect(throws: VectorError.self) { // k > n−1 in the brute-force path
+            try Operations.umap(Array(data.prefix(8)), config: UMAPConfig(neighbors: 15))
+        }
+        #expect(throws: VectorError.self) { // graph size != vector count
+            try Operations.umap(Array(data.prefix(10)), graph: graph,
+                                config: UMAPConfig(neighbors: 4))
+        }
+        #expect(throws: VectorError.self) { // initial coordinate count != n
+            try Operations.umap(graph: graph,
+                                initialCoordinates: [[0, 0], [1, 1]],
+                                config: UMAPConfig(neighbors: 4))
+        }
+        #expect(throws: VectorError.self) { // ragged initial coordinates
+            var coords = [[Float]](repeating: [0, 0], count: graph.pointCount)
+            coords[3] = [1, 2, 3]
+            _ = try Operations.umap(graph: graph, initialCoordinates: coords,
+                                    config: UMAPConfig(neighbors: 4))
+        }
+        #expect(throws: VectorError.self) { // PCA init impossible: d < dimensions
+            let thin = (0..<20).map { DynamicVector([Float($0) * 0.1]) }
+            _ = try Operations.umap(thin, config: UMAPConfig(neighbors: 3))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements the VectorCore side of the HN semantic-search P0 band (`Docs/gap-analysis-hn-semantic-search.md`, §5 build order):

- **LAPACK enabler (§3.0)** — `LinearAlgebraProvider` seam (thin QR, thin SVD, symmetric eigen) over column-major `[Float]`; LAPACK-backed via a C shim (`ACCELERATE_NEW_LAPACK` through `cSettings`, no unsafeFlags, 32-bit LAPACK ints) with a pure-Swift fallback (Householder QR, cyclic Jacobi eigen, Hestenes SVD); selected via the `Operations.$linearAlgebraProvider` task-local.
- **PCA / randomized SVD (§3.1)** — Halko–Martinsson–Tropp sketch with QR-stabilized power iterations; `PCAModel.fit`/`transform` (fit on a sample, stream the corpus in batches) plus `Operations.pca` one-shot; seeded deterministic sketch, pinned sign convention; exact thin-SVD fallback when the sketch cannot be thinner than the data.
- **UMAP layout (§3.3)** — fuzzy simplicial set (smooth-kNN ρ/σ bisection against the log₂(k+1) target, probabilistic t-conorm union), output-kernel curve fit by Levenberg–Marquardt (reproduces umap-learn's a≈1.577, b≈0.895 defaults), and SGD with epoch-cadence edge sampling, negative sampling, ±4 gradient clip, linear anneal. Single-threaded and fully seeded: bit-for-bit reproducible. PCA initialization is the default per the gap report's scale correction (dense spectral init is not viable at 5M nodes).
- **Core-owned kNN contract (§3.2 boundary note)** — `KNNGraph` (validated CSR interchange struct) lives in Core; VectorIndex produces it at corpus scale, so data flows Index → Core and code never does. `KNNGraph.bruteForce` (blocked Gram-trick GEMM, O(n²·d)) keeps the full pipeline self-contained at sample/test scale. Zero new package dependencies.

## Verification
- Full suite: **1116 tests / 164 suites green** (main baseline: 1091 / 156); MinimalTests XCTest 59 executed / 0 failures.
- Spectral claims tested against an independent exact eigendecomposition on both the LAPACK and Swift providers; UMAP σ and t-conorm weights against hand-computed closed forms; brute-force kNN against direct-from-definition distances; curve fit against umap-learn's published constants; layout checked for exact same-seed determinism and cluster-separation geometry under both init paths.
- swiftlint: 0 violations in all touched files.

## Notes for review
- Column-major seam, C shim, and no-ILP64 are deliberate, documented decisions (see source headers).
- The `cblas_sgemm` deprecation warning matches pre-existing repo behavior (`MatrixDistance.swift`).
- The parallel (Hogwild/GPU) UMAP optimizer is intentionally deferred — the seeded single-threaded baseline is the reference; it's the natural future `ComputeProvider`/`BatchKernelProvider` candidate.
- Sibling follow-up (not this PR): VectorIndex grows an ANN-backed `KNNGraph` producer; a prompt for that agent has been prepared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)