### PR TITLE
Add Accelerate-backed ArraySIMDProvider

### DIFF
--- a/Sources/VectorCore/Operations/Operations.swift
+++ b/Sources/VectorCore/Operations/Operations.swift
@@ -16,10 +16,18 @@ import Foundation
 /// // Default: Pure Swift implementation
 /// let results = try await Operations.findNearest(to: query, in: database, k: 10)
 ///
-/// // With custom providers (e.g., from VectorAccelerate)
-/// Operations.computeProvider = MetalComputeProvider()
-/// Operations.simdProvider = AccelerateSIMDProvider()
+/// // Opt into Accelerate-backed SIMD for a scoped region. The providers are
+/// // `@TaskLocal`, so they are installed via `$provider.withValue(_:operation:)`
+/// // rather than assigned directly:
+/// try await Operations.$simdProvider.withValue(AccelerateArraySIMDProvider()) {
+///     let normalized = try await Operations.normalize(vectors)
+///     // ...further Operations calls here also see the Accelerate provider...
+/// }
 /// ```
+///
+/// Downstream packages (e.g. VectorAccelerate) can swap the compute strategy the
+/// same way — bind a concrete `ComputeProvider` for the scope, e.g.
+/// `Operations.$computeProvider.withValue(someMetalComputeProvider) { ... }`.
 public enum Operations {
 
     // MARK: - Provider Configuration

--- a/Sources/VectorCore/Platform/ArraySIMDProvider.swift
+++ b/Sources/VectorCore/Platform/ArraySIMDProvider.swift
@@ -536,3 +536,284 @@ public struct SwiftSIMDProvider: ArraySIMDProvider, Sendable {
         provider.maxIndex(a)
     }
 }
