### PR TITLE
test: gate wall-clock perf assertions behind VECTORCORE_STRICT_PERF

### DIFF
--- a/Tests/ComprehensiveTests/BatchKernels_SoATests.swift
+++ b/Tests/ComprehensiveTests/BatchKernels_SoATests.swift
@@ -770,7 +770,9 @@ struct BatchKernels_SoATests {
                 }
 
                 // SoA should not be more than 2x slower (allowing for setup overhead)
-                #expect(batchTime < individualTime * 2.0, "Batch processing took \(batchTime)s vs individual \(individualTime)s for size \(batchSize)")
+                if strictPerfGatesEnabled {
+                    #expect(batchTime < individualTime * 2.0, "Batch processing took \(batchTime)s vs individual \(individualTime)s for size \(batchSize)")
+                }
             }
         }
 
@@ -819,8 +821,10 @@ struct BatchKernels_SoATests {
                     // For large batches, SoA should show performance benefits
                     // Allow some tolerance for measurement variance
                     let expectedRatio = 3.0 // Allow SoA to be up to 3x slower in debug mode
-                    #expect(batchTime < individualTime * expectedRatio || batchTime < 0.1,
-                           "Large batch \(batchSize): SoA time \(batchTime)s should be reasonable vs individual \(individualTime)s")
+                    if strictPerfGatesEnabled {
+                        #expect(batchTime < individualTime * expectedRatio || batchTime < 0.1,
+                               "Large batch \(batchSize): SoA time \(batchTime)s should be reasonable vs individual \(individualTime)s")
+                    }
                 }
             }
         }
@@ -1083,8 +1087,11 @@ struct BatchKernels_SoATests {
 
             // SoA should be reasonable for large batches (debug mode considerations)
             // Allow tolerance for debug overhead
-            #expect(soaTime < individualTime * 10.0 || soaTime < 1.0,
-                   "SoA blocking should be efficient: SoA time \(soaTime)s vs individual \(individualTime)s")
+            print("  [perf] SoA blocking: \(soaTime)s vs individual \(individualTime)s")
+            if strictPerfGatesEnabled {
+                #expect(soaTime < individualTime * 10.0 || soaTime < 1.0,
+                       "SoA blocking should be efficient: SoA time \(soaTime)s vs individual \(individualTime)s")
+            }
 
             // Test that blocking handles different batch sizes efficiently
             let testSizes = [2, 4, 10, 50, 100, 500]
@@ -1103,7 +1110,9 @@ struct BatchKernels_SoATests {
                 }
             }
 
-            #expect(allTimesReasonable, "Blocking efficiency should scale reasonably with batch size")
+            if strictPerfGatesEnabled {
+                #expect(allTimesReasonable, "Blocking efficiency should scale reasonably with batch size")
+            }
         }
 
         @Test
@@ -1236,8 +1245,10 @@ struct BatchKernels_SoATests {
 
             // For large batches, SoA should be reasonable (debug mode considerations)
             // Allow tolerance for debug overhead
-            #expect(soaTime < aosTime * 3.0 || soaTime < 0.1,
-                   "SoA should be reasonable vs AoS: SoA \(soaTime)s vs AoS \(aosTime)s")
+            if strictPerfGatesEnabled {
+                #expect(soaTime < aosTime * 3.0 || soaTime < 0.1,
+                       "SoA should be reasonable vs AoS: SoA \(soaTime)s vs AoS \(aosTime)s")
+            }
 
             // Test at the threshold where SoA should be beneficial
             let shouldUseSoA = BatchKernels_SoA.shouldUseSoA(candidateCount: largeCandidateCount, dimension: 512)
