### PR TITLE
chore: release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to VectorCore will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-06-11
+
+The projection stack from the HN semantic-search gap analysis (the P0 band):
+dense linear algebra, PCA, and UMAP land in Core, plus the Core-owned
+kNN-graph interchange contract that VectorIndex populates at corpus scale.
+Zero new dependencies; everything stochastic is seeded and deterministic.
+
+### Added
+
+- **`LinearAlgebraProvider` seam — thin QR / thin SVD / symmetric eigen.**
+  Column-major `[Float]` factorizations behind a task-local provider
+  (`Operations.$linearAlgebraProvider`): `LAPACKLinearAlgebraProvider` routes
+  through Accelerate's modern LAPACK (`ACCELERATE_NEW_LAPACK` via `cSettings`,
+  32-bit indices, a `VectorCoreC` shim with lwork negotiation), and
+  `SwiftLinearAlgebraProvider` (Householder QR, cyclic Jacobi eigen, Hestenes
+  SVD) keeps non-Apple platforms working. Parity-tested against each other.
+- **`PCAModel` / `Operations.pca` — PCA via randomized SVD**
+  (Halko–Martinsson–Tropp): Gaussian sketch plus QR-stabilized power
+  iterations; fit on a sample, then stream the corpus through `transform` in
+  caller-sized batches (one GEMM per batch). Seeded deterministic sketch,
+  pinned sign convention (largest-|coordinate| positive), exact thin-SVD
+  fallback when the sketch cannot be thinner than the data;
+  `explainedVariance` / `explainedVarianceRatio` reported.
+- **`Operations.umap` — UMAP layout.** Fuzzy simplicial set (smooth-kNN ρ/σ
+  bisection against the log₂(k+1) target, probabilistic t-conorm union),
+  output-kernel curve fit by Levenberg–Marquardt (reproduces umap-learn's
+  a≈1.577, b≈0.895 defaults), and SGD with epoch-cadence edge sampling,
+  negative sampling, ±4 gradient clipping, and linear annealing.
+  Single-threaded and fully seeded: identical inputs give a bit-for-bit
+  identical layout. PCA initialization by default (per the gap report's scale
+  correction); random and caller-provided coordinates supported.
+- **`KNNGraph` — the Core-owned CSR interchange contract.** A validated
+  sparse k-nearest-neighbor graph (no self-loops, finite non-negative
+  distances, monotone offsets, variable row degree) that graph producers —
+  VectorIndex's ANN indexes at corpus scale — hand TO Core: data flows
+  Index → Core, code never does. `KNNGraph.bruteForce` (blocked Gram-trick
+  GEMM, O(n²·d)) is the exact in-Core builder for samples and tests.
+- **`LAMatMul`** (internal) — column-major GEMM utility (`cblas_sgemm` on
+  Apple platforms; a parity-tested pure-Swift kernel elsewhere) shared by
+  PCA, UMAP, and the brute-force kNN builder.
+
+### Fixed
+
+- **`VectorCoreVersion` drift.** The constants still reported 0.2.2 in the
+  0.3.0 release; they now match the package version again.
+
+### Documentation
+
+- `Docs/Package_Boundaries.md` records the ratified projection-stack
+  placement: dense linear algebra / PCA / UMAP *math* in Core; the `KNNGraph`
+  CSR container Core-owned as a data-interchange contract; graph
+  *construction* and clustering remain VectorIndex territory.
+
 ## [0.3.0] - 2026-06-07
 
 Outcome of the "beta-evolution-4" (BE4) review: **hold the line, sharpen the

--- a/Docs/Package_Boundaries.md
+++ b/Docs/Package_Boundaries.md
@@ -43,11 +43,12 @@ VectorCore is designed as part of a modular 4-package ecosystem, each with clear
 
 **Purpose**: CPU-first vector mathematics and core abstractions
 
