### PR TITLE
release: 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to VectorCore will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-07-24
+
+Maintenance release: an Accelerate-backed `ArraySIMDProvider`, a fresh
+sanitizer-verified baseline, and deterministic (non-flaky) test sweeps.
+
+### Added
+
+- **`AccelerateArraySIMDProvider`** — an `ArraySIMDProvider` for Apple
+  platforms that routes every operation vDSP covers (arithmetic, reductions,
+  dot/distance, element-wise combine) through Accelerate, and delegates the
+  rest (the vForce-backed `abs`/`sqrt`/`log` and trivial index scans) to
+  `DefaultArraySIMDProvider`. Parity-tested against `DefaultArraySIMDProvider`
+  at lengths 1–513, including non-multiple-of-SIMD-width inputs. Installed the
+  standard way:
+  `Operations.$simdProvider.withValue(AccelerateArraySIMDProvider()) { ... }`.
+
+### Fixed
+
+- **`Operations` provider docs showed a non-compiling pattern.** The header
+  example assigned providers directly (`Operations.simdProvider = ...`); the
+  providers are `@TaskLocal`, so the docs now show scoped
+  `$provider.withValue(_:operation:)` binding.
+- **Two tests asserted debug-only `VectorError` behavior in all
+  configurations.** Source-location context capture is `#if DEBUG`-gated in
+  `VectorError`; the assertions now carry the same gate, fixing spurious
+  failures in Release test runs.
+
+### Tests
+
+- **Wall-clock performance assertions are now opt-in.** 47 timing/speedup
+  `#expect`s across the comprehensive suites only assert when
+  `VECTORCORE_STRICT_PERF=1` is set (see `Tests/ComprehensiveTests/PerfGate.swift`);
+  otherwise measurements are printed but never fail the suite. This makes
+  Debug/Release/ASan/TSan sweeps deterministic — sanitizer slowdowns and CI
+  load no longer produce noise failures. Accuracy and layout assertions are
+  unaffected.
+
+### Documentation
+
+- `Docs/verification-baseline-0.3.1.md` — full verification baseline on
+  `main` @ 0.3.1: Debug and Release suites, an ASan pass (0 reports,
+  including the LAPACK shim and `PageAlignedBuffer` allocation-consumption
+  paths), and a TSan pass over the batch/GEMM/SoA kernels (0 reports), with
+  every failure classified (test bugs and timing noise; no code regressions).
+- `Docs/gap-analysis-hn-semantic-search.md` (+ its execution plan) added;
+  ecosystem strategy doc renumbered.
+
 ## [0.3.1] - 2026-06-11
 
 The projection stack from the HN semantic-search gap analysis (the P0 band):

--- a/Docs/API_Overview_Map.md
+++ b/Docs/API_Overview_Map.md
@@ -215,8 +215,8 @@ let d = Lp3Metric().distance(v1, v2)
 - Provider Override (Accelerate vs Swift SIMD)
 
 ```swift
-await Operations.$simdProvider.withValue(DefaultArraySIMDProvider()) {
-    // Calls inside use this array-SIMD provider
+await Operations.$simdProvider.withValue(AccelerateArraySIMDProvider()) {
+    // Calls inside use the Accelerate-backed array-SIMD provider (0.3.2+)
     let nn = try await Operations.findNearest(to: q, in: xs, k: 10)
 }
 

--- a/Docs/Performance_Guide.md
+++ b/Docs/Performance_Guide.md
@@ -138,8 +138,9 @@ Operations.$simdProvider.withValue(SwiftFloatSIMDProvider()) {
 Controls low-level SIMD operations (add, multiply, reduce, etc.)
 
 **Available Implementations**:
-- `SwiftFloatSIMDProvider` (default): Pure Swift SIMD
-- `AccelerateSIMDProvider` (VectorAccelerate): vDSP-backed operations
+- `SwiftSIMDProvider` (default): Pure Swift SIMD
+- `DefaultArraySIMDProvider`: delegates to the `SwiftFloatSIMDProvider` kernels
+- `AccelerateArraySIMDProvider` (0.3.2+): vDSP/vForce-backed operations on Apple platforms
 
 **When to override**:
 - Large vectors (>1000 dimensions): Use Accelerate for vDSP
@@ -147,7 +148,7 @@ Controls low-level SIMD operations (add, multiply, reduce, etc.)
 
 **Example**:
 ```swift