@@ -1261,8 +1272,10 @@ struct BatchKernels_SoATests {
             // Time should scale roughly linearly (allowing for overhead)
             let expectedRatio = 500.0 / 100.0 // 5x
             let actualRatio = mediumTime / max(smallTime, 1e-6)
-            #expect(actualRatio < expectedRatio * 2 || mediumTime < 0.001,
-                   "Performance should scale reasonably: small \(smallTime)s, medium \(mediumTime)s, ratio \(actualRatio)")
+            if strictPerfGatesEnabled {
+                #expect(actualRatio < expectedRatio * 2 || mediumTime < 0.001,
+                       "Performance should scale reasonably: small \(smallTime)s, medium \(mediumTime)s, ratio \(actualRatio)")
+            }
         }
 
         @Test(.enabled(if: ProcessInfo.processInfo.environment["VECTORCORE_TEST_EXTENDED"] == "1"))
@@ -1289,8 +1302,10 @@ struct BatchKernels_SoATests {
             }
 
             // Sequential should be at least as fast as random (cache benefits)
-            #expect(sequentialTime <= randomTime * 1.5 || sequentialTime < 0.1,
-                   "Sequential access should benefit from cache locality: sequential \(sequentialTime)s vs random \(randomTime)s")
+            if strictPerfGatesEnabled {
+                #expect(sequentialTime <= randomTime * 1.5 || sequentialTime < 0.1,
+                       "Sequential access should benefit from cache locality: sequential \(sequentialTime)s vs random \(randomTime)s")
+            }
 
             // Test 3: Verify lane-wise access pattern efficiency
             let soa = SoA<Vector512Optimized>.build(from: candidates)
@@ -1319,8 +1334,10 @@ struct BatchKernels_SoATests {
             }
 
             // Lane-wise access should be more cache-friendly
-            #expect(laneAccessTime <= candidateAccessTime * 2.0 || laneAccessTime < 0.01,
-                   "Lane-wise access should be cache-friendly: lane \(laneAccessTime)s vs candidate \(candidateAccessTime)s")
+            if strictPerfGatesEnabled {
+                #expect(laneAccessTime <= candidateAccessTime * 2.0 || laneAccessTime < 0.01,
+                       "Lane-wise access should be cache-friendly: lane \(laneAccessTime)s vs candidate \(candidateAccessTime)s")
+            }
 
             // Test 4: Memory access pattern validation
             let accessPatternTest = measureTime {
@@ -1415,8 +1432,10 @@ struct BatchKernels_SoATests {
             }
 
             // SIMD should be reasonably efficient (allowing for debug mode)
-            #expect(simdTime <= scalarTime * 2.0 || simdTime < 0.1,
-                   "SIMD operations should be efficient: SIMD \(simdTime)s vs scalar \(scalarTime)s")
+            if strictPerfGatesEnabled {
+                #expect(simdTime <= scalarTime * 2.0 || simdTime < 0.1,
+                       "SIMD operations should be efficient: SIMD \(simdTime)s vs scalar \(scalarTime)s")
+            }
 
             // Test 3: Verify alignment for SIMD operations
             for laneIdx in 0..<min(10, soa.lanes) {
@@ -1475,7 +1494,7 @@ struct BatchKernels_SoATests {
             let timePerItemValues = timings.map { $0.timePerItem }
             let meanTimePerItem = timePerItemValues.reduce(0, +) / Double(timePerItemValues.count)
 
-            for timing in timings {
+            for timing in timings where strictPerfGatesEnabled {
                 let deviation = abs(timing.timePerItem - meanTimePerItem) / meanTimePerItem
                 #expect(deviation < 2.0 || timing.time < 0.01,
                        "Scaling should be roughly linear. Size \(timing.size): \(timing.timePerItem) vs mean \(meanTimePerItem)")
@@ -1488,8 +1507,10 @@ struct BatchKernels_SoATests {
                 let largeBatchEfficiency = timings[timings.count - 1].timePerItem  // size 2000
 
                 // Large batches should have better or similar efficiency
-                #expect(largeBatchEfficiency <= smallBatchEfficiency * 3.0 || largeBatchEfficiency < 1e-6,
-                       "Large batches should be efficient: small \(smallBatchEfficiency) vs large \(largeBatchEfficiency)")
+                if strictPerfGatesEnabled {
+                    #expect(largeBatchEfficiency <= smallBatchEfficiency * 3.0 || largeBatchEfficiency < 1e-6,
+                           "Large batches should be efficient: small \(smallBatchEfficiency) vs large \(largeBatchEfficiency)")
+                }
             }
 
             // Test 3: Check for performance cliffs
@@ -1506,7 +1527,9 @@ struct BatchKernels_SoATests {
                 }
             }
 