+
+// MARK: - Accelerate-backed ArraySIMDProvider
+
+#if canImport(Accelerate)
+/// `ArraySIMDProvider` whose hot arithmetic and reductions run on Accelerate's
+/// vDSP via ``AccelerateFloatProvider``, with the handful of vDSP-uncovered
+/// operations (`elementWiseMin`/`elementWiseMax`, `abs`/`sqrt`/`log`,
+/// `minIndex`/`maxIndex`) delegated to ``DefaultArraySIMDProvider`` (already
+/// vForce-backed or trivial index scans).
+///
+/// This is the Accelerate analog of ``DefaultArraySIMDProvider``: the bodies are
+/// structurally identical, only the backing static-provider type changes from
+/// `SwiftFloatSIMDProvider` to `AccelerateFloatProvider`. Install it for the
+/// `Operations` API (and `Vector<D>` array math that flows through it) via the
+/// scoped `Operations.$simdProvider.withValue(_:operation:)` API.
+///
+/// - Note: vDSP reductions (`vDSP_sve`, `vDSP_dotpr`, `vDSP_svesq`, …) use a
+///   pairwise/tree summation, so results agree with the sequential Swift
+///   provider only to within floating-point rounding — never bit-for-bit.
+public struct AccelerateArraySIMDProvider: ArraySIMDProvider, Sendable {
+
+    /// Backing provider for the operations vDSP does not cover. These are either
+    /// vForce-backed (`abs`/`sqrt`/`log`) or trivial scalar scans
+    /// (`elementWiseMin`/`elementWiseMax`/`minIndex`/`maxIndex`), so delegating
+    /// them introduces no "fake Accelerate" dishonesty.
+    private let fallback = DefaultArraySIMDProvider()
+
+    public init() {}
+
+    /// Allocate an output array of `count` floats **without** the redundant zero-fill.
+    ///
+    /// Mirrors ``DefaultArraySIMDProvider``'s allocation idiom so allocation
+    /// behavior is identical across the two providers: every arithmetic /
+    /// element-wise op below fully overwrites its result buffer via the
+    /// underlying vDSP primitive, so `Array`'s `unsafeUninitializedCapacity:`
+    /// initializer hands us raw storage and skips the zero-fill entirely.
+    ///
+    /// - Important: `body` MUST initialize all `count` elements of the buffer.
+    ///   Empty requests short-circuit to `[]` so the vDSP primitives never see a
+    ///   nil base pointer.
+    @inline(__always)
+    private func uninitializedResult(
+        count: Int,
+        _ body: (UnsafeMutableBufferPointer<Float>) -> Void
+    ) -> [Float] {
+        guard count > 0 else { return [] }
+        return [Float](unsafeUninitializedCapacity: count) { buffer, initializedCount in
+            body(buffer)
+            initializedCount = count
+        }
+    }
+
+    public func add(_ a: [Float], _ b: [Float]) -> [Float] {
+        precondition(a.count == b.count, "Arrays must have same length")
+        let count = a.count
+        return uninitializedResult(count: count) { resultBuffer in
+            a.withUnsafeBufferPointer { aBuffer in
+                b.withUnsafeBufferPointer { bBuffer in
+                    AccelerateFloatProvider.add(
+                        aBuffer.baseAddress!,
+                        bBuffer.baseAddress!,
+                        result: resultBuffer.baseAddress!,
+                        count: count
+                    )
+                }
+            }
+        }
+    }
+
+    public func subtract(_ a: [Float], _ b: [Float]) -> [Float] {
+        precondition(a.count == b.count, "Arrays must have same length")
+        let count = a.count
+        return uninitializedResult(count: count) { resultBuffer in
+            a.withUnsafeBufferPointer { aBuffer in
+                b.withUnsafeBufferPointer { bBuffer in
+                    AccelerateFloatProvider.subtract(
+                        aBuffer.baseAddress!,
+                        bBuffer.baseAddress!,
+                        result: resultBuffer.baseAddress!,
+                        count: count
+                    )
+                }
+            }
+        }
+    }
+
+    public func multiply(_ a: [Float], by scalar: Float) -> [Float] {
+        let count = a.count
+        return uninitializedResult(count: count) { resultBuffer in
+            a.withUnsafeBufferPointer { aBuffer in
+                AccelerateFloatProvider.multiplyScalar(
+                    aBuffer.baseAddress!,
+                    scalar: scalar,
+                    result: resultBuffer.baseAddress!,
+                    count: count
+                )
+            }
+        }
+    }
+
+    public func divide(_ a: [Float], by scalar: Float) -> [Float] {
+        multiply(a, by: 1.0 / scalar)
+    }
+
+    public func dot(_ a: [Float], _ b: [Float]) -> Float {
+        precondition(a.count == b.count, "Arrays must have same length")
+
+        return a.withUnsafeBufferPointer { aBuffer in
+            b.withUnsafeBufferPointer { bBuffer in
+                AccelerateFloatProvider.dot(
+                    aBuffer.baseAddress!,
+                    bBuffer.baseAddress!,
+                    count: a.count
+                )
+            }
+        }
+    }
+
+    public func sum(_ a: [Float]) -> Float {
+        a.withUnsafeBufferPointer { aBuffer in
+            AccelerateFloatProvider.sum(
+                aBuffer.baseAddress!,
+                count: a.count
+            )
+        }
+    }
+
+    public func max(_ a: [Float]) -> Float {
+        guard !a.isEmpty else { return -.infinity }
+
+        return a.withUnsafeBufferPointer { aBuffer in
+            AccelerateFloatProvider.maximum(
+                aBuffer.baseAddress!,
+                count: a.count
+            )
+        }
+    }
+
+    public func min(_ a: [Float]) -> Float {
+        guard !a.isEmpty else { return .infinity }
+
+        return a.withUnsafeBufferPointer { aBuffer in
+            AccelerateFloatProvider.minimum(
+                aBuffer.baseAddress!,
+                count: a.count
+            )
+        }
+    }
+
+    public func mean(_ a: [Float]) -> Float {
+        guard !a.isEmpty else { return 0 }
+        return sum(a) / Float(a.count)
+    }
+
+    public func magnitude(_ a: [Float]) -> Float {
+        Foundation.sqrt(magnitudeSquared(a))
+    }
+
+    public func magnitudeSquared(_ a: [Float]) -> Float {
+        a.withUnsafeBufferPointer { aBuffer in
+            AccelerateFloatProvider.sumOfSquares(
+                aBuffer.baseAddress!,
+                count: a.count
+            )
+        }
+    }
+
+    public func normalize(_ a: [Float]) -> [Float] {
+        let mag = magnitude(a)
+        guard mag > 0 else { return a }
+        return multiply(a, by: 1.0 / mag)
+    }
+
+    public func euclideanDistanceSquared(_ a: [Float], _ b: [Float]) -> Float {
+        precondition(a.count == b.count, "Arrays must have same length")
+
+        return a.withUnsafeBufferPointer { aBuffer in
+            b.withUnsafeBufferPointer { bBuffer in
+                AccelerateFloatProvider.distanceSquared(
+                    aBuffer.baseAddress!,
+                    bBuffer.baseAddress!,
+                    count: a.count
+                )
+            }
+        }
+    }
+
+    public func cosineSimilarity(_ a: [Float], _ b: [Float]) -> Float {
+        let dotProduct = dot(a, b)
+        let magA = magnitude(a)
+        let magB = magnitude(b)
+
+        guard magA > 0 && magB > 0 else { return 0 }
+        return dotProduct / (magA * magB)
+    }
+
+    public func elementWiseMin(_ a: [Float], _ b: [Float]) -> [Float] {
+        // vDSP has no element-wise min; delegate to the trivial scalar-scan impl.
+        fallback.elementWiseMin(a, b)
+    }
+
+    public func elementWiseMax(_ a: [Float], _ b: [Float]) -> [Float] {
+        // vDSP has no element-wise max; delegate to the trivial scalar-scan impl.
+        fallback.elementWiseMax(a, b)
+    }
+
+    public func elementWiseMultiply(_ a: [Float], _ b: [Float]) -> [Float] {
+        precondition(a.count == b.count, "Arrays must have same length")
+        let count = a.count
+        return uninitializedResult(count: count) { resultBuffer in
+            a.withUnsafeBufferPointer { aBuffer in
+                b.withUnsafeBufferPointer { bBuffer in
+                    AccelerateFloatProvider.multiply(
+                        aBuffer.baseAddress!,
+                        bBuffer.baseAddress!,
+                        result: resultBuffer.baseAddress!,
+                        count: count
+                    )
+                }
+            }
+        }
+    }
+
+    public func elementWiseDivide(_ a: [Float], _ b: [Float]) -> [Float] {
+        precondition(a.count == b.count, "Arrays must have same length")
+        let count = a.count
+        return uninitializedResult(count: count) { resultBuffer in
+            a.withUnsafeBufferPointer { aBuffer in
+                b.withUnsafeBufferPointer { bBuffer in
+                    AccelerateFloatProvider.divide(
+                        aBuffer.baseAddress!,
+                        bBuffer.baseAddress!,
+                        result: resultBuffer.baseAddress!,
+                        count: count
+                    )
+                }
+            }
+        }
+    }
+
+    public func abs(_ a: [Float]) -> [Float] {
+        // vForce-backed (vvfabsf) inside DefaultArraySIMDProvider.
+        fallback.abs(a)
+    }
+
+    public func sqrt(_ a: [Float]) -> [Float] {
+        // vForce-backed (vvsqrtf) inside DefaultArraySIMDProvider.
+        fallback.sqrt(a)
+    }
+
+    public func log(_ a: [Float]) -> [Float] {
+        // vForce-backed (vvlogf) inside DefaultArraySIMDProvider.
+        fallback.log(a)
+    }
+
+    public func clip(_ a: [Float], min minVal: Float, max maxVal: Float) -> [Float] {
+        let count = a.count
+        return uninitializedResult(count: count) { resultBuffer in
+            a.withUnsafeBufferPointer { aBuffer in
+                AccelerateFloatProvider.clip(
+                    aBuffer.baseAddress!,
+                    low: minVal,
+                    high: maxVal,
+                    result: resultBuffer.baseAddress!,
+                    count: count
+                )
+            }
+        }
+    }
+
+    public func minIndex(_ a: [Float]) -> Int {
+        // Trivial scalar scan; delegate to the shared implementation.
+        fallback.minIndex(a)
+    }
+
+    public func maxIndex(_ a: [Float]) -> Int {
+        // Trivial scalar scan; delegate to the shared implementation.
+        fallback.maxIndex(a)
+    }
+}
+#endif // canImport(Accelerate)