-**Scope** (v0.3.0):
+**Scope** (v0.3.1):
 - Vector data types (fixed & dynamic dimensions)
 - SIMD-optimized operations (512/768/1536 dimensions)
 - Distance metrics (Euclidean, Cosine, Manhattan, Chebyshev, Hamming, Minkowski, DotProduct)
 - CPU GEMM batch distance (`MatrixDistance`: `euclideanSquaredMatrix` / `cosineDistanceMatrix`, `prepare(_:normalized:)` → `PreparedCandidates`) via Accelerate `cblas_sgemm` (AMX on Apple Silicon)
+- Dense linear algebra seam (`LinearAlgebraProvider`: thin QR / thin SVD / symmetric eigen — LAPACK-backed with a pure-Swift fallback) and projection math: PCA (`PCAModel`, randomized SVD) and UMAP layout (`Operations.umap`), consuming the Core-owned `KNNGraph` CSR interchange
 - Normalization, statistics, centroid computation
 - Top-K selection (deterministic `TieBreaker`: `.smallerIndex` default / `.insertionOrder` / `.smallerValue`)
 - Memory management (aligned allocation, buffer pools)
@@ -83,8 +84,32 @@ it **owns the seams** they plug into. What Core newly owns in 0.3.0:
 > the GPU *seam*: the `BatchKernelProvider` dispatch hook plus the page-aligned `bytesNoCopy`
 > buffer contract. The kernels themselves live in VectorAccelerate.
 