-            #expect(!hasPerformanceCliff, "Should not have dramatic performance cliffs")
+            if strictPerfGatesEnabled {
+                #expect(!hasPerformanceCliff, "Should not have dramatic performance cliffs")
+            }
 
             // Test 4: Verify SoA threshold recommendations
             for timing in timings {
@@ -1550,8 +1573,10 @@ struct BatchKernels_SoATests {
             let ratio768to512 = time768 / max(time512, 1e-9)
             let ratio1536to512 = time1536 / max(time512, 1e-9)
 
-            #expect(ratio768to512 < 3.0 || time768 < 0.01, "768D should scale reasonably vs 512D: \(ratio768to512)x")
-            #expect(ratio1536to512 < 6.0 || time1536 < 0.01, "1536D should scale reasonably vs 512D: \(ratio1536to512)x")
+            if strictPerfGatesEnabled {
+                #expect(ratio768to512 < 3.0 || time768 < 0.01, "768D should scale reasonably vs 512D: \(ratio768to512)x")
+                #expect(ratio1536to512 < 6.0 || time1536 < 0.01, "1536D should scale reasonably vs 512D: \(ratio1536to512)x")
+            }
         }
     }
 
@@ -1586,7 +1611,10 @@ struct BatchKernels_SoATests {
                 }
             }
 
-            #expect(emptyTime < 0.001, "Empty batch processing should be very fast: \(emptyTime)s")
+            print("  [perf] empty-batch ×100: \(emptyTime)s (gate < 0.001)")
+            if strictPerfGatesEnabled {
+                #expect(emptyTime < 0.001, "Empty batch processing should be very fast: \(emptyTime)s")
+            }
         }
 
         @Test
@@ -2837,8 +2865,10 @@ struct BatchKernels_SoATests {
 
             // Generally expect processing time to scale with dimension
             // (may not hold in debug mode)
-            #expect(time512 <= time1536 * 2 || time512 < 0.01,
-                   "512D should generally be faster than 1536D")
+            if strictPerfGatesEnabled {
+                #expect(time512 <= time1536 * 2 || time512 < 0.01,
+                       "512D should generally be faster than 1536D")
+            }
         }
 
         @Test