-await Operations.$simdProvider.withValue(AccelerateSIMDProvider()) {
+await Operations.$simdProvider.withValue(AccelerateArraySIMDProvider()) {
     let centroid = Operations.centroid(of: largeVectors)
     // Uses vDSP for aggregation
 }

--- a/Docs/verification-baseline-0.3.1.md
+++ b/Docs/verification-baseline-0.3.1.md
@@ -32,4 +32,6 @@ Supersedes the 2026-06-05 baseline (`rng-verify-full.log`, 996 tests), which pre
 
 Convert the class-B and class-C wall-clock assertions into non-blocking benchmarks (report, don't `#expect`) so future sweeps can be strictly green, and apply the two class-A `#if DEBUG` gates. Until then, a sweep is "green" iff its only failures are in the lists above.
 
+**Status (2026-07-24, shipped in 0.3.2):** implemented via PR #38 — the class-A `#if DEBUG` gates are applied, and all wall-clock assertions (the lists above, plus additional derived-ratio sites found in a wider sweep; 47 total) now assert only under `VECTORCORE_STRICT_PERF=1` (`Tests/ComprehensiveTests/PerfGate.swift`). Sweeps are strictly green by construction.
+
 Raw logs (not committed): `baseline-0.3.1-release-tests.log`, `baseline-0.3.1-asan.log`, `baseline-0.3.1-tsan-batch-gemm.log` in the session job dir.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add VectorCore to your Swift Package Manager dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/gifton/VectorCore.git", from: "0.3.1")
+    .package(url: "https://github.com/gifton/VectorCore.git", from: "0.3.2")
 ]
 ```
 
@@ -244,20 +244,20 @@ let dmat = MatrixDistance.euclideanSquaredMatrix(queries: queryVecs, candidates:
 VectorCore uses `@TaskLocal` for zero-cost provider abstraction:
 
 ```swift
-// Override SIMD provider (e.g., for custom Accelerate integration)
-await Operations.$simdProvider.withValue(AccelerateSIMDProvider()) {
+// Override SIMD provider (Accelerate-backed vDSP on Apple platforms, 0.3.2+)
+await Operations.$simdProvider.withValue(AccelerateArraySIMDProvider()) {
     let centroid = Operations.centroid(of: vectors)
     // All operations in this scope use Accelerate vDSP
 }
 
-// Override compute provider (e.g., for GPU via VectorAccelerate)
-await Operations.$computeProvider.withValue(MetalComputeProvider()) {
+// Override compute provider (e.g., bind a GPU provider from VectorAccelerate)
+await Operations.$computeProvider.withValue(someGPUComputeProvider) {
     let results = try await Operations.findNearest(to: query, in: database, k: 100)
     // GPU-accelerated search
 }
 
 // Multiple provider overrides
-await Operations.$simdProvider.withValue(AccelerateSIMDProvider()) {
+await Operations.$simdProvider.withValue(AccelerateArraySIMDProvider()) {
     await Operations.$computeProvider.withValue(CPUComputeProvider.automatic) {
         // Fully customized execution environment
         let normalized = try await Operations.normalize(vectors)

--- a/Sources/VectorCore/Version.swift
+++ b/Sources/VectorCore/Version.swift
@@ -27,8 +27,9 @@
 public struct VectorCoreVersion {
     /// Current version string of VectorCore.
     ///
-    /// This matches the version in Package.swift.
-    public static let version = "0.3.1"
+    /// This matches the package's release tag (SwiftPM versions are git tags;
+    /// Package.swift carries no version field).
+    public static let version = "0.3.2"
 
     /// Major version number.
     ///
@@ -43,7 +44,7 @@ public struct VectorCoreVersion {
     /// Patch version number.
     ///
     /// Incremented when making backwards-compatible bug fixes.
-    public static let patch = 1
+    public static let patch = 2
 
     /// Pre-release version identifier.
     ///


### PR DESCRIPTION
## Summary

Version bump for the **0.3.2** patch release, plus documentation-accuracy fixes found while sweeping for version references.

### Version bump
- `VectorCoreVersion` constants → 0.3.2 (`version` string and `patch`)
- README install snippet → `from: "0.3.2"`
- CHANGELOG entry for 0.3.2 covering what landed since 0.3.1 (PRs #36–#38): `AccelerateArraySIMDProvider`, the Release-config test fixes, the `VECTORCORE_STRICT_PERF` perf-gate conversion, and the verification-baseline / gap-analysis docs

### Doc accuracy fixes
- **README, Performance_Guide, API_Overview_Map**: provider examples referenced `AccelerateSIMDProvider` / `SwiftFloatSIMDProvider` as `Operations.$simdProvider` bindings — neither conforms to `ArraySIMDProvider` (the examples didn't compile). Now use `AccelerateArraySIMDProvider` (new in 0.3.2) and correctly name `SwiftSIMDProvider` as the task-local default
- **README** GPU example: uses a placeholder binding (same style as the `Operations` doc header) instead of naming a VectorAccelerate type from Core's quickstart
- **Version.swift** doc comment: claimed the constant "matches the version in Package.swift" — SwiftPM versions are git tags; Package.swift has no version field
- **verification-baseline-0.3.1.md**: recommendation section marked implemented (PR #38)

Left intact: all historical 0.3.0/0.3.1 references in release records, the baseline doc, and beta-evolution specs; `Package_Boundaries.md`'s `MetalComputeProvider` examples (verified real — `public actor MetalComputeProvider: BatchKernelProvider` in VectorAccelerate, installed via the `Operations.computeProvider` downcast at `Operations.swift:78`).

## Test plan
- [x] `swift build` clean
- [x] No test pins the version string (checked)
- [x] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)