+### 0.3.1 — the projection stack
+
+The P0 band of the HN semantic-search gap analysis. Same philosophy as 0.3.0:
+Core owns the *math* and the *contracts*; corpus-scale graph construction stays
+in VectorIndex. What Core newly owns in 0.3.1:
+
+- **`LinearAlgebraProvider`** — thin QR / thin SVD / symmetric eigen over column-major
+  `[Float]`, task-local-selectable (`Operations.$linearAlgebraProvider`): Accelerate LAPACK
+  on Apple platforms, a pure-Swift fallback (Householder QR / cyclic Jacobi / Hestenes SVD)
+  elsewhere.
+- **PCA** — `PCAModel` / `Operations.pca`, randomized SVD (Halko); fit on a sample,
+  stream the corpus through `transform`.
+- **UMAP layout** — `Operations.umap`: fuzzy simplicial set + seeded single-threaded SGD.
+  Initialization via PCA (default), random, or caller-provided coordinates.
+- **`KNNGraph`** — the **ratified CSR interchange contract** (per the gap analysis §3.2
+  boundary note): a dumb, validated sparse kNN container that lives in Core so that
+  graph *producers* (VectorIndex's ANN indexes) can hand graphs TO Core's UMAP without
+  Core ever depending on an index package. **Data flows Index → Core; code never does.**
+  Producers must emit the raw directed graph with Euclidean distances and no self-loops —
+  Core's fuzzy-set stage owns symmetrization. `KNNGraph.bruteForce` (exact, O(n²·d)) is
+  the in-Core reference builder for samples and tests, not the corpus path.
+
 **What's NOT in Core**:
-- ❌ Graph algorithms or data structures
+- ❌ Graph algorithms or graph *construction* at scale (the `KNNGraph` CSR *container* is the
+  one deliberate exception — a Core-owned data-interchange contract that VectorIndex populates;
+  see the 0.3.1 note above)
 - ❌ Clustering algorithms (K-means, hierarchical, etc.)
 - ❌ GPU/Metal **kernels** (Core owns the seam — `BatchKernelProvider` dispatch + the page-aligned `bytesNoCopy` buffer contract — but not the shaders)
 - ❌ Approximate nearest neighbor (ANN) indexes
@@ -95,8 +120,9 @@ it **owns the seams** they plug into. What Core newly owns in 0.3.0:
 
 **Public API Surface**:
 - Vector types: `Vector<D>`, `DynamicVector`, `Vector{512,768,1536}Optimized`
-- Protocols: `VectorProtocol`, `VectorFactory`, `SIMDProvider`, `ComputeProvider`, `BatchKernelProvider`, `UnifiedVectorBuffer`
+- Protocols: `VectorProtocol`, `VectorFactory`, `SIMDProvider`, `ComputeProvider`, `BatchKernelProvider`, `UnifiedVectorBuffer`, `LinearAlgebraProvider`
 - Operations: `Operations`, `BatchOperations`, `MatrixDistance`
+- Projection stack: `PCAConfig`/`PCAModel`, `UMAPConfig`/`UMAPInitialization`/`UMAPResult`, `KNNGraph`
 - Distance metrics: `EuclideanDistance`, `CosineDistance`, etc.
 - GPU-bridge: `PageAlignedBuffer`, `SoALayout` (see [SoA Layout Contract](SoA_Layout_Contract.md))
 
@@ -121,6 +147,7 @@ seams.
   - NSW (Navigable Small World)
   - Graph primitives (adjacency lists, edge management)
   - Graph algorithms (traversal, connectivity, centrality)
+  - kNN-graph construction at corpus scale (batch ANN over an index → Core's `KNNGraph` CSR interchange, feeding Core's UMAP)
 - **Clustering**:
   - K-means (MiniBatch, Streaming, Distributed)
   - Hierarchical clustering
@@ -415,6 +442,6 @@ A: Basic INT8 quantization is CPU-friendly and device-agnostic. Auto-tuning requ
 
 ---
 
-**Document Version**: 1.1
-**Last Updated**: 2026-06-07
-**Applies to**: VectorCore v0.3.0+
+**Document Version**: 1.2
+**Last Updated**: 2026-06-11
+**Applies to**: VectorCore v0.3.1+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add VectorCore to your Swift Package Manager dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/gifton/VectorCore.git", from: "0.3.0")
+    .package(url: "https://github.com/gifton/VectorCore.git", from: "0.3.1")
 ]
 ```
 

--- a/Sources/VectorCore/Version.swift
+++ b/Sources/VectorCore/Version.swift
@@ -28,7 +28,7 @@ public struct VectorCoreVersion {
     /// Current version string of VectorCore.
     ///
     /// This matches the version in Package.swift.
-    public static let version = "0.2.2"
+    public static let version = "0.3.1"
 
     /// Major version number.
     ///
@@ -38,12 +38,12 @@ public struct VectorCoreVersion {
     /// Minor version number.
     ///
     /// Incremented when adding functionality in a backwards-compatible manner.
-    public static let minor = 2
+    public static let minor = 3
 
     /// Patch version number.
     ///
     /// Incremented when making backwards-compatible bug fixes.
-    public static let patch = 2
+    public static let patch = 1
 
     /// Pre-release version identifier.
     ///


### PR DESCRIPTION
## Summary
Version bump for the 0.3.1 release, carrying the projection stack merged in #34 (LAPACK seam, randomized-SVD PCA, UMAP layout, Core-owned `KNNGraph` CSR interchange).

- **`VectorCoreVersion` 0.2.2 → 0.3.1** — the constants had drifted (never bumped for 0.3.0); now back in sync with the package version.
- **CHANGELOG** — full 0.3.1 entry for the #34 surface, in the existing Keep-a-Changelog style.
- **`Docs/Package_Boundaries.md`** — records the ratified §3.2 contract decision from the gap analysis: the `KNNGraph` CSR *container* is Core-owned as a data-interchange contract; VectorIndex *produces* it at corpus scale (data flows Index → Core, code never does; producers emit raw directed Euclidean-distance graphs, Core's fuzzy-set stage owns symmetrization). Scope/API-surface lists and the VectorIndex section updated; doc rev 1.2.
- **README** — install snippet `from: "0.3.1"`.

## After merge
Tag `v0.3.1` on the merge commit and cut the GitHub release — VectorIndex's `from: "0.2.1"` dependency then resolves the new `KNNGraph` / `Operations.umap` / `PCAModel` APIs.

## Verification
- `swift build` clean; no tests reference the version constants; swiftlint clean on `Version.swift`. Doc-only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)