--- a/Tests/ComprehensiveTests/AccelerateArraySIMDProviderParityTests.swift
+++ b/Tests/ComprehensiveTests/AccelerateArraySIMDProviderParityTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import VectorCore
+
+/// Numerical-parity suite for ``AccelerateArraySIMDProvider``.
+///
+/// The Accelerate provider routes its hot arithmetic and reductions through vDSP
+/// (``AccelerateFloatProvider``) while ``DefaultArraySIMDProvider`` uses
+/// hand-rolled Swift SIMD loops. The two are expected to agree on the same
+/// inputs — but only to within floating-point rounding, because vDSP reductions
+/// (`vDSP_sve`, `vDSP_dotpr`, `vDSP_svesq`, `vDSP_distancesq`) accumulate with a
+/// pairwise/tree order while the Swift provider accumulates sequentially. So we
+/// assert agreement under a tight mixed absolute/relative tolerance rather than
+/// bit-for-bit equality.
+///
+/// Guarded behind `canImport(Accelerate)` to match the provider's own guard.
+#if canImport(Accelerate)
+@Suite("AccelerateArraySIMDProvider parity")
+struct AccelerateArraySIMDProviderParityTests {
+
+    /// Mixed absolute/relative closeness: `|x - y| <= absTol + relTol * max(|x|, |y|)`.
+    ///
+    /// Pure relative tolerance is unstable when the reference value is ~0 (e.g. a
+    /// near-zero dot product), so an absolute floor is added. These bounds are
+    /// deliberately tight (1e-5 relative / 1e-6 absolute) to catch a wrong vDSP
+    /// routing — they are loose only relative to exact equality.
+    private func isClose(
+        _ x: Float, _ y: Float,
+        relTol: Float = 1e-5, absTol: Float = 1e-6
+    ) -> Bool {
+        if x == y { return true } // exact (covers ±inf and identical bit patterns)
+        let diff = Swift.abs(x - y)
+        let scale = Swift.max(Swift.abs(x), Swift.abs(y))
+        return diff <= absTol + relTol * scale
+    }
+
+    /// Element-wise closeness over two equal-length arrays.
+    private func arraysClose(
+        _ x: [Float], _ y: [Float],
+        relTol: Float = 1e-5, absTol: Float = 1e-6
+    ) -> Bool {
+        guard x.count == y.count else { return false }
+        for i in x.indices where !isClose(x[i], y[i], relTol: relTol, absTol: absTol) {
+            return false
+        }
+        return true
+    }
+
+    /// Sizes spanning: scalar tail (1), sub-SIMD4 remainder (7), an exact
+    /// SIMD8-aligned block (64), and a large odd size with a non-trivial
+    /// remainder (513) so the vDSP and Swift accumulation orders diverge most.
+    private static let sizes = [1, 7, 64, 513]
+
+    @Test("Accelerate provider matches the default Swift provider", arguments: sizes)
+    func parity(n: Int) {
+        let accel = AccelerateArraySIMDProvider()
+        let swift = DefaultArraySIMDProvider()
+
+        // Fresh, per-size deterministic generator (documented race-free pattern).
+        var rng = SeededGenerator(seed: 0xA22E_1D00 &+ UInt64(n))
+        let a = (0..<n).map { _ in Float.random(in: -1...1, using: &rng) }
+        // `b` is offset away from zero so cosineSimilarity / euclidean divisors
+        // stay well-conditioned and the relative tolerance is meaningful.
+        let b = (0..<n).map { _ in Float.random(in: 0.25...1.25, using: &rng) }
+
+        // --- Reductions ---
+        #expect(isClose(accel.dot(a, b), swift.dot(a, b)),
+                "dot mismatch (n=\(n))")
+        #expect(isClose(accel.sum(a), swift.sum(a)),
+                "sum mismatch (n=\(n))")
+        #expect(isClose(accel.magnitude(a), swift.magnitude(a)),
+                "magnitude mismatch (n=\(n))")
+        #expect(isClose(accel.euclideanDistanceSquared(a, b),
+                        swift.euclideanDistanceSquared(a, b)),
+                "euclideanDistanceSquared mismatch (n=\(n))")
+        #expect(isClose(accel.cosineSimilarity(a, b), swift.cosineSimilarity(a, b)),
+                "cosineSimilarity mismatch (n=\(n))")
+
+        // --- Array-returning arithmetic ---
+        #expect(arraysClose(accel.normalize(a), swift.normalize(a)),
+                "normalize mismatch (n=\(n))")
+        #expect(arraysClose(accel.add(a, b), swift.add(a, b)),
+                "add mismatch (n=\(n))")
+        #expect(arraysClose(accel.subtract(a, b), swift.subtract(a, b)),
+                "subtract mismatch (n=\(n))")
+        #expect(arraysClose(accel.multiply(a, by: 3.5), swift.multiply(a, by: 3.5)),
+                "multiply(_:by:) mismatch (n=\(n))")
+    }
+}
+#endif // canImport(Accelerate)


### PR DESCRIPTION
## Summary

- Adds `AccelerateArraySIMDProvider` — a vDSP-backed implementation of `ArraySIMDProvider` (+281 lines) for array-level SIMD operations on Apple platforms
- Adds a parity test suite (`AccelerateArraySIMDProviderParityTests`) validating it against the default generic provider at n = 1, 7, 64, 513
- Updates the `Operations` doc comment: replaces the old provider-assignment example with the `@TaskLocal` scoped-binding pattern (`Operations.$simdProvider.withValue(...)`)

Rebased onto `main` (0.3.1). No version bump.

## Test plan

- `swift build -c release` clean
- Parity suite green (4/4 cases)
- Full local suite green: XCTest 91 executed / 0 failures, swift-testing 1117 tests / 165 suites passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)