@@ -3076,7 +3106,10 @@ struct BatchKernels_SoATests {
                 .map { $0.0 }
 
             #expect(rankedDocs.count == topK, "Should find top K documents")
-            #expect(searchTime < 1.0, "Search should complete in reasonable time")
+            print("  [perf] document search: \(searchTime)s (gate < 1.0)")
+            if strictPerfGatesEnabled {
+                #expect(searchTime < 1.0, "Search should complete in reasonable time")
+            }
 
             // Test 2: Recommendation system pattern
             // User-item similarity computation

--- a/Tests/ComprehensiveTests/ErrorHandlingTests.swift
+++ b/Tests/ComprehensiveTests/ErrorHandlingTests.swift
@@ -1265,8 +1265,10 @@ struct ErrorHandlingTests {
             #expect(error.description.contains("1024"))
             #expect(error.description.contains("768"))
 
-            // Verify error context
+            // Verify error context (source location is captured only in debug builds)
+            #if DEBUG
             #expect(error.context.line > 0)
+            #endif
         }
 
         @Test("Zero dimension vectors")
@@ -1558,8 +1560,10 @@ struct ErrorHandlingTests {
             #expect(description.contains("Expected dimension") || description.contains("expected"))
             // Description format may vary, just ensure both values are present
 
-            // Test that file and line info is included
+            // File/line info is appended to descriptions only in debug builds
+            #if DEBUG
             #expect(description.contains(".swift"))
+            #endif
         }
 
         @Test("Error debug description")
@@ -1711,13 +1715,18 @@ struct ErrorHandlingTests {
             let elapsed = Date().timeIntervalSince(startTime)
 
             // Should complete in reasonable time (< 1 second for 10k errors)
-            #expect(elapsed < 1.0, "Error handling took \(elapsed) seconds")
+            print("  [perf] 10k error handling: \(elapsed)s (gate < 1.0)")
+            if strictPerfGatesEnabled {
+                #expect(elapsed < 1.0, "Error handling took \(elapsed) seconds")
+            }
 
             // Test that error creation is lightweight
             let singleErrorStart = Date()
             _ = VectorError.invalidData("Performance test")
             let singleErrorTime = Date().timeIntervalSince(singleErrorStart)
-            #expect(singleErrorTime < 0.001, "Single error creation should be sub-millisecond")
+            if strictPerfGatesEnabled {
+                #expect(singleErrorTime < 0.001, "Single error creation should be sub-millisecond")
+            }
         }
 
         @Test("Error context memory efficiency")

--- a/Tests/ComprehensiveTests/MixedPrecisionKernelTests.swift
+++ b/Tests/ComprehensiveTests/MixedPrecisionKernelTests.swift
@@ -2823,8 +2823,8 @@ struct MixedPrecisionKernelTests {
             let speedup = fp32Time / fp16Time
 
             // Wall-clock speedup, invalid in a debug build (FP16 decode overhead isn't
-            // vectorized); only assert under extended/release benchmarking.
-            if ProcessInfo.processInfo.environment["VECTORCORE_TEST_EXTENDED"] == "1" {
+            // vectorized); only assert in strict-perf runs.
+            if strictPerfGatesEnabled {
                 #expect(speedup > 0.8, "FP16 should not be significantly slower: speedup=\(speedup)")
             }
 
@@ -3354,7 +3354,9 @@ struct MixedPrecisionKernelTests {
             let candidatesFP16 = MixedPrecisionKernels.convertToFP16_512(candidates512)
             let conversionTime = CFAbsoluteTimeGetCurrent() - conversionStart
 
-            #expect(conversionTime < 0.1, "Conversion should be fast")
+            if strictPerfGatesEnabled {
+                #expect(conversionTime < 0.1, "Conversion should be fast")
+            }
             #expect(candidatesFP16.count == candidateCount)
 
             // Test mixed precision operations with optimized vectors
@@ -3444,8 +3446,8 @@ struct MixedPrecisionKernelTests {
             }
             let fallbackTime = CFAbsoluteTimeGetCurrent() - fallbackStart
 
-            // Wall-clock timing, invalid in a debug build; only assert under extended benchmarking.
-            if ProcessInfo.processInfo.environment["VECTORCORE_TEST_EXTENDED"] == "1" {
+            // Wall-clock timing, invalid in a debug build; only assert in strict-perf runs.
+            if strictPerfGatesEnabled {
                 #expect(fallbackTime < 1.0, "Fallback should complete in reasonable time")
             }
 
@@ -3678,7 +3680,10 @@ struct MixedPrecisionKernelTests {
 
             // Single candidate should be fast (100 iterations)
             // Allow up to 0.02 seconds for 100 iterations (0.2ms per iteration)
-            #expect(elapsed < 0.02, "Single candidate should process quickly (\(elapsed)s for \(iterations) iterations)")
+            print("  [perf] single-candidate ×\(iterations): \(elapsed)s (gate < 0.02)")
+            if strictPerfGatesEnabled {
+                #expect(elapsed < 0.02, "Single candidate should process quickly (\(elapsed)s for \(iterations) iterations)")
+            }
         }
 
         @Test("Mismatched dimensions error handling")
@@ -4129,7 +4134,10 @@ struct MixedPrecisionKernelTests {
             let alignedTime = CFAbsoluteTimeGetCurrent() - alignedStart
 
             // Aligned access should be efficient
-            #expect(alignedTime < 0.01, "Aligned access should be fast")
+            print("  [perf] aligned range_euclid2 (\(alignedCount)): \(alignedTime)s (gate < 0.01)")
+            if strictPerfGatesEnabled {
+                #expect(alignedTime < 0.01, "Aligned access should be fast")
+            }
 
             // Test SoA alignment
             let soaVectors = try SoAFP16(vectors: alignedVectors)

--- a/Tests/ComprehensiveTests/MixedPrecisionKernelsTests.swift
+++ b/Tests/ComprehensiveTests/MixedPrecisionKernelsTests.swift
@@ -224,8 +224,10 @@ struct MixedPrecisionKernelsTests {
             let fp16ToFP32Time = Date().timeIntervalSince(fp16ToFP32Start)
 
             // Conversions should be fast (< 1ms per 1000 vectors on modern hardware)
-            #expect(fp32ToFP16Time < 0.001 * Double(vectorCount))
-            #expect(fp16ToFP32Time < 0.001 * Double(vectorCount))
+            if strictPerfGatesEnabled {
+                #expect(fp32ToFP16Time < 0.001 * Double(vectorCount))
+                #expect(fp16ToFP32Time < 0.001 * Double(vectorCount))
+            }
 
             // Verify memory savings
             let fp32MemorySize = MemoryLayout<SIMD4<Float>>.size * 128 * vectorCount
@@ -925,7 +927,9 @@ struct MixedPrecisionKernelsTests {
             print("  Time saved: \((1 - fp16Time/fp32Time) * 100)%")
 
             // FP16 should show nearly 2x effective bandwidth improvement
-            #expect(effectiveBandwidthRatio > 1.5, "FP16 should provide >1.5x bandwidth improvement")
+            if strictPerfGatesEnabled {
+                #expect(effectiveBandwidthRatio > 1.5, "FP16 should provide >1.5x bandwidth improvement")
+            }
         }
 
         @Test
@@ -1088,7 +1092,9 @@ struct MixedPrecisionKernelsTests {
             let elapsed = Date().timeIntervalSince(start)
 
             print("NEON FP16 Performance: \(iterations) conversions in \(elapsed * 1000)ms")
-            #expect(elapsed < 1.0)  // Should be fast
+            if strictPerfGatesEnabled {
+                #expect(elapsed < 1.0)  // Should be fast
+            }
         }
 
         @Test
@@ -1237,7 +1243,7 @@ struct MixedPrecisionKernelsTests {
                 print("  Amortized cost per vector: \(toFP16Time / Double(batchSize) * 1e6)μs")
 
                 // Larger batches should show better amortization
-                if batchSize > 10 {
+                if batchSize > 10, strictPerfGatesEnabled {
                     let perVectorTime = toFP16Time / Double(batchSize)
                     let smallBatchPerVector = toFP16Time / 10.0  // Approximate
                     #expect(perVectorTime < smallBatchPerVector, "Larger batches should amortize better")
@@ -1461,7 +1467,9 @@ struct MixedPrecisionKernelsTests {
                 let scalingFactor = largeEfficiency / smallEfficiency
 
                 print("Scaling efficiency: \(scalingFactor)")
-                #expect(scalingFactor > 0.5, "Performance should scale reasonably with size")
+                if strictPerfGatesEnabled {
+                    #expect(scalingFactor > 0.5, "Performance should scale reasonably with size")
+                }
             }
         }
 
@@ -1518,8 +1526,10 @@ struct MixedPrecisionKernelsTests {
             print("  Range: \((maxTime - minTime) * 1000)ms")
 
             // Performance should be consistent (CV < 10%)
-            #expect(cv < 0.10, "Coefficient of variation should be < 10%")
-            #expect((maxTime - minTime) / mean < 0.2, "Range should be < 20% of mean")
+            if strictPerfGatesEnabled {
+                #expect(cv < 0.10, "Coefficient of variation should be < 10%")
+                #expect((maxTime - minTime) / mean < 0.2, "Range should be < 20% of mean")
+            }
         }
 
         @Test
@@ -1585,10 +1595,13 @@ struct MixedPrecisionKernelsTests {
                 print("⚠️ WARNING: Euclidean distance regression detected")
             }
 
-            // Tests pass as long as we're within 10x of baseline (very generous for CI)
-            #expect(conversionTime < PerformanceBaseline.fp16Conversion * 10, "Severe conversion regression")
-            #expect(dotTime < PerformanceBaseline.dotProduct * 10, "Severe dot product regression")
-            #expect(distTime < PerformanceBaseline.euclideanDistance * 10, "Severe distance regression")
+            // Tests pass as long as we're within 10x of baseline (very generous for CI);
+            // still trips under sanitizer slowdown, so gate behind strict-perf runs
+            if strictPerfGatesEnabled {
+                #expect(conversionTime < PerformanceBaseline.fp16Conversion * 10, "Severe conversion regression")
+                #expect(dotTime < PerformanceBaseline.dotProduct * 10, "Severe dot product regression")
+                #expect(distTime < PerformanceBaseline.euclideanDistance * 10, "Severe distance regression")
+            }
         }
     }
 
@@ -1851,7 +1864,9 @@ struct MixedPrecisionKernelsTests {
 
             // Denormals shouldn't cause extreme slowdown with FP16
             // (they're likely flushed to zero)
-            #expect(denormalTime / normalTime < 2.0, "Denormals shouldn't cause extreme slowdown")
+            if strictPerfGatesEnabled {
+                #expect(denormalTime / normalTime < 2.0, "Denormals shouldn't cause extreme slowdown")
+            }
         }
 
         @Test

--- a/Tests/ComprehensiveTests/PerfGate.swift
+++ b/Tests/ComprehensiveTests/PerfGate.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Wall-clock performance gates are opt-in: they assert only when the
+/// environment sets `VECTORCORE_STRICT_PERF=1` (e.g. a dedicated benchmark
+/// CI job on quiet hardware). In normal runs — and especially under
+/// ASan/TSan, whose 2–15× slowdowns make wall-clock thresholds meaningless —
+/// the measurements are still printed but never fail the suite.
+/// Inventory of gated sites: Docs/verification-baseline-0.3.1.md.
+let strictPerfGatesEnabled: Bool = ProcessInfo.processInfo.environment["VECTORCORE_STRICT_PERF"] == "1"

--- a/Tests/ComprehensiveTests/QuantizedKernelsComprehensiveTests.swift
+++ b/Tests/ComprehensiveTests/QuantizedKernelsComprehensiveTests.swift
@@ -938,7 +938,10 @@ struct QuantizedKernelsComprehensiveTests {
             let quantizationTime = CFAbsoluteTimeGetCurrent() - start
 
             #expect(quantized.count == batchSize)
-            #expect(quantizationTime < 1.0, "Batch quantization should be fast")
+            print("  [perf] batch quantization (\(batchSize)): \(quantizationTime)s (gate < 1.0)")
+            if strictPerfGatesEnabled {
+                #expect(quantizationTime < 1.0, "Batch quantization should be fast")
+            }
         }
 
         @Test("Quantization/dequantization overhead", .enabled(if: ProcessInfo.processInfo.environment["VECTORCORE_TEST_EXTENDED"] == "1"))
@@ -956,7 +959,10 @@ struct QuantizedKernelsComprehensiveTests {
             let elapsed = CFAbsoluteTimeGetCurrent() - start
             let timePerConversion = elapsed / Double(iterations)
 
-            #expect(timePerConversion < 0.001, "Conversion should be fast")
+            print("  [perf] INT8 round-trip conversion: \(timePerConversion)s/op (gate < 0.001)")
+            if strictPerfGatesEnabled {
+                #expect(timePerConversion < 0.001, "Conversion should be fast")
+            }
         }
 
         @Test("Mixed precision performance")
@@ -973,7 +979,10 @@ struct QuantizedKernelsComprehensiveTests {
             }
 
             let elapsed = CFAbsoluteTimeGetCurrent() - start
-            #expect(elapsed < 1.0, "Mixed precision should be performant")
+            print("  [perf] mixed-precision euclidean ×\(iterations): \(elapsed)s (gate < 1.0)")
+            if strictPerfGatesEnabled {
+                #expect(elapsed < 1.0, "Mixed precision should be performant")
+            }
         }
     }
 

--- a/Tests/ComprehensiveTests/QuantizedKernelsTests.swift
+++ b/Tests/ComprehensiveTests/QuantizedKernelsTests.swift
@@ -624,7 +624,11 @@ struct QuantizedKernelsTests {
             print("    INT8 time: \(int8Time * 1000)ms")
             print("    Speedup: \(speedup)x")
 
-            #expect(speedup > 1.0, "INT8 should be faster than FP32")
+            // INT8-vs-FP32 ratio is hardware-dependent (0.91x on M3 Max after the
+            // 0.3.0 FP32 GEMM/SoA gains) — gate only in strict-perf runs
+            if strictPerfGatesEnabled {
+                #expect(speedup > 1.0, "INT8 should be faster than FP32")
+            }
 
             // Test edge case: identical vectors
             let identicalDist = QuantizedKernels.euclidean512(query: q1, candidate: q1)
@@ -722,8 +726,8 @@ struct QuantizedKernelsTests {
 
             // Wall-clock timing, invalid in a debug build (and the "without sqrt" branch
             // actually calls euclidean512 — which sqrts — then squares, so it does MORE work).
-            // Only assert under extended/release benchmarking.
-            if ProcessInfo.processInfo.environment["VECTORCORE_TEST_EXTENDED"] == "1" {
+            // Only assert in strict-perf runs.
+            if strictPerfGatesEnabled {
                 #expect(withoutSqrtTime < withSqrtTime, "Squared distance should be faster")
             }
 
@@ -1452,7 +1456,9 @@ struct QuantizedKernelsTests {
             print("    INT8 elements per cache line: \(int8VectorsPerCacheLine * 4)")
             print("    Cache efficiency improvement: \(int8VectorsPerCacheLine * 4 / (fp32VectorsPerCacheLine * 4))x")
 
-            #expect(int8Time < fp32Time, "INT8 should have better memory bandwidth")
+            if strictPerfGatesEnabled {
+                #expect(int8Time < fp32Time, "INT8 should have better memory bandwidth")
+            }
         }
 
         @Test
@@ -1613,7 +1619,9 @@ struct QuantizedKernelsTests {
             let dotProductResult = QuantizedKernels.dotProduct512(query: q1, candidate: q2)
             print("\n  Packed dot product result: \(dotProductResult)")
 
-            #expect(simdTime < scalarTime, "SIMD should be faster than scalar")
+            if strictPerfGatesEnabled {
+                #expect(simdTime < scalarTime, "SIMD should be faster than scalar")
+            }
         }
 
         @Test
@@ -2155,7 +2163,9 @@ struct QuantizedKernelsTests {
             print("  INT8 throughput: \(String(format: "%.0f", int8Throughput)) ops/sec")
             print("  Improvement: \(String(format: "%.1fx", throughputImprovement))")
 
-            #expect(throughputImprovement > 2.0, "INT8 should have higher throughput")
+            if strictPerfGatesEnabled {
+                #expect(throughputImprovement > 2.0, "INT8 should have higher throughput")
+            }
 
             // Test 3: Energy efficiency (estimated by ops count)
             print("\n3. Energy Efficiency (estimated):")
@@ -2254,7 +2264,9 @@ struct QuantizedKernelsTests {
             print("    INT8 time: \(String(format: "%.2f ms", int8Time * 1000))")
             print("    Cache efficiency gain: \(String(format: "%.1fx", cacheSpeedup))")
 
-            #expect(cacheSpeedup > 2.5, "INT8 should benefit from better cache utilization")
+            if strictPerfGatesEnabled {
+                #expect(cacheSpeedup > 2.5, "INT8 should benefit from better cache utilization")
+            }
 
             // Test 2: Sequential vs random access patterns
             print("\n  Access pattern test:")
@@ -2474,7 +2486,9 @@ struct QuantizedKernelsTests {
             print("  Parallel time: \(String(format: "%.2f ms", parallelTime * 1000))")
             print("  Speedup: \(String(format: "%.1fx", quantSpeedup))")
 
-            #expect(quantSpeedup > 2.0, "Parallel quantization should provide speedup")
+            if strictPerfGatesEnabled {
+                #expect(quantSpeedup > 2.0, "Parallel quantization should provide speedup")
+            }
             #expect(serialQuantized.count == parallelQuantized.count, "Should produce same number of vectors")
 
             // Test 2: Parallel distance computation
@@ -2517,7 +2531,9 @@ struct QuantizedKernelsTests {
             print("  Parallel time: \(String(format: "%.2f ms", parallelDistTime * 1000))")
             print("  Speedup: \(String(format: "%.1fx", distSpeedup))")
 
-            #expect(distSpeedup > 2.0, "Parallel distance computation should provide speedup")
+            if strictPerfGatesEnabled {
+                #expect(distSpeedup > 2.0, "Parallel distance computation should provide speedup")
+            }
             #expect(serialDistances.count == parallelDistances.count, "Should compute same number of distances")
 
             // Test 3: Scalability test
@@ -2623,7 +2639,9 @@ struct QuantizedKernelsTests {
             print("  INT8: \(String(format: "%.2f sec", int8Time)) (\(String(format: "%.0f comps/sec", int8CompPerSec)))")
             print("  Speedup: \(String(format: "%.1fx", fp32Time / int8Time))")
 
-            #expect(int8Time < fp32Time, "INT8 should be faster for batch operations")
+            if strictPerfGatesEnabled {
+                #expect(int8Time < fp32Time, "INT8 should be faster for batch operations")
+            }
 
             // Test 3: Memory-bound vs compute-bound analysis
             print("\n3. Memory vs compute bound analysis:")


### PR DESCRIPTION
Closes the open item from the 0.3.1 verification baseline (`Docs/verification-baseline-0.3.1.md`): wall-clock timing assertions made full sweeps impossible to keep strictly green — 16 failed under ASan slowdown, 1 fails deterministically in Release on M3 Max, 2 more flaked during ordinary debug runs. All noise, never regressions.

## Changes

- **`PerfGate.swift`**: `strictPerfGatesEnabled`, opt-in via `VECTORCORE_STRICT_PERF=1` (for a dedicated benchmark job on quiet hardware)
- **47 timing-derived `#expect`s across 6 test files** now gate on it; measurements still print in every run
- Two prior ad-hoc `VECTORCORE_TEST_EXTENDED` wall-clock gates converge on the new flag (extended-tests ≠ strict-perf)
- **ErrorHandlingTests**: two expectations asserted debug-only behavior (`VectorError` source-location capture is `#if DEBUG`-gated by design) → gated with `#if DEBUG`, fixing the two deterministic Release failures
- Accuracy/correctness assertions and deterministic arithmetic checks remain always-on

## Result

Full sweeps (Debug, Release, ASan, TSan) are now expected strictly green by construction.

## Test plan

- Release, all affected suites: 506 tests / 103 suites passed
- Debug recheck of the two flaked tests: passed
- CI (Debug comprehensive + Release smoke) as backstop

🤖 Generated with [Claude Code](https://claude.com/claude